### PR TITLE
remove local host from show cdp neighbors details template

### DIFF
--- a/templates/cisco_ios_show_cdp_neighbors_detail.template
+++ b/templates/cisco_ios_show_cdp_neighbors_detail.template
@@ -1,4 +1,3 @@
-Value Filldown LOCAL_HOST (\S+)
 Value Required DESTINATION_HOST (\S+)
 Value MANAGEMENT_IP (.*)
 Value PLATFORM (.*)
@@ -7,7 +6,6 @@ Value LOCAL_PORT (.*)
 Value SOFTWARE_VERSION (.*)
 
 Start
-  ^${LOCAL_HOST}[>#].
   ^Device ID: ${DESTINATION_HOST}
   ^Entry address\(es\): -> ParseIP
   ^Platform: ${PLATFORM},

--- a/tests/cisco_ios/show_cdp_neighbors_detail/cisco_ios_show_cdp_neighbors_detail.parsed
+++ b/tests/cisco_ios/show_cdp_neighbors_detail/cisco_ios_show_cdp_neighbors_detail.parsed
@@ -6,7 +6,6 @@ parsed_sample:
   destination_host: "desktop-switch"
   remote_port: "GigabitEthernet0/1"
   local_port: "GigabitEthernet1/0/16"
-  local_host: "Switch"
 
 - platform: "Cisco 3825"
   management_ip: "10.1.1.1"
@@ -14,7 +13,6 @@ parsed_sample:
   destination_host: "ce-router"
   remote_port: "GigabitEthernet0/0"
   local_port: "GigabitEthernet1/0/22"
-  local_host: "Switch"
 
 - platform: "VMware"
   management_ip: "10.1.1.232"
@@ -22,4 +20,3 @@ parsed_sample:
   destination_host: "server"
   remote_port: "eth0"
   local_port: "GigabitEthernet1/0/19"
-  local_host: "Switch"

--- a/tests/cisco_ios/show_cdp_neighbors_detail/cisco_ios_show_cdp_neighbors_detail.raw
+++ b/tests/cisco_ios/show_cdp_neighbors_detail/cisco_ios_show_cdp_neighbors_detail.raw
@@ -1,4 +1,3 @@
-Switch#show inventory
 -------------------------
 Device ID: desktop-switch
 Entry address(es):


### PR DESCRIPTION
Hi, I removed the local host from the `show cdp neighbor details command` because it isn't available in the raw output.