### PR TITLE
vmware nsx-v edge templates (esg/dlr)

### DIFF
--- a/templates/index
+++ b/templates/index
@@ -142,3 +142,6 @@ paloalto_panos_show_interface_logical.template, .*, paloalto_panos, sh[[ow]] int
 paloalto_panos_show_counter_global.template, .*, paloalto_panos, sh[[ow]] coun[[ter]] glo[[bal]]
 paloalto_panos_show_system_info.template, .*, paloalto_panos, sh[[ow]] sys[[tem]] in[[fo]]
 paloalto_panos_show_jobs_all.template, .*, paloalto_panos, sh[[ow]] jo[[bs]] all
+
+vmware_nsxv_show_ip_bgp_neighbors.template, .*, vmware_nsxv, sh[[ow]] ip b[[gp]] n[[eighbors]]
+vmware_nsxv_show_ip_route.template, .*, vmware_nsxv, sh[[ow]] ip r[[oute]]

--- a/templates/vmware_nsxv_show_ip_bgp_neighbors.template
+++ b/templates/vmware_nsxv_show_ip_bgp_neighbors.template
@@ -1,0 +1,15 @@
+Value NEIGHBOR_ID (\d+(\.\d+){3})
+Value REMOTE_AS (\d+)
+Value STATE (\D.*)
+Value HOLD_INTERVAL (\d+)
+Value KEEPALIVE_INTERVAL (\d+)
+Value PFX_RECV (\d+)
+Value PFX_SENT (\d+)
+Value PFX_ADV (\d+)
+
+Start
+	^BGP neighbor.* -> Continue.Record
+	^BGP neighbor is ${NEIGHBOR_ID},\s+remote AS ${REMOTE_AS}
+	^BGP state = ${STATE}
+	^Hold time is ${HOLD_INTERVAL}, Keep alive interval is ${KEEPALIVE_INTERVAL}
+	^\s+Prefixes received ${PFX_RECV} sent ${PFX_SENT} advertised ${PFX_ADV}

--- a/templates/vmware_nsxv_show_ip_route.template
+++ b/templates/vmware_nsxv_show_ip_route.template
@@ -1,0 +1,9 @@
+Value PROTOCOL ([OiBCS])
+Value TYPE (\w{0,2})
+Value PREFIX (\d+(\.\d+){3}\/\d{1,2})
+Value DISTANCE (\d+)
+Value METRIC (\d+)
+Value NEXTHOP (\d+(\.\d+){3})
+
+Start
+	^${PROTOCOL}\s+${TYPE}\s+${PREFIX}\s+\[${DISTANCE}\/${METRIC}\]\s+via\s+${NEXTHOP} -> Next.Record

--- a/tests/test_index_order.py
+++ b/tests/test_index_order.py
@@ -66,7 +66,7 @@ def test_index_ordering():
         'cisco_asa', 'cisco_ios', 'cisco_nxos', 'cisco_s300', 'cisco_wlc', 'cisco_xe', 'cisco_xr',
         'dell_force10', 'enterasys', 'extreme', 'f5_ltm', 'fortinet', 'hp_comware', 'hp_procurve',
         'huawei', 'juniper', 'juniper_junos', 'linux', 'ovs_linux', 'paloalto_panos',
-        'quanta_mesh', 'vyatta_vyos', 'vyos'
+        'quanta_mesh', 'vmware_nsxv', 'vyatta_vyos', 'vyos'
         ] 
 
     prior_os = ""

--- a/tests/vmware_nsxv/show_ip_bgp_neighbors/vmware_nsxv_show_ip_bgp_neighbors.parsed
+++ b/tests/vmware_nsxv/show_ip_bgp_neighbors/vmware_nsxv_show_ip_bgp_neighbors.parsed
@@ -1,0 +1,19 @@
+---
+parsed_sample:
+
+-   hold_interval: '3'
+    keepalive_interval: '1'
+    neighbor_id: 192.0.2.2
+    pfx_adv: '0'
+    pfx_recv: '3'
+    pfx_sent: '0'
+    remote_as: '64706'
+    state: Established, up
+-   hold_interval: '3'
+    keepalive_interval: '1'
+    neighbor_id: 192.0.2.3
+    pfx_adv: '0'
+    pfx_recv: '3'
+    pfx_sent: '0'
+    remote_as: '64706'
+    state: Established, up

--- a/tests/vmware_nsxv/show_ip_bgp_neighbors/vmware_nsxv_show_ip_bgp_neighbors.raw
+++ b/tests/vmware_nsxv/show_ip_bgp_neighbors/vmware_nsxv_show_ip_bgp_neighbors.raw
@@ -1,0 +1,38 @@
+
+BGP neighbor is 192.0.2.2,   remote AS 64706,
+BGP state = Established, up
+Hold time is 3, Keep alive interval is 1 seconds
+Neighbor capabilities:
+         Route refresh: advertised and received 
+         Address family IPv4 Unicast:advertised and received
+         Graceful restart Capability:none 
+                 Restart remain time: 0
+Received 338 messages, Sent 338 messages
+Default minimum time between advertisement runs is 30 seconds
+For Address family IPv4 Unicast:advertised and received
+         Index 1 Identifier 0xd9f2d49c
+         Route refresh request:received 0 sent 0
+         Prefixes received 3 sent 0 advertised 0
+Connections established 1, dropped 1
+Local host: 192.0.2.1, Local port: 179
+Remote host: 192.0.2.2, Remote port: 56330
+
+
+BGP neighbor is 192.0.2.3,   remote AS 64706,
+BGP state = Established, up
+Hold time is 3, Keep alive interval is 1 seconds
+Neighbor capabilities:
+         Route refresh: advertised and received 
+         Address family IPv4 Unicast:advertised and received
+         Graceful restart Capability:none 
+                 Restart remain time: 0
+Received 340 messages, Sent 339 messages
+Default minimum time between advertisement runs is 30 seconds
+For Address family IPv4 Unicast:advertised and received
+         Index 2 Identifier 0xd9f2d49c
+         Route refresh request:received 0 sent 0
+         Prefixes received 3 sent 0 advertised 0
+Connections established 1, dropped 1
+Local host: 192.0.2.1, Local port: 50963
+Remote host: 192.0.2.3, Remote port: 179
+

--- a/tests/vmware_nsxv/show_ip_route/vmware_nsxv_show_ip_route.parsed
+++ b/tests/vmware_nsxv/show_ip_route/vmware_nsxv_show_ip_route.parsed
@@ -1,0 +1,39 @@
+---
+parsed_sample:
+
+-   distance: '0'
+    metric: '0'
+    nexthop: 169.254.1.42
+    prefix: 169.254.1.40/30
+    protocol: C
+    type: ''
+-   distance: '200'
+    metric: '0'
+    nexthop: 192.168.143.121
+    prefix: 192.168.143.88/29
+    protocol: B
+    type: ''
+-   distance: '200'
+    metric: '0'
+    nexthop: 192.168.143.122
+    prefix: 192.168.143.88/29
+    protocol: B
+    type: ''
+-   distance: '200'
+    metric: '0'
+    nexthop: 192.168.143.121
+    prefix: 192.168.143.104/29
+    protocol: B
+    type: ''
+-   distance: '200'
+    metric: '0'
+    nexthop: 192.168.143.122
+    prefix: 192.168.143.104/29
+    protocol: B
+    type: ''
+-   distance: '0'
+    metric: '0'
+    nexthop: 192.168.143.124
+    prefix: 192.168.143.120/29
+    protocol: C
+    type: ''

--- a/tests/vmware_nsxv/show_ip_route/vmware_nsxv_show_ip_route.raw
+++ b/tests/vmware_nsxv/show_ip_route/vmware_nsxv_show_ip_route.raw
@@ -1,0 +1,14 @@
+
+Codes: O - OSPF derived, i - IS-IS derived, B - BGP derived,
+C - connected, S - static, L1 - IS-IS level-1, L2 - IS-IS level-2,
+IA - OSPF inter area, E1 - OSPF external type 1, E2 - OSPF external type 2,
+N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
+
+Total number of routes: 4
+
+C       169.254.1.40/30      [0/0]         via 169.254.1.42    
+B       192.168.143.88/29    [200/0]       via 192.168.143.121 
+B       192.168.143.88/29    [200/0]       via 192.168.143.122 
+B       192.168.143.104/29   [200/0]       via 192.168.143.121 
+B       192.168.143.104/29   [200/0]       via 192.168.143.122 
+C       192.168.143.120/29   [0/0]         via 192.168.143.124 

--- a/tests/vmware_nsxv/show_ip_route/vmware_nsxv_show_ip_route1.parsed
+++ b/tests/vmware_nsxv/show_ip_route/vmware_nsxv_show_ip_route1.parsed
@@ -1,0 +1,27 @@
+---
+parsed_sample:
+
+-   distance: '110'
+    metric: '1'
+    nexthop: 192.168.143.91
+    prefix: 192.0.3.0/24
+    protocol: O
+    type: E2
+-   distance: '0'
+    metric: '0'
+    nexthop: 192.168.143.90
+    prefix: 192.168.143.88/29
+    protocol: C
+    type: ''
+-   distance: '0'
+    metric: '0'
+    nexthop: 192.168.143.106
+    prefix: 192.168.143.104/29
+    protocol: C
+    type: ''
+-   distance: '0'
+    metric: '0'
+    nexthop: 192.168.143.121
+    prefix: 192.168.143.120/29
+    protocol: C
+    type: ''

--- a/tests/vmware_nsxv/show_ip_route/vmware_nsxv_show_ip_route1.raw
+++ b/tests/vmware_nsxv/show_ip_route/vmware_nsxv_show_ip_route1.raw
@@ -1,0 +1,12 @@
+
+Codes: O - OSPF derived, i - IS-IS derived, B - BGP derived,
+C - connected, S - static, L1 - IS-IS level-1, L2 - IS-IS level-2,
+IA - OSPF inter area, E1 - OSPF external type 1, E2 - OSPF external type 2,
+N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
+
+Total number of routes: 4
+
+O   E2  192.0.3.0/24         [110/1]       via 192.168.143.91  
+C       192.168.143.88/29    [0/0]         via 192.168.143.90  
+C       192.168.143.104/29   [0/0]         via 192.168.143.106 
+C       192.168.143.120/29   [0/0]         via 192.168.143.121 

--- a/tests/vmware_nsxv/show_ip_route/vmware_nsxv_show_ip_route2.parsed
+++ b/tests/vmware_nsxv/show_ip_route/vmware_nsxv_show_ip_route2.parsed
@@ -1,0 +1,27 @@
+---
+parsed_sample:
+
+-   distance: '1'
+    metric: '1'
+    nexthop: 192.168.143.92
+    prefix: 192.0.3.0/24
+    protocol: S
+    type: ''
+-   distance: '0'
+    metric: '0'
+    nexthop: 192.168.143.91
+    prefix: 192.168.143.88/29
+    protocol: C
+    type: ''
+-   distance: '0'
+    metric: '0'
+    nexthop: 192.168.143.107
+    prefix: 192.168.143.104/29
+    protocol: C
+    type: ''
+-   distance: '0'
+    metric: '0'
+    nexthop: 192.168.143.122
+    prefix: 192.168.143.120/29
+    protocol: C
+    type: ''

--- a/tests/vmware_nsxv/show_ip_route/vmware_nsxv_show_ip_route2.raw
+++ b/tests/vmware_nsxv/show_ip_route/vmware_nsxv_show_ip_route2.raw
@@ -1,0 +1,12 @@
+
+Codes: O - OSPF derived, i - IS-IS derived, B - BGP derived,
+C - connected, S - static, L1 - IS-IS level-1, L2 - IS-IS level-2,
+IA - OSPF inter area, E1 - OSPF external type 1, E2 - OSPF external type 2,
+N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
+
+Total number of routes: 4
+
+S       192.0.3.0/24         [1/1]         via 192.168.143.92  
+C       192.168.143.88/29    [0/0]         via 192.168.143.91  
+C       192.168.143.104/29   [0/0]         via 192.168.143.107 
+C       192.168.143.120/29   [0/0]         via 192.168.143.122


### PR DESCRIPTION
##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
VMware NSX-v Edge (ESG/DLR)

show ip bgp neighbors
show ip route

##### SUMMARY
New templates for VMware NSX-v Edge (ESG/DLR) virtual network functions for show ip bgp neighbors and show ip route commands. The NSX Manager REST API does not support getting operational state of routes or BGP neighbors in a structured way. Thus, these templates are for use when executing the show command on the Edge via SSH, or using the central CLI feature of NSX Manager REST API.

This commit also includes tests for the two templates.
