### PR TITLE
add speed + duplex to ios show interfaces

### DIFF
--- a/templates/cisco_ios_show_interfaces.template
+++ b/templates/cisco_ios_show_interfaces.template
@@ -7,6 +7,8 @@ Value BIA ([a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+)
 Value DESCRIPTION (.*)
 Value IP_ADDRESS (\d+\.\d+\.\d+\.\d+\/\d+)
 Value MTU (\d+)
+Value DUPLEX (.+?)
+Value SPEED (.+?)
 Value BANDWIDTH (\d+\s+\w+)
 Value DELAY (\d+\s+\w+)
 Value ENCAPSULATION (\w+)
@@ -23,5 +25,6 @@ Start
   ^\s+MTU ${MTU}.*BW ${BANDWIDTH}.*DLY ${DELAY}
   ^\s+Encapsulation ${ENCAPSULATION}
   ^\s+Queueing strategy: ${QUEUE_STRATEGY}
+  ^\s+${DUPLEX}, ${SPEED}, media type
   ^.*input rate ${INPUT_RATE}
   ^.*output rate ${OUTPUT_RATE} -> Record

--- a/tests/cisco_ios/show_interfaces/cisco_ios_show_interfaces.parsed
+++ b/tests/cisco_ios/show_interfaces/cisco_ios_show_interfaces.parsed
@@ -1,130 +1,139 @@
 ---
 parsed_sample:
 
-- address: 'fa16.3e57.336f'
-  ip_address: ''
-  bandwidth: '1000000 Kbit'
-  bia: 'fa16.3e57.336f'
-  delay: '10 usec'
-  description: ''
-  encapsulation: 'ARPA'
-  hardware_type: 'iGbE'
-  input_rate: '0'
-  interface: 'GigabitEthernet0/0'
-  link_status: 'reset'
-  mtu: '1500'
-  output_rate: '0'
-  protocol_status: 'down (notconnect)'
-  queue_strategy: 'fifo'
-
-- address: 'fa16.3e4f.41cc'
-  ip_address: ''
-  bandwidth: '1000000 Kbit'
-  bia: 'fa16.3e4f.41cc'
-  delay: '10 usec'
-  description: 'to iosvl2-2'
-  encapsulation: 'ARPA'
-  hardware_type: 'iGbE'
-  input_rate: '0'
-  interface: 'GigabitEthernet0/1'
-  link_status: 'up'
-  mtu: '1500'
-  output_rate: '0'
-  protocol_status: 'up (connected)'
-  queue_strategy: 'fifo'
-
-- address: 'fa16.3ea3.3e49'
-  ip_address: ''
-  bandwidth: '1000000 Kbit'
-  bia: 'fa16.3ea3.3e49'
-  delay: '10 usec'
-  description: 'to iosvl2-4'
-  encapsulation: 'ARPA'
-  hardware_type: 'iGbE'
-  input_rate: '0'
-  interface: 'GigabitEthernet0/2'
-  link_status: 'up'
-  mtu: '1500'
-  output_rate: '1000'
-  protocol_status: 'up (connected)'
-  queue_strategy: 'fifo'
-
-- address: 'fa16.3e31.2c47'
-  ip_address: ''
-  bandwidth: '1000000 Kbit'
-  bia: 'fa16.3e31.2c47'
-  delay: '10 usec'
-  description: 'to iosvl2-3'
-  encapsulation: 'ARPA'
-  hardware_type: 'iGbE'
-  input_rate: '0'
-  interface: 'GigabitEthernet0/3'
-  link_status: 'up'
-  mtu: '1500'
-  output_rate: '1000'
-  protocol_status: 'up (connected)'
-  queue_strategy: 'fifo'
-
-- address: 'fa16.3ec8.50ab'
-  ip_address: ''
-  bandwidth: '1000000 Kbit'
-  bia: 'fa16.3ec8.50ab'
-  delay: '10 usec'
-  description: 'to iosvl2-3'
-  encapsulation: 'ARPA'
-  hardware_type: 'iGbE'
-  input_rate: '0'
-  interface: 'GigabitEthernet1/0'
-  link_status: 'up'
-  mtu: '1500'
-  output_rate: '2000'
-  protocol_status: 'up (connected)'
-  queue_strategy: 'fifo'
-
-- address: 'fa16.3e4f.41cc'
-  ip_address: ''
-  bandwidth: '100000 Kbit'
-  bia: 'fa16.3e4f.41cc'
-  delay: '100 usec'
-  description: ''
-  encapsulation: 'ARPA'
-  hardware_type: 'EtherChannel'
-  input_rate: '0'
-  interface: 'Port-channel1'
-  link_status: 'down'
-  mtu: '1500'
-  output_rate: '0'
-  protocol_status: 'down (notconnect)'
-  queue_strategy: 'fifo'
-
-- address: ''
-  ip_address: ''
-  bandwidth: '8000000 Kbit'
-  bia: ''
-  delay: '5000 usec'
-  description: 'Loopback'
-  encapsulation: 'LOOPBACK'
-  hardware_type: 'Loopback'
-  input_rate: '0'
-  interface: 'Loopback0'
-  link_status: 'up'
-  mtu: '1514'
-  output_rate: '0'
-  protocol_status: 'up'
-  queue_strategy: 'fifo'
-
-- address: 'fa16.3e57.8001'
-  ip_address: '10.255.0.16/16'
-  bandwidth: '1000000 Kbit'
-  bia: 'fa16.3e57.8001'
-  delay: '10 usec'
-  description: 'OOB Management'
-  encapsulation: 'ARPA'
-  hardware_type: 'Ethernet SVI'
-  input_rate: '0'
-  interface: 'Vlan1'
-  link_status: 'up'
-  mtu: '1500'
-  output_rate: '0'
-  protocol_status: 'up'
-  queue_strategy: 'fifo'
+-   address: fa16.3e57.336f
+    bandwidth: 1000000 Kbit
+    bia: fa16.3e57.336f
+    delay: 10 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: iGbE
+    input_rate: '0'
+    interface: GigabitEthernet0/0
+    ip_address: ''
+    link_status: reset
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed, link type is auto
+-   address: fa16.3e4f.41cc
+    bandwidth: 1000000 Kbit
+    bia: fa16.3e4f.41cc
+    delay: 10 usec
+    description: to iosvl2-2
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: iGbE
+    input_rate: '0'
+    interface: GigabitEthernet0/1
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: Auto-speed, link type is auto
+-   address: fa16.3ea3.3e49
+    bandwidth: 1000000 Kbit
+    bia: fa16.3ea3.3e49
+    delay: 10 usec
+    description: to iosvl2-4
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: iGbE
+    input_rate: '0'
+    interface: GigabitEthernet0/2
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '1000'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: Auto-speed, link type is auto
+-   address: fa16.3e31.2c47
+    bandwidth: 1000000 Kbit
+    bia: fa16.3e31.2c47
+    delay: 10 usec
+    description: to iosvl2-3
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: iGbE
+    input_rate: '0'
+    interface: GigabitEthernet0/3
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '1000'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: Auto-speed, link type is auto
+-   address: fa16.3ec8.50ab
+    bandwidth: 1000000 Kbit
+    bia: fa16.3ec8.50ab
+    delay: 10 usec
+    description: to iosvl2-3
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: iGbE
+    input_rate: '0'
+    interface: GigabitEthernet1/0
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '2000'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: Auto-speed, link type is auto
+-   address: fa16.3e4f.41cc
+    bandwidth: 100000 Kbit
+    bia: fa16.3e4f.41cc
+    delay: 100 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: EtherChannel
+    input_rate: '0'
+    interface: Port-channel1
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: ''
+    bandwidth: 8000000 Kbit
+    bia: ''
+    delay: 5000 usec
+    description: Loopback
+    duplex: ''
+    encapsulation: LOOPBACK
+    hardware_type: Loopback
+    input_rate: '0'
+    interface: Loopback0
+    ip_address: ''
+    link_status: up
+    mtu: '1514'
+    output_rate: '0'
+    protocol_status: up
+    queue_strategy: fifo
+    speed: ''
+-   address: fa16.3e57.8001
+    bandwidth: 1000000 Kbit
+    bia: fa16.3e57.8001
+    delay: 10 usec
+    description: OOB Management
+    duplex: ''
+    encapsulation: ARPA
+    hardware_type: Ethernet SVI
+    input_rate: '0'
+    interface: Vlan1
+    ip_address: 10.255.0.16/16
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up
+    queue_strategy: fifo
+    speed: ''

--- a/tests/cisco_ios/show_interfaces/cisco_ios_show_interfaces2.parsed
+++ b/tests/cisco_ios/show_interfaces/cisco_ios_show_interfaces2.parsed
@@ -1,0 +1,955 @@
+---
+parsed_sample:
+
+-   address: 0014.1c57.a4c0
+    bandwidth: 1000000 Kbit
+    bia: 0014.1c57.a4c0
+    delay: 10 usec
+    description: ''
+    duplex: ''
+    encapsulation: ARPA
+    hardware_type: EtherSVI
+    input_rate: '0'
+    interface: Vlan1
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up
+    queue_strategy: fifo
+    speed: ''
+-   address: 0014.1c57.a4c1
+    bandwidth: 1000000 Kbit
+    bia: 0014.1c57.a4c1
+    delay: 10 usec
+    description: ''
+    duplex: ''
+    encapsulation: ARPA
+    hardware_type: EtherSVI
+    input_rate: '0'
+    interface: Vlan50
+    ip_address: 10.1.50.1/24
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up
+    queue_strategy: fifo
+    speed: ''
+-   address: 0014.1c57.a4c2
+    bandwidth: 1000000 Kbit
+    bia: 0014.1c57.a4c2
+    delay: 10 usec
+    description: ''
+    duplex: ''
+    encapsulation: ARPA
+    hardware_type: EtherSVI
+    input_rate: '2000'
+    interface: Vlan100
+    ip_address: 10.1.100.1/24
+    link_status: up
+    mtu: '1500'
+    output_rate: '2000'
+    protocol_status: up
+    queue_strategy: fifo
+    speed: ''
+-   address: 0014.1c57.a4c3
+    bandwidth: 1000000 Kbit
+    bia: 0014.1c57.a4c3
+    delay: 10 usec
+    description: ''
+    duplex: ''
+    encapsulation: ARPA
+    hardware_type: EtherSVI
+    input_rate: '0'
+    interface: Vlan254
+    ip_address: 10.1.254.1/24
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up
+    queue_strategy: fifo
+    speed: ''
+-   address: 0014.1c57.a483
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a483
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '182000'
+    interface: FastEthernet1/0/1
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '38883000'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a484
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a484
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '38882000'
+    interface: FastEthernet1/0/2
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '182000'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a485
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a485
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/3
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '1000'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a486
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a486
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/4
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a487
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a487
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/5
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a488
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a488
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/6
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a489
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a489
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/7
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a48a
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a48a
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/8
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a48b
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a48b
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '38871000'
+    interface: FastEthernet1/0/9
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '174000'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a48c
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a48c
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/10
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a48d
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a48d
+    delay: 100 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/11
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a48e
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a48e
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/12
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a48f
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a48f
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/13
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a490
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a490
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/14
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a491
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a491
+    delay: 100 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/15
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a492
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a492
+    delay: 100 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/16
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a493
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a493
+    delay: 100 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/17
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a494
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a494
+    delay: 100 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/18
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a495
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a495
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/19
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a496
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a496
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/20
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a497
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a497
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/21
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a498
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a498
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/22
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a499
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a499
+    delay: 100 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/23
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a49a
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a49a
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/24
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a49d
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a49d
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/25
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a49e
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a49e
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/26
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a49f
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a49f
+    delay: 100 usec
+    description: ''
+    duplex: Half-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/27
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a4a0
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4a0
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/28
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a4a1
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4a1
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '1000'
+    interface: FastEthernet1/0/29
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '2000'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a4a2
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4a2
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/30
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a4a3
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4a3
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/31
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a4a4
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4a4
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/32
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a4a5
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4a5
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/33
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a4a6
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4a6
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/34
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a4a7
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4a7
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '3000'
+    interface: FastEthernet1/0/35
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '2000'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a4a8
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4a8
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/36
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a4a9
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4a9
+    delay: 100 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/37
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a4aa
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a4aa
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/38
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a4ab
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a4ab
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/39
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a4ac
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a4ac
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/40
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a4ad
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a4ad
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/41
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a4ae
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a4ae
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/42
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a4af
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4af
+    delay: 100 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/43
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a4b0
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a4b0
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/44
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a4b1
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4b1
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/45
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a4b2
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a4b2
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/46
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a4b3
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a4b3
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '0'
+    interface: FastEthernet1/0/47
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed
+-   address: 0014.1c57.a4b4
+    bandwidth: 100000 Kbit
+    bia: 0014.1c57.a4b4
+    delay: 100 usec
+    description: ''
+    duplex: Full-duplex
+    encapsulation: ARPA
+    hardware_type: Fast Ethernet
+    input_rate: '180000'
+    interface: FastEthernet1/0/48
+    ip_address: ''
+    link_status: up
+    mtu: '1500'
+    output_rate: '38881000'
+    protocol_status: up (connected)
+    queue_strategy: fifo
+    speed: 100Mb/s
+-   address: 0014.1c57.a481
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a481
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Gigabit Ethernet
+    input_rate: '0'
+    interface: GigabitEthernet1/0/1
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed, link type is auto
+-   address: 0014.1c57.a482
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a482
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Gigabit Ethernet
+    input_rate: '0'
+    interface: GigabitEthernet1/0/2
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed, link type is auto
+-   address: 0014.1c57.a49b
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a49b
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Gigabit Ethernet
+    input_rate: '0'
+    interface: GigabitEthernet1/0/3
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed, link type is auto
+-   address: 0014.1c57.a49c
+    bandwidth: 10000 Kbit
+    bia: 0014.1c57.a49c
+    delay: 1000 usec
+    description: ''
+    duplex: Auto-duplex
+    encapsulation: ARPA
+    hardware_type: Gigabit Ethernet
+    input_rate: '0'
+    interface: GigabitEthernet1/0/4
+    ip_address: ''
+    link_status: down
+    mtu: '1500'
+    output_rate: '0'
+    protocol_status: down (notconnect)
+    queue_strategy: fifo
+    speed: Auto-speed, link type is auto

--- a/tests/cisco_ios/show_interfaces/cisco_ios_show_interfaces2.raw
+++ b/tests/cisco_ios/show_interfaces/cisco_ios_show_interfaces2.raw
@@ -1,0 +1,1491 @@
+Vlan1 is up, line protocol is up
+  Hardware is EtherSVI, address is 0014.1c57.a4c0 (bia 0014.1c57.a4c0)
+  MTU 1500 bytes, BW 1000000 Kbit, DLY 10 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive not supported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:00, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     37453340 packets input, 2249839744 bytes, 0 no buffer
+     Received 0 broadcasts (0 IP multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 interface resets
+     0 output buffer failures, 0 output buffers swapped out
+Vlan50 is up, line protocol is up
+  Hardware is EtherSVI, address is 0014.1c57.a4c1 (bia 0014.1c57.a4c1)
+  Internet address is 10.1.50.1/24
+  MTU 1500 bytes, BW 1000000 Kbit, DLY 10 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive not supported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 01:04:54, output 01:04:54, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     3772 packets input, 226742 bytes, 0 no buffer
+     Received 0 broadcasts (0 IP multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     3804 packets output, 243514 bytes, 0 underruns
+     0 output errors, 0 interface resets
+     0 output buffer failures, 0 output buffers swapped out
+Vlan100 is up, line protocol is up
+  Hardware is EtherSVI, address is 0014.1c57.a4c2 (bia 0014.1c57.a4c2)
+  Internet address is 10.1.100.1/24
+  MTU 1500 bytes, BW 1000000 Kbit, DLY 10 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive not supported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:00, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 2000 bits/sec, 2 packets/sec
+  5 minute output rate 2000 bits/sec, 2 packets/sec
+     6313297 packets input, 426193389 bytes, 0 no buffer
+     Received 0 broadcasts (31802 IP multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     10453439 packets output, 695857497 bytes, 0 underruns
+     0 output errors, 0 interface resets
+     0 output buffer failures, 0 output buffers swapped out
+Vlan254 is up, line protocol is up
+  Hardware is EtherSVI, address is 0014.1c57.a4c3 (bia 0014.1c57.a4c3)
+  Internet address is 10.1.254.1/24
+  MTU 1500 bytes, BW 1000000 Kbit, DLY 10 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive not supported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:08:48, output 00:08:48, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     7881502 packets input, 565885779 bytes, 0 no buffer
+     Received 0 broadcasts (0 IP multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     47843 packets output, 3119470 bytes, 0 underruns
+     0 output errors, 0 interface resets
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/1 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a483 (bia 0014.1c57.a483)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 99/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:01, output 00:00:06, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 182000 bits/sec, 334 packets/sec
+  5 minute output rate 38883000 bits/sec, 10094 packets/sec
+     8647579827 packets input, 638901996995 bytes, 0 no buffer
+     Received 61011302 broadcasts (28370454 multicasts)
+     0 runts, 0 giants, 0 throttles
+     1 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 28370454 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     86941746207 packets output, 41399413469427 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/2 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a484 (bia 0014.1c57.a484)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 99/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output 00:00:01, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 38882000 bits/sec, 10093 packets/sec
+  5 minute output rate 182000 bits/sec, 334 packets/sec
+     86697408651 packets input, 41363381670535 bytes, 0 no buffer
+     Received 8 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     8485702870 packets output, 609564954763 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/3 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a485 (bia 0014.1c57.a485)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output 00:00:01, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 1000 bits/sec, 1 packets/sec
+     233361378 packets input, 34485100658 bytes, 0 no buffer
+     Received 4812693 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     246128007 packets output, 35790595839 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/4 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a486 (bia 0014.1c57.a486)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/5 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a487 (bia 0014.1c57.a487)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/6 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a488 (bia 0014.1c57.a488)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/7 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a489 (bia 0014.1c57.a489)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/8 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a48a (bia 0014.1c57.a48a)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/9 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a48b (bia 0014.1c57.a48b)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 99/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:27, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 38871000 bits/sec, 10083 packets/sec
+  5 minute output rate 174000 bits/sec, 327 packets/sec
+     86293954347 packets input, 41067077112070 bytes, 0 no buffer
+     Received 1862329 broadcasts (1861711 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 1861711 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     8120676183 packets output, 530792567729 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/10 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a48c (bia 0014.1c57.a48c)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:27, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     85011546 packets input, 11989861828 bytes, 0 no buffer
+     Received 2516226 broadcasts (2515452 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 2515452 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     118427887 packets output, 13878610375 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/11 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a48d (bia 0014.1c57.a48d)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 21w5d, output 21w5d, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     13503663 packets input, 4753753238 bytes, 0 no buffer
+     Received 1253486 broadcasts (1253337 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 1253337 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     96706284 packets output, 8355857467 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/12 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a48e (bia 0014.1c57.a48e)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:27, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     566684 packets input, 149322191 bytes, 0 no buffer
+     Received 554098 broadcasts (554096 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 554096 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     10387099 packets output, 839593247 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/13 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a48f (bia 0014.1c57.a48f)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:13, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     5093298 packets input, 808035580 bytes, 0 no buffer
+     Received 827918 broadcasts (826665 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 826665 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     35059143 packets output, 4327552848 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/14 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a490 (bia 0014.1c57.a490)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:13, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     4381776 packets input, 714050947 bytes, 0 no buffer
+     Received 888514 broadcasts (825040 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 825040 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     33579140 packets output, 4215972552 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/15 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a491 (bia 0014.1c57.a491)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 36w5d, output 36w5d, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     6095906 packets input, 969445394 bytes, 0 no buffer
+     Received 739894 broadcasts (738041 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 738041 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     31933579 packets output, 2817760810 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/16 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a492 (bia 0014.1c57.a492)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 36w5d, output 36w5d, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     3048741 packets input, 489808413 bytes, 0 no buffer
+     Received 495442 broadcasts (495388 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 495388 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     23191458 packets output, 1834173050 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/17 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a493 (bia 0014.1c57.a493)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 1y28w, output 1y28w, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     515815 packets input, 79623043 bytes, 0 no buffer
+     Received 41131 broadcasts (41093 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 41093 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     3364092 packets output, 256764837 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/18 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a494 (bia 0014.1c57.a494)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 1y29w, output 1y29w, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     56335 packets input, 9435768 bytes, 0 no buffer
+     Received 9185 broadcasts (9149 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 9149 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     2263838 packets output, 151796214 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/19 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a495 (bia 0014.1c57.a495)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:13, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     2154038 packets input, 348457077 bytes, 0 no buffer
+     Received 549246 broadcasts (548182 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 548182 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     15816478 packets output, 2861125524 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/20 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a496 (bia 0014.1c57.a496)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:13, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     2238092 packets input, 360874580 bytes, 0 no buffer
+     Received 549631 broadcasts (548228 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 548228 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     15877977 packets output, 2842501679 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/21 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a497 (bia 0014.1c57.a497)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:25, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     4942593 packets input, 553715331 bytes, 0 no buffer
+     Received 816566 broadcasts (814921 multicasts)
+     0 runts, 0 giants, 0 throttles
+     1 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 814921 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     43723513 packets output, 3415744145 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/22 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a498 (bia 0014.1c57.a498)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:00, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     6201152 packets input, 700304632 bytes, 0 no buffer
+     Received 652574 broadcasts (652397 multicasts)
+     0 runts, 0 giants, 0 throttles
+     1 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 652397 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     43660027 packets output, 3409805231 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/23 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a499 (bia 0014.1c57.a499)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output 25w5d, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     56 packets output, 5194 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/24 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a49a (bia 0014.1c57.a49a)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:05, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     2397801 packets input, 533671784 bytes, 0 no buffer
+     Received 2031277 broadcasts (2031248 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 2031248 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     45635335 packets output, 4268271556 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/25 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a49d (bia 0014.1c57.a49d)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/26 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a49e (bia 0014.1c57.a49e)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/27 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a49f (bia 0014.1c57.a49f)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Half-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     288816 packets input, 29063120 bytes, 0 no buffer
+     Received 93730 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     55357995 packets output, 4340952662 bytes, 0 underruns
+     0 output errors, 3 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/28 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4a0 (bia 0014.1c57.a4a0)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     295313 packets input, 31891003 bytes, 0 no buffer
+     Received 93743 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     2 input errors, 1 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     55364859 packets output, 4341674021 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/29 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4a1 (bia 0014.1c57.a4a1)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 1000 bits/sec, 1 packets/sec
+  5 minute output rate 2000 bits/sec, 2 packets/sec
+     39214781 packets input, 7433968714 bytes, 0 no buffer
+     Received 2429 broadcasts (190 multicasts)
+     0 runts, 39 giants, 0 throttles
+     28898 input errors, 14167 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 190 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     90202230 packets output, 9923517076 bytes, 0 underruns
+     0 output errors, 0 collisions, 3 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/30 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4a2 (bia 0014.1c57.a4a2)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     4811284 packets input, 307924495 bytes, 0 no buffer
+     Received 4811274 broadcasts (60 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 60 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     55162378 packets output, 4320891856 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/31 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4a3 (bia 0014.1c57.a4a3)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:13, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     2255624 packets input, 378850249 bytes, 0 no buffer
+     Received 559581 broadcasts (551530 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 551530 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     15969856 packets output, 2990878148 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/32 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4a4 (bia 0014.1c57.a4a4)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:13, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     5743877 packets input, 940903033 bytes, 0 no buffer
+     Received 504351 broadcasts (503679 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 503679 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     20133314 packets output, 3482805506 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/33 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4a5 (bia 0014.1c57.a4a5)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:13, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     11086568 packets input, 2419043608 bytes, 0 no buffer
+     Received 694838 broadcasts (689889 multicasts)
+     0 runts, 0 giants, 0 throttles
+     1 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 689889 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     46398900 packets output, 10652109924 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/34 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4a6 (bia 0014.1c57.a4a6)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:13, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     1071483 packets input, 185592800 bytes, 0 no buffer
+     Received 596225 broadcasts (592703 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 592703 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     11192764 packets output, 2239833866 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/35 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4a7 (bia 0014.1c57.a4a7)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 25w5d, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 252
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 3000 bits/sec, 3 packets/sec
+  5 minute output rate 2000 bits/sec, 3 packets/sec
+     252774135 packets input, 267313974161 bytes, 0 no buffer
+     Received 108008 broadcasts (63919 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 63919 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     136849790 packets output, 51880935835 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/36 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4a8 (bia 0014.1c57.a4a8)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 00:00:00, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     30561744 packets input, 33540275610 bytes, 0 no buffer
+     Received 688013 broadcasts (625257 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 625257 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     25816556 packets output, 13469425319 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/37 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4a9 (bia 0014.1c57.a4a9)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input 25w5d, output 25w5d, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     23 packets input, 7026 bytes, 0 no buffer
+     Received 23 broadcasts (5 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 5 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     110 packets output, 14268 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/38 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4aa (bia 0014.1c57.a4aa)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/39 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4ab (bia 0014.1c57.a4ab)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/40 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4ac (bia 0014.1c57.a4ac)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/41 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4ad (bia 0014.1c57.a4ad)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/42 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4ae (bia 0014.1c57.a4ae)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/43 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4af (bia 0014.1c57.a4af)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output 25w5d, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     33944 packets input, 4980418 bytes, 0 no buffer
+     Received 2337 broadcasts (614 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 614 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     52215 packets output, 23364008 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/44 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4b0 (bia 0014.1c57.a4b0)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/45 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4b1 (bia 0014.1c57.a4b1)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output 00:00:01, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     1103 packets input, 70592 bytes, 0 no buffer
+     Received 16 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     10099477 packets output, 862020215 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/46 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4b2 (bia 0014.1c57.a4b2)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/47 is down, line protocol is down (notconnect)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4b3 (bia 0014.1c57.a4b3)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Auto-duplex, Auto-speed, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+FastEthernet1/0/48 is up, line protocol is up (connected)
+  Hardware is Fast Ethernet, address is 0014.1c57.a4b4 (bia 0014.1c57.a4b4)
+  MTU 1500 bytes, BW 100000 Kbit, DLY 100 usec,
+     reliability 255/255, txload 99/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive set (10 sec)
+  Full-duplex, 100Mb/s, media type is 10/100BaseTX
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output 00:00:00, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 15775
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 180000 bits/sec, 332 packets/sec
+  5 minute output rate 38881000 bits/sec, 10093 packets/sec
+     8407299374 packets input, 603713995336 bytes, 0 no buffer
+     Received 42103 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     86731716396 packets output, 41366362101294 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+GigabitEthernet1/0/1 is down, line protocol is down (notconnect)
+  Hardware is Gigabit Ethernet, address is 0014.1c57.a481 (bia 0014.1c57.a481)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive not set
+  Auto-duplex, Auto-speed, link type is auto, media type is Not Present
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+GigabitEthernet1/0/2 is down, line protocol is down (notconnect)
+  Hardware is Gigabit Ethernet, address is 0014.1c57.a482 (bia 0014.1c57.a482)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive not set
+  Auto-duplex, Auto-speed, link type is auto, media type is Not Present
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+GigabitEthernet1/0/3 is down, line protocol is down (notconnect)
+  Hardware is Gigabit Ethernet, address is 0014.1c57.a49b (bia 0014.1c57.a49b)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive not set
+  Auto-duplex, Auto-speed, link type is auto, media type is Not Present
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out
+GigabitEthernet1/0/4 is down, line protocol is down (notconnect)
+  Hardware is Gigabit Ethernet, address is 0014.1c57.a49c (bia 0014.1c57.a49c)
+  MTU 1500 bytes, BW 10000 Kbit, DLY 1000 usec,
+     reliability 255/255, txload 1/255, rxload 1/255
+  Encapsulation ARPA, loopback not set
+  Keepalive not set
+  Auto-duplex, Auto-speed, link type is auto, media type is Not Present
+  input flow-control is off, output flow-control is unsupported
+  ARP type: ARPA, ARP Timeout 04:00:00
+  Last input never, output never, output hang never
+  Last clearing of "show interface" counters never
+  Input queue: 0/75/0/0 (size/max/drops/flushes); Total output drops: 0
+  Queueing strategy: fifo
+  Output queue: 0/40 (size/max)
+  5 minute input rate 0 bits/sec, 0 packets/sec
+  5 minute output rate 0 bits/sec, 0 packets/sec
+     0 packets input, 0 bytes, 0 no buffer
+     Received 0 broadcasts (0 multicasts)
+     0 runts, 0 giants, 0 throttles
+     0 input errors, 0 CRC, 0 frame, 0 overrun, 0 ignored
+     0 watchdog, 0 multicast, 0 pause input
+     0 input packets with dribble condition detected
+     0 packets output, 0 bytes, 0 underruns
+     0 output errors, 0 collisions, 1 interface resets
+     0 babbles, 0 late collision, 0 deferred
+     0 lost carrier, 0 no carrier, 0 PAUSE output
+     0 output buffer failures, 0 output buffers swapped out


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios, show interfaces

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding speed and duplex to show interfaces
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
