### PR TITLE
Updated IOS show-ip-route to handle additional cases

### DIFF
--- a/templates/cisco_ios_show_ip_route.template
+++ b/templates/cisco_ios_show_ip_route.template
@@ -1,31 +1,43 @@
-Value Filldown Protocol (C|S|R|B|D|O|i|L)
+Value Filldown Protocol (\w)
 Value Filldown Type (\w{0,2})
-Value Required,Filldown Network ([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3})
+Value Required,Filldown Network (\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3})
 Value Filldown Mask (\/\d{1,2})
 Value Distance (\d+)
 Value Metric (\d+)
-Value NexthopIP ([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3})
-Value NexthopIf ([\w\/]*)
+Value NexthopIP (\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3})
+Value NexthopIf ([\w\-\/\.:]+)
 Value Uptime ([0-9]{2}:[0-9]{2}:[0-9]{2})
 
 Start
   ^Gateway.* -> Routes
 
 Routes
+  # For "is (variably )subnetted" line, capture mask, clear all values.
+  ^\s+\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}${Mask}\sis -> Clear
   #
-  # Match regular routes with all data in same line
-  ^${Protocol}(\s|\*)${Type}\s+${Network}${Mask}\s\[${Distance}\/${Metric}\]\svia\s${NexthopIP}(,\s${Uptime}){0,1}(,\s${NexthopIf}){0,1} -> Record
+  # Match directly connected route with explicit mask
+  ^${Protocol}(\s|\*)${Type}\s+${Network}${Mask}\sis\sdirectly\sconnected,\s${NexthopIf} -> Record
   #
-  # Clear all non Filldown variables when line started with network that is variably subnetted
-  ^\s+[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}${Mask} -> Clear
-  ^${Protocol}(\s|\*)${Type}\s+${Network}\s\[${Distance}\/${Metric}\]\svia\s${NexthopIP}(,\s${Uptime}){0,1}(,\s${NexthopIf}){0,1} -> Record
+  # Match directly connected route (mask is inherited from "is subnetted")
+  ^${Protocol}(\s|\*)${Type}\s+${Network}\sis\sdirectly\sconnected,\s${NexthopIf} -> Record
+  #
+  # Match regular routes, with mask, where all data in same line
+  ^${Protocol}(\s|\*)${Type}\s+${Network}${Mask}\s\[${Distance}\/${Metric}\]\svia\s${NexthopIP}(,\s${Uptime})?(,\s${NexthopIf})? -> Record
+  #
+  # Match regular route, all one line, where mask is learned from "is subnetted" line
+  ^${Protocol}(\s|\*)${Type}\s+${Network}\s\[${Distance}\/${Metric}\]\svia\s${NexthopIP}(,\s${Uptime})?(,\s${NexthopIf})? -> Record
+  #
+  # Match regular routes where the network/mask is on the line above the rest of the route
+  ^${Protocol}(\s|\*)${Type}\s+${Network}${Mask} -> Next
+  #
+  # Match regular routes where the network only (mask from subnetted line) is on the line above the rest of the route
+  ^${Protocol}(\s|\*)${Type}\s+${Network} -> Next
+  #
+  # Match the rest of the route information on line below network (and possibly mask)
+  ^\s+\[${Distance}\/${Metric}\]\svia\s${NexthopIP}(,\s${Uptime})?(,\s${NexthopIf})? -> Record
   #
   # Match load-balanced routes
   ^\s+\[${Distance}\/${Metric}\]\svia\s${NexthopIP} -> Record
-  #
-  # Match directly connected routes
-  ^${Protocol}\s${Type}\s+${Network}\sis\sdirectly\sconnected,\s${NexthopIf} -> Record
-  ^${Protocol}(\*){0,1}\s${Type}\s+${Network}${Mask}\sis\sdirectly\sconnected,\s${NexthopIf} -> Record
   #
   # Clear all variables on empty lines
   ^\s* -> Clearall

--- a/tests/cisco_ios/show_ip_route/cisco_ios_show_ip_route.parsed
+++ b/tests/cisco_ios/show_ip_route/cisco_ios_show_ip_route.parsed
@@ -37,7 +37,7 @@ parsed_sample:
   metric: '20'
   nexthopif: FastEthernet0/0
   nexthopip: 194.0.0.2
-  protocol: 'O'
+  protocol: O
   type: E2
   uptime: 00:02:00
 
@@ -160,6 +160,126 @@ parsed_sample:
   protocol: D
   type: ''
   uptime: 00:12:03
+
+- network: 192.168.10.168
+  distance: '110'
+  mask: /29
+  metric: '20'
+  nexthopif: TenGigabitEthernet7/4
+  nexthopip: 7.7.7.170
+  protocol: O
+  type: E2
+  uptime: '12:54:35'
+
+- network: 10.63.184.0
+  distance: '110'
+  mask: /23
+  metric: '20'
+  nexthopif: TenGigabitEthernet1/15
+  nexthopip: 10.62.4.29
+  protocol: O
+  type: E2
+  uptime: '12:55:19'
+
+- network: 10.63.184.0
+  distance: '110'
+  mask: /23
+  metric: '20'
+  nexthopif: TenGigabitEthernet1/16
+  nexthopip: 10.62.3.29
+  protocol: O
+  type: E2
+  uptime: '12:55:19'
+
+- network: 192.168.12.0
+  distance: '110'
+  mask: /27
+  metric: '20'
+  nexthopif: Port-channel202
+  nexthopip: 10.64.3.13
+  protocol: O
+  type: E2
+  uptime: '12:54:36'
+
+- network: 192.168.12.0
+  distance: '110'
+  mask: /27
+  metric: '20'
+  nexthopif: Port-channel201
+  nexthopip: 10.64.1.9
+  protocol: O
+  type: E2
+  uptime: '12:54:36'
+
+- network: 10.64.4.88
+  distance: ''
+  mask: /30
+  metric: ''
+  nexthopif: Serial0/0/0:0
+  nexthopip: ''
+  protocol: C
+  type: ''
+  uptime: ''
+
+- network: 10.6.234.0
+  distance: '110'
+  mask: /24
+  metric: '20'
+  nexthopif: Serial0/0/0:0
+  nexthopip: 10.64.4.90
+  protocol: O
+  type: E2
+  uptime: '12:54:53'
+
+- network: 7.7.7.168
+  distance: ''
+  mask: /30
+  metric: ''
+  nexthopif: TenGigabitEthernet7/4
+  nexthopip: ''
+  protocol: C
+  type: ''
+  uptime: ''
+
+- network: 10.64.3.12
+  distance: ''
+  mask: /30
+  metric: ''
+  nexthopif: Port-channel202
+  nexthopip: ''
+  protocol: C
+  type: ''
+  uptime: ''
+
+- network: 10.64.1.8
+  distance: ''
+  mask: /30
+  metric: ''
+  nexthopif: Port-channel201
+  nexthopip: ''
+  protocol: C
+  type: ''
+  uptime: ''
+
+- network: 10.62.4.28
+  distance: ''
+  mask: /30
+  metric: ''
+  nexthopif: TenGigabitEthernet1/15
+  nexthopip: ''
+  protocol: C
+  type: ''
+  uptime: ''
+
+- network: 10.62.3.28
+  distance: ''
+  mask: /30
+  metric: ''
+  nexthopif: TenGigabitEthernet1/16
+  nexthopip: ''
+  protocol: C
+  type: ''
+  uptime: ''
 
 - network: 195.0.0.0
   distance: '110'

--- a/tests/cisco_ios/show_ip_route/cisco_ios_show_ip_route.raw
+++ b/tests/cisco_ios/show_ip_route/cisco_ios_show_ip_route.raw
@@ -1,4 +1,3 @@
-ESW1#sh ip route 
 Codes: C - connected, S - static, R - RIP, M - mobile, B - BGP
        D - EIGRP, EX - EIGRP external, O - OSPF, IA - OSPF inter area 
        N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
@@ -34,9 +33,23 @@ D       10.0.5.128/26 [90/2297856] via 10.0.1.2, 00:12:03, Serial0/0
 D       10.0.5.192/27 [90/2297856] via 10.0.1.2, 00:12:03, Serial0/0
      192.168.0.0/32 is subnetted, 1 subnets
 D       192.168.0.1 [90/2297856] via 10.0.1.2, 00:12:03, Serial0/0
+     192.168.10.0/29 is subnetted, 1 subnets
+O E2    192.168.10.168 
+           [110/20] via 7.7.7.170, 12:54:35, TenGigabitEthernet7/4
+O E2    10.63.184.0/23 
+           [110/20] via 10.62.4.29, 12:55:19, TenGigabitEthernet1/15
+           [110/20] via 10.62.3.29, 12:55:19, TenGigabitEthernet1/16
+O E2    192.168.12.0/27 [110/20] via 10.64.3.13, 12:54:36, Port-channel202
+                        [110/20] via 10.64.1.9, 12:54:36, Port-channel201
+C       10.64.4.88/30 is directly connected, Serial0/0/0:0
+O E2    10.6.234.0/24 [110/20] via 10.64.4.90, 12:54:53, Serial0/0/0:0
+C       7.7.7.168/30 is directly connected, TenGigabitEthernet7/4
+C       10.64.3.12/30 is directly connected, Port-channel202
+C       10.64.1.8/30 is directly connected, Port-channel201
+C       10.62.4.28/30 is directly connected, TenGigabitEthernet1/15
+C       10.62.3.28/30 is directly connected, TenGigabitEthernet1/16
 O IA 195.0.0.0/24 [110/11] via 194.0.0.2, 00:05:45, FastEthernet0/0
 O*E2 0.0.0.0/0 [110/1] via 194.0.0.2, 00:05:35, FastEthernet0/0
 O E2 212.0.0.0/8 [110/20] via 194.0.0.2, 00:05:35, FastEthernet0/0
 C    194.0.0.0/16 is directly connected, FastEthernet0/0
-ESW1# 
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_ip_route.template, cisco_ios, show ip route

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Modifies the the Cisco IOS "show ip route" template to account for the following scenarios:
* Less common interface names that include: a dash (Port-channel123), a colon (Serial0/0/0:0), or a period (FastEthernet0/0.100)
* Recognizes routes that are split across lines, such as when the Protocol, Type, Network and Mask are on one line and the rest of the route is on one or more follow-up lines (examples added to tests, which were sanitized from a real route table).  Covers both single and ECMP cases.
* Made the Protocol regex more generic since not all possible values were being matched.
* Replaced [0-9] with \d since they are equivalent (and I was already changing other parts)

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
