### PR TITLE
Add Comware display mac-address command

### DIFF
--- a/templates/hp_comware_display_arp.template
+++ b/templates/hp_comware_display_arp.template
@@ -7,9 +7,3 @@ Value TYPE (\S+)
 
 Start
   ^${IPADDRESS}\s+${MACADDRESS}\s+${VLAN}\s+${INTERFACE}\s+${AGING}\s+${TYPE} -> Record
-
-
-
-
-
-

--- a/templates/hp_comware_display_mac-address.template
+++ b/templates/hp_comware_display_mac-address.template
@@ -1,0 +1,8 @@
+Value MACADDRESS (^[\d\w-]+)
+Value VLAN ([\d]+)
+Value STATE (\S+)
+Value INTERFACE (\S+)
+Value AGING (\S+)
+
+Start
+  ^${MACADDRESS}\s+${VLAN}\s+${STATE}\s+${INTERFACE}\s+${AGING} -> Record

--- a/templates/index
+++ b/templates/index
@@ -120,6 +120,7 @@ dell_force10_show_version.template, .*, dell_force10, sh[[ow]] ver[[sion]]
 dell_force10_show_vlan.template, .*, dell_force10, sh[[ow]] vl[[an]]
 dell_force10_show_arp.template, .*, dell_force10, sh[[ow]] ar[[p]]
 
+hp_comware_display_mac-address.template, .*, hp_comware, di[[splay]] mac-ad[[dress]]
 hp_comware_display_vlan_brief.template, .*, hp_comware, di[[splay]] v[[lan]] b[[rief]]
 hp_comware_display_clock.template, .*, hp_comware, di[[splay]] clo[[ck]]
 hp_comware_display_arp.template, .*, hp_comware, di[[splay]] a[[rp]]

--- a/tests/hp_comware/display_mac-address/hp_comware_display_mac-address.parsed
+++ b/tests/hp_comware/display_mac-address/hp_comware_display_mac-address.parsed
@@ -1,0 +1,27 @@
+---
+
+parsed_sample:
+
+- macaddress: "0000-1111-2222"
+  vlan: "1"
+  state: "Learned"
+  interface: "Bridge-Aggregation1"
+  aging: "AGING"
+
+- macaddress: "fedc-ba09-8765"
+  vlan: "10"
+  state: "Learned"
+  interface: "GigabitEthernet1/0/20"
+  aging: "NOAGED"
+
+- macaddress: "aaaa-bbbb-cccc"
+  vlan: "10"
+  state: "Learned"
+  interface: "GigabitEthernet1/0/41"
+  aging: "AGING"
+
+- macaddress: "dead-beef-0042"
+  vlan: "20"
+  state: "Learned"
+  interface: "GigabitEthernet1/0/10"
+  aging: "AGING"

--- a/tests/hp_comware/display_mac-address/hp_comware_display_mac-address.raw
+++ b/tests/hp_comware/display_mac-address/hp_comware_display_mac-address.raw
@@ -1,0 +1,5 @@
+MAC ADDR       VLAN ID  STATE          PORT INDEX               AGING TIME(s)
+0000-1111-2222 1        Learned        Bridge-Aggregation1      AGING
+fedc-ba09-8765 10       Learned        GigabitEthernet1/0/20    NOAGED
+aaaa-bbbb-cccc 10       Learned        GigabitEthernet1/0/41    AGING
+dead-beef-0042 20       Learned        GigabitEthernet1/0/10    AGING


### PR DESCRIPTION
##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
 - Template name `hp_comware_display_mac-address`
 - Command `display mac-address` on HP Comware switches

##### SUMMARY
Adding the mac-address display template for HP Comware, nothing more.

`py.test` has passed all the tests.
