### PR TITLE
ntc-templates the package

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,0 +1,7 @@
+Release History
+---------------
+
+1.0.0
++++++
+
+* First initial release

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md HISTORY.rst templates/*

--- a/ntc_templates/__init__.py
+++ b/ntc_templates/__init__.py
@@ -1,0 +1,3 @@
+"""ntc_templates - Parse raw output from network devices and return structured data."""
+
+__version__ = '1.0.0'

--- a/ntc_templates/parse.py
+++ b/ntc_templates/parse.py
@@ -1,0 +1,46 @@
+"""ntc_templates.parse."""
+import os
+import sys
+from textfsm.clitable import CliTableError
+import textfsm.clitable as clitable
+
+
+def _get_template_dir():
+    ntc_template_abspath = os.path.abspath(sys.modules['ntc_templates'].__file__)
+    base_dir = os.path.dirname(ntc_template_abspath)
+    template_dir = '%s%s%s' % (base_dir, os.sep, 'templates')
+    return template_dir
+
+
+def _clitable_to_dict(cli_table):
+    """Convert TextFSM cli_table object to list of dictionaries."""
+    objs = []
+    for row in cli_table:
+        temp_dict = {}
+        for index, element in enumerate(row):
+            temp_dict[cli_table.header[index].lower()] = element
+        objs.append(temp_dict)
+
+    return objs
+
+
+def parse_output(platform=None, command=None, data=None):
+    """Return the structured data based on the output from a network device."""
+    template_dir = _get_template_dir()
+    cli_table = clitable.CliTable('index', template_dir)
+
+    attrs = dict(
+        Command=command,
+        Platform=platform
+    )
+    try:
+        cli_table.ParseCmd(data, attrs)
+        structured_data = _clitable_to_dict(cli_table)
+    except CliTableError as e:
+        raise Exception('Unable to parse command "%s" on platform %s - %s' % (command, platform, str(e)))
+        # Invalid or Missing template
+        # module.fail_json(msg='parsing error', error=str(e))
+        # rather than fail, fallback to return raw text
+        # structured_data = [data]
+
+    return structured_data

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,0 +1,7 @@
+[pylama]
+linters = mccabe,pep257,pep8,pyflakes
+ignore = D203,
+skip = .tox/*,.ntc-modules/*
+
+[pylama:pep8]
+max_line_length = 110

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,59 @@
+"""setup.py file."""
+import re
+from codecs import open
+from glob import glob
+from setuptools import setup
+import os
+import shutil
+
+version = ''
+with open('ntc_templates/__init__.py', 'r') as fd:
+    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+                        fd.read(), re.MULTILINE).group(1)
+
+if not version:
+    raise RuntimeError('Cannot find version information')
+
+with open('README.md', 'r', 'utf-8') as f:
+    readme = f.read()
+
+with open('HISTORY.rst', 'r', 'utf-8') as f:
+    history = f.read()
+
+
+long_description = readme + '\n\n' + history
+
+
+template_files = glob('templates/*')
+
+if os.path.islink('ntc_templates/templates'):
+    os.unlink('ntc_templates/templates')
+elif os.path.isdir('ntc_templates/templates'):
+    shutil.rmtree('ntc_templates/templates')
+
+os.symlink('../templates', 'ntc_templates/templates')
+config = {
+    'name': 'ntc_templates',
+    # 'package_dir': {'': 'lib'},
+    'packages': ['ntc_templates'],
+    'version': version,
+    'package_data': {'ntc_templates': template_files},
+    'description': 'Package to return structured data from the output of network devices.',
+    'long_description': long_description,
+    'author': 'network.toCode()',
+    'author_email': 'info@networktocode.com',
+    'url': 'https://github.com/networktocode/ntc-templates',
+    'install_requires': [
+        'gtextfsm',
+        'terminal',
+    ],
+    'classifiers': ['Development Status :: 4 - Beta',
+                    'Intended Audience :: Developers',
+                    'Intended Audience :: System Administrators',
+                    'Programming Language :: Python :: 2.7']
+}
+
+setup(**config)
+
+if os.path.islink('ntc_templates/templates'):
+    os.unlink('ntc_templates/templates')


### PR DESCRIPTION
I'm missing a way to distribute the templates in a way which doesn't include github (which is currently blocked from my environment).

I had a thought of optionally treating ntc-templates as a Python package. This can be done without impacting the project in any other way. The setup.py file gets a bit strange though.

Another reason to have this is to make it easier to use the ntc-templates outside of Ansible. In the future the Ansible module could be changed to use this package instead.

To test:
```bash
python setup.py sdist
pip install dist/ntc_templates-1.0.0.tar.gz
````

An example of how the package can be used:

```python
from ntc_templates.parse import parse_output

data = """
Capability Codes: R - Router, T - Trans Bridge, B- Source Route Bridge
	       S - Switch, H - Host, I - IGMP, r - Repeater, P - Phone

Device ID         Local Intrfce Holdtme    Capability   Platform   Port ID
R1-PBX            Gig 1/0/10    144          R S I      2811       Fas 0/0
TS-1              Gig 1/0/39    122          R          2611       Eth 0/1
Cisco-WAP-N       Gig 1/0/1     120          T I        AIR-AP125  Gig 0
SEP04FE7F689D33   Gig 1/0/2     125          H P        IP Phone   Port 1
SEP000DBC50FCD1   Gig 1/0/4     147          H P        IP Phone   Port 1
SEP00124362C4D2   Gig 1/0/42    147          H P        IP Phone   Port 1
"""

s = parse_output(platform='cisco_ios', command='show cdp neighbors', data=data)

>>> s
[{'neighbor_interface': 'Fas 0/0', 'local_interface': 'Gig 1/0/10', 'neighbor': 'R1-PBX'}, {'neighbor_interface': 'Eth 0/1', 'local_interface': 'Gig 1/0/39', 'neighbor': 'TS-1'}, {'neighbor_interface': 'Gig 0', 'local_interface': 'Gig 1/0/1', 'neighbor': 'Cisco-WAP-N'}, {'neighbor_interface': 'Port 1', 'local_interface': 'Gig 1/0/2', 'neighbor': 'SEP04FE7F689D33'}, {'neighbor_interface': 'Port 1', 'local_interface': 'Gig 1/0/4', 'neighbor': 'SEP000DBC50FCD1'}, {'neighbor_interface': 'Port 1', 'local_interface': 'Gig 1/0/42', 'neighbor': 'SEP00124362C4D2'}]
```

Perhaps the function of the names could be changed.

Probably we'll just raise an exception if someone tries to use a template which hasn't been created. Perhaps also print the version of ntc_templates so that it's easy to point people to a later version if a template already exists. 

```python
>>> s = parse_output(platform='cisco_ios', command='show unsupported feature', data=data)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/patrick/.virtualenvs/scratch/lib/python2.7/site-packages/ntc_templates/parse.py", line 40, in parse_output
    raise Exception('Unable to parse command "%s" on platform %s - %s' % (command, platform, str(e)))
Exception: Unable to parse command "show unsupported feature" on platform cisco_ios - No template found for attributes: "{'Platform': 'cisco_ios', 'Command': 'show unsupported feature'}"
>>>
```

If this is supported more files will need to be added to the .gitignore file and perhaps the README.md should be changed to .rst for pypi support.