### PR TITLE
add template for the Cisco IOS show cdp neighbors detail command

### DIFF
--- a/templates/cisco_ios_show_cdp_neighbors_detail.template
+++ b/templates/cisco_ios_show_cdp_neighbors_detail.template
@@ -1,0 +1,21 @@
+Value Filldown LOCAL_HOST (\S+)
+Value Required DESTINATION_HOST (\S+)
+Value MANAGEMENT_IP (.*)
+Value PLATFORM (.*)
+Value REMOTE_PORT (.*)
+Value LOCAL_PORT (.*)
+Value SOFTWARE_VERSION (.*)
+
+Start
+  ^${LOCAL_HOST}[>#].
+  ^Device ID: ${DESTINATION_HOST}
+  ^Entry address\(es\): -> ParseIP
+  ^Platform: ${PLATFORM},
+  ^Interface: ${LOCAL_PORT},  Port ID \(outgoing port\): ${REMOTE_PORT}
+  ^Version : -> GetVersion
+
+ParseIP
+  ^.*IP address: ${MANAGEMENT_IP} -> Start
+
+GetVersion
+  ^${SOFTWARE_VERSION} -> Record Start

--- a/templates/index
+++ b/templates/index
@@ -59,6 +59,7 @@ arista_eos_show_lldp_neighbors.template, .*, arista_eos, sh[[ow]] ll[[dp]] nei[[
 cisco_nxos_show_cdp_neighbors.template, .*, cisco_nxos, sh[[ow]] cd[[p]] neig[[hbors]]
 arista_eos_show_ip_access-lists.template, .*, arista_eos, sh[[ow]] i[[p]] acce[[ss-lists]]
 cisco_nxos_show_lldp_neighbors.template, .*, cisco_nxos, sh[[ow]] ll[[dp]] nei[[ghbors]]
+cisco_ios_show_cdp_neighbors_detail.template, .*, cisco_ios, sh[[ow]] c[[dp]] neig[[hbors]] det[[ail]]
 cisco_ios_show_cdp_neighbors.template, .*, cisco_ios, sh[[ow]] c[[dp]] neig[[hbors]]
 cisco_ios_show_lldp_neighbors.template, .*, cisco_ios, sh[[ow]] lld[[p]] neig[[hbors]]
 cisco_ios_show_version.template, .*, cisco_ios, sh[[ow]] ver[[sion]]

--- a/tests/cisco_ios/show_cdp_neighbors_detail/cisco_ios_show_cdp_neighbors_detail.parsed
+++ b/tests/cisco_ios/show_cdp_neighbors_detail/cisco_ios_show_cdp_neighbors_detail.parsed
@@ -1,0 +1,25 @@
+---
+parsed_sample:
+- platform: "cisco WS-C2960-8TC-L"
+  management_ip: "10.1.1.2"
+  software_version: "Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(55)SE9, RELEASE SOFTWARE (fc1)"
+  destination_host: "desktop-switch"
+  remote_port: "GigabitEthernet0/1"
+  local_port: "GigabitEthernet1/0/16"
+  local_host: "Switch"
+
+- platform: "Cisco 3825"
+  management_ip: "10.1.1.1"
+  software_version: "Cisco IOS Software, 3800 Software (C3825-ADVENTERPRISEK9-M), Version 12.4(24)T1, RELEASE SOFTWARE (fc3)"
+  destination_host: "ce-router"
+  remote_port: "GigabitEthernet0/0"
+  local_port: "GigabitEthernet1/0/22"
+  local_host: "Switch"
+
+- platform: "VMware"
+  management_ip: "10.1.1.232"
+  software_version: "Linux 2.6.32-431.20.3.el6.x86_64 #1 SMP Fri Jun 6 18:30:54 EDT 2014 CCM:10.5.2.10000-5.i386"
+  destination_host: "server"
+  remote_port: "eth0"
+  local_port: "GigabitEthernet1/0/19"
+  local_host: "Switch"

--- a/tests/cisco_ios/show_cdp_neighbors_detail/cisco_ios_show_cdp_neighbors_detail.raw
+++ b/tests/cisco_ios/show_cdp_neighbors_detail/cisco_ios_show_cdp_neighbors_detail.raw
@@ -1,0 +1,57 @@
+Switch#show inventory
+-------------------------
+Device ID: desktop-switch
+Entry address(es):
+  IP address: 10.1.1.2
+Platform: cisco WS-C2960-8TC-L,  Capabilities: Switch IGMP
+Interface: GigabitEthernet1/0/16,  Port ID (outgoing port): GigabitEthernet0/1
+Holdtime : 164 sec
+
+Version :
+Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(55)SE9, RELEASE SOFTWARE (fc1)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2014 by Cisco Systems, Inc.
+Compiled Mon 03-Mar-14 22:53 by prod_rel_team
+
+advertisement version: 2
+Protocol Hello:  OUI=0x00000C, Protocol ID=0x0112; payload len=27, value=00000000FFFFFFFF010205010000000000000024508ECA00FF0000
+VTP Management Domain: ''
+Native VLAN: 1
+Duplex: full
+Management address(es):
+  IP address: 10.1.1.2
+
+-------------------------
+Device ID: ce-router
+Entry address(es):
+  IP address: 10.1.1.1
+Platform: Cisco 3825,  Capabilities: Router Switch IGMP
+Interface: GigabitEthernet1/0/22,  Port ID (outgoing port): GigabitEthernet0/0
+Holdtime : 156 sec
+
+Version :
+Cisco IOS Software, 3800 Software (C3825-ADVENTERPRISEK9-M), Version 12.4(24)T1, RELEASE SOFTWARE (fc3)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2009 by Cisco Systems, Inc.
+Compiled Fri 19-Jun-09 18:40 by prod_rel_team
+
+advertisement version: 2
+VTP Management Domain: ''
+Duplex: full
+Management address(es):
+
+-------------------------
+Device ID: server
+Entry address(es):
+  IP address: 10.1.1.232
+Platform: VMware,  Capabilities: Host
+Interface: GigabitEthernet1/0/19,  Port ID (outgoing port): eth0
+Holdtime : 145 sec
+
+Version :
+Linux 2.6.32-431.20.3.el6.x86_64 #1 SMP Fri Jun 6 18:30:54 EDT 2014 CCM:10.5.2.10000-5.i386
+
+advertisement version: 2
+Duplex: full
+Management address(es):
+


### PR DESCRIPTION
add a new TextFSM template for the "show cdp neighbors detail" command on Cisco IOS.