### PR TITLE
Update cisco_ios_show_interfaces.template

### DIFF
--- a/templates/cisco_ios_show_interfaces.template
+++ b/templates/cisco_ios_show_interfaces.template
@@ -11,6 +11,8 @@ Value BANDWIDTH (\d+\s+\w+)
 Value DELAY (\d+\s+\w+)
 Value ENCAPSULATION (\w+)
 Value QUEUE_STRATEGY (.*)
+Value INPUT_RATE (\d+)
+Value OUTPUT_RATE (\d+)
 
 Start
   ^${INTERFACE} is ${LINK_STATUS}.*protocol is ${PROTOCOL_STATUS}
@@ -20,4 +22,6 @@ Start
   ^\s+Internet address is ${IP_ADDRESS}
   ^\s+MTU ${MTU}.*BW ${BANDWIDTH}.*DLY ${DELAY}
   ^\s+Encapsulation ${ENCAPSULATION}
-  ^\s+Queueing strategy: ${QUEUE_STRATEGY} -> Record
+  ^\s+Queueing strategy: ${QUEUE_STRATEGY}
+  ^.*input rate ${INPUT_RATE}
+  ^.*output rate ${OUTPUT_RATE} -> Record


### PR DESCRIPTION
Added configuration to gather the 5 minute input and output rates for the interface.  I found this useful when building an ansible playbook that removes a redundant router from service.  I used the input and output rate information to determine when traffic has drained from the router.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
Cisco_ios_show_interfaces

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Added configuration to gather the 5 minute input and output rates for the interface. I found this useful when building an ansible playbook that removes a redundant router from service. I used the input and output rate information to determine when traffic has drained from the router.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
before:

ok: [3.3.3.3] => {
    "result": {
        "changed": false,
        "response": [
            {
                "address": "c403.854c.0001",
                "bandwidth": "100000 Kbit",
                "bia": "c403.854c.0001",
                "delay": "100 usec",
                "description": "Connected to R1",
                "encapsulation": "ARPA",
                "hardware_type": "Gt96k FE",
                "interface": "FastEthernet0/1",
                "ip_address": "10.0.10.9/31",
                "link_status": "up",
                "mtu": "1500",
                "protocol_status": "up ",
                "queue_strategy": "fifo"
            }
        ],
        "response_list": []
    }
}

after:

ok: [3.3.3.3] => {
    "result": {
        "changed": false,
        "response": [
            {
                "address": "c403.854c.0001",
                "bandwidth": "100000 Kbit",
                "bia": "c403.854c.0001",
                "delay": "100 usec",
                "description": "Connected to R1",
                "encapsulation": "ARPA",
                "hardware_type": "Gt96k FE",
                "input_rate": "1000",
                "interface": "FastEthernet0/1",
                "ip_address": "10.0.10.9/31",
                "link_status": "up",
                "mtu": "1500",
                "output_rate": "1000",
                "protocol_status": "up ",
                "queue_strategy": "fifo"
            }
        ],
        "response_list": []
    }
}


```
