### PR TITLE
fix for vlans not starting with 0, e.g VLAN1001

### DIFF
--- a/templates/cisco_ios_show_spanning-tree.template
+++ b/templates/cisco_ios_show_spanning-tree.template
@@ -8,5 +8,5 @@ Value PORT_ID (\w+)
 Value TYPE (.*)
 
 Start
-  ^VLAN(0*)?${VLAN_ID}
+  ^VLAN0*${VLAN_ID}
   ^${INTERFACE}\s+${ROLE}\s+${STATUS}\s+${COST}\s+${PORT_PRIORITY}.${PORT_ID}\s+${TYPE} -> Record

--- a/tests/cisco_ios/show_spanning_tree/cisco_ios_show_spanning_tree_1.parsed
+++ b/tests/cisco_ios/show_spanning_tree/cisco_ios_show_spanning_tree_1.parsed
@@ -1,0 +1,21 @@
+---
+parsed_sample:
+
+- cost: '19'                   
+  interface: Gi1/0/48
+  port_id: '48' 
+  port_priority: '128'
+  role: Desg
+  status: FWD
+  type: P2p Edge
+  vlan_id: '1000'
+
+- cost: '19'
+  interface: Gi1/0/48
+  port_id: '48'
+  port_priority: '128'
+  role: Desg  
+  status: FWD
+  type: P2p Edge
+  vlan_id: '1001' 
+

--- a/tests/cisco_ios/show_spanning_tree/cisco_ios_show_spanning_tree_1.raw
+++ b/tests/cisco_ios/show_spanning_tree/cisco_ios_show_spanning_tree_1.raw
@@ -1,0 +1,37 @@
+
+VLAN1000
+  Spanning tree enabled protocol rstp
+  Root ID    Priority    33768
+             Address     f8a5.c5c0.9680
+             This bridge is the root
+             Hello Time   2 sec  Max Age 20 sec  Forward Delay 15 sec
+
+  Bridge ID  Priority    33768  (priority 32768 sys-id-ext 1000)
+             Address     f8a5.c5c0.9680
+             Hello Time   2 sec  Max Age 20 sec  Forward Delay 15 sec
+             Aging Time  300 sec
+
+Interface           Role Sts Cost      Prio.Nbr Type
+------------------- ---- --- --------- -------- --------------------------------
+Gi1/0/48            Desg FWD 19        128.48   P2p Edge 
+
+
+          
+VLAN1001
+  Spanning tree enabled protocol rstp
+  Root ID    Priority    33769
+             Address     f8a5.c5c0.9680
+             This bridge is the root
+             Hello Time   2 sec  Max Age 20 sec  Forward Delay 15 sec
+
+  Bridge ID  Priority    33769  (priority 32768 sys-id-ext 1001)
+             Address     f8a5.c5c0.9680
+             Hello Time   2 sec  Max Age 20 sec  Forward Delay 15 sec
+             Aging Time  300 sec
+
+Interface           Role Sts Cost      Prio.Nbr Type
+------------------- ---- --- --------- -------- --------------------------------
+Gi1/0/48            Desg FWD 19        128.48   P2p Edge 
+
+
+


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
cisco_ios_show_spanning-tree.template

##### SUMMARY
VLANs not starting with 0, e.g. VLAN1001 did not work

Output before the change:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: textfsm.textfsm.TextFSMTemplateError: Invalid regular expression: '^VLAN(0*)?(?P<VLAN_ID>\d+)'. Line: 11.
failed: [test_stag] (item=show sp) => {"failed": true, "item": "show sp", "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_20693y/ansible_module_ntc_show_command.py\", line 470, in <module>\n    main()\n  File \"/tmp/ansible_20693y/ansible_module_ntc_show_command.py\", line 457, in main\n    results['response'] = parse_raw_output(rawtxt, module)\n  File \"/tmp/ansible_20693y/ansible_module_ntc_show_command.py\", line 290, in parse_raw_output\n    structured_data = get_structured_data(rawoutput, module)\n  File \"/tmp/ansible_20693y/ansible_module_ntc_show_command.py\", line 266, in get_structured_data\n    cli_table.ParseCmd(rawoutput, attrs)\n  File \"build/bdist.linux-x86_64/egg/textfsm/clitable.py\", line 241, in ParseCmd\n  File \"build/bdist.linux-x86_64/egg/textfsm/clitable.py\", line 262, in _ParseCmdItem\n  File \"build/bdist.linux-x86_64/egg/textfsm/textfsm.py\", line 546, in __init__\n  File \"build/bdist.linux-x86_64/egg/textfsm/textfsm.py\", line 647, in _Parse\n  File \"build/bdist.linux-x86_64/egg/textfsm/textfsm.py\", line 781, in _ParseFSMState\n  File \"build/bdist.linux-x86_64/egg/textfsm/textfsm.py\", line 443, in __init__\ntextfsm.textfsm.TextFSMTemplateError: Invalid regular expression: '^VLAN(0*)?(?P<VLAN_ID>\\d+)'. Line: 11.\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```

Output after the change:
```
                "item": "show sp", 
                "response": [
                    {
                        "cost": "19", 
                        "interface": "Gi1/0/48", 
                        "port_id": "48", 
                        "port_priority": "128", 
                        "role": "Desg", 
                        "status": "FWD", 
                        "type": "P2p Edge ", 
                        "vlan_id": "1000"
                    }, 
                    {
                        "cost": "19", 
                        "interface": "Gi1/0/48", 
                        "port_id": "48", 
                        "port_priority": "128", 
                        "role": "Desg", 
                        "status": "FWD", 
                        "type": "P2p Edge ", 
                        "vlan_id": "1001"
                    }
                ], 
                "response_list": []

```