### PR TITLE
Reordered data to pass pytest (junos show interfaces)

### DIFF
--- a/tests/juniper_junos/show_interfaces/juniper_junos_show_interfaces.parsed
+++ b/tests/juniper_junos/show_interfaces/juniper_junos_show_interfaces.parsed
@@ -31,13 +31,13 @@ parsed_sample:
   mtu: "Unlimited"
 
 - admin_state: "Enabled"
-  hardware_type: "Adaptive-Services"
-  interface: "sp-0/0/0"
-  link_status: "Up"
-  mtu: "9192"
-
-- admin_state: "Enabled"
   hardware_type: "GRE"
   interface: "mt-0/0/0"
   link_status: "Up"
   mtu: "Unlimited"
+
+- admin_state: "Enabled"
+  hardware_type: "Adaptive-Services"
+  interface: "sp-0/0/0"
+  link_status: "Up"
+  mtu: "9192"


### PR DESCRIPTION
Changed the order of sp-0/0/0 and mt-0/0/0 in the parsed data to pass pytest. 