### PR TITLE
Show environment power all

### DIFF
--- a/templates/cisco_ios_show_environment_power_all.template
+++ b/templates/cisco_ios_show_environment_power_all.template
@@ -1,0 +1,13 @@
+####
+# For 3850 switches, does not work on 3750 switches
+###
+Value PS_MODULE (\w+)
+Value PID (\S+)
+Value SERIAL (\w+)
+Value STATUS (.+?)
+Value SYS_PWR (Good|Bad)
+Value POE_PWR (\w+)
+Value WATTS (\w+)
+
+Start
+  ^${PS_MODULE}\s+${PID}\s+${SERIAL}\s+${STATUS}\s+${SYS_PWR}\s+${POE_PWR}\s+${WATTS} -> Record

--- a/templates/index
+++ b/templates/index
@@ -79,6 +79,7 @@ cisco_asa_dir.template, .*, cisco_asa, dir
 cisco_ios_show_capability_feature_routing.template,  .*, cisco_ios, sh[[ow]] cap[[ability]] f[[eature]] r[[outing]]
 cisco_ios_show_authentication_sessions.template, .*, cisco_ios, show authen[[tication]] ses[[sions]]
 cisco_ios_show_ip_ospf_interface_brief.template, .*, cisco_ios, sh[[ow]] ip ospf int[[erface]]
+cisco_ios_show_environment_power_all.template, .*, cisco_ios, sh[[ow]] envi[[ronment]] p[[ower]] a[[ll]]
 cisco_ios_show_interface_transceiver.template, .*, cisco_ios, sh[[ow]] int[[erface]] trans[[ceiver]]
 cisco_ios_show_cdp_neighbors_detail.template, .*, cisco_ios, sh[[ow]] c[[dp]] neig[[hbors]] det[[ail]]
 cisco_ios_show_interfaces_status.template, .*, cisco_ios, sh[[ow]] int[[erfaces]] st[[atus]]

--- a/tests/cisco_ios/show_environment_power_all/cisco_ios_show_environment_power_all.parsed
+++ b/tests/cisco_ios/show_environment_power_all/cisco_ios_show_environment_power_all.parsed
@@ -1,0 +1,45 @@
+---
+parsed_sample:
+
+-   pid: PWR-C1-1100WAC
+    poe_pwr: Good
+    ps_module: 1A
+    serial: ABC123456AB
+    status: OK
+    sys_pwr: Good
+    watts: '1100'
+-   pid: PWR-C1-1100WAC
+    poe_pwr: Good
+    ps_module: 1B
+    serial: ABC123456CD
+    status: OK
+    sys_pwr: Good
+    watts: '1100'
+-   pid: PWR-C1-1100WAC
+    poe_pwr: Good
+    ps_module: 2A
+    serial: ABC123456EF
+    status: OK
+    sys_pwr: Good
+    watts: '1100'
+-   pid: PWR-C1-1100WAC
+    poe_pwr: Good
+    ps_module: 2B
+    serial: ABC123456GH
+    status: OK
+    sys_pwr: Good
+    watts: '1100'
+-   pid: Unknown
+    poe_pwr: Bad
+    ps_module: 3A
+    serial: Unknown
+    status: No Input Power
+    sys_pwr: Bad
+    watts: '235'
+-   pid: PWR-C1-1100WAC
+    poe_pwr: Good
+    ps_module: 3B
+    serial: ABC123456KL
+    status: OK
+    sys_pwr: Good
+    watts: '1100'

--- a/tests/cisco_ios/show_environment_power_all/cisco_ios_show_environment_power_all.raw
+++ b/tests/cisco_ios/show_environment_power_all/cisco_ios_show_environment_power_all.raw
@@ -1,0 +1,8 @@
+SW  PID                 Serial#     Status           Sys Pwr  PoE Pwr  Watts
+--  ------------------  ----------  ---------------  -------  -------  -----
+1A  PWR-C1-1100WAC      ABC123456AB  OK              Good     Good     1100
+1B  PWR-C1-1100WAC      ABC123456CD  OK              Good     Good     1100
+2A  PWR-C1-1100WAC      ABC123456EF  OK              Good     Good     1100
+2B  PWR-C1-1100WAC      ABC123456GH  OK              Good     Good     1100
+3A  Unknown             Unknown      No Input Power  Bad      Bad      235 
+3B  PWR-C1-1100WAC      ABC123456KL  OK              Good     Good     1100

--- a/tests/cisco_ios/show_environment_power_all/cisco_ios_show_environment_power_all1.parsed
+++ b/tests/cisco_ios/show_environment_power_all/cisco_ios_show_environment_power_all1.parsed
@@ -1,0 +1,31 @@
+---
+parsed_sample:
+
+-   pid: PWR-C1-1100WAC
+    poe_pwr: Good
+    ps_module: 1A
+    serial: DEF123456AB
+    status: OK
+    sys_pwr: Good
+    watts: '1100'
+-   pid: PWR-C1-1100WAC
+    poe_pwr: Good
+    ps_module: 1B
+    serial: DEF123456CD
+    status: OK
+    sys_pwr: Good
+    watts: '1100'
+-   pid: PWR-C1-1100WAC
+    poe_pwr: Good
+    ps_module: 2A
+    serial: DEF123456EF
+    status: OK
+    sys_pwr: Good
+    watts: '1100'
+-   pid: PWR-C1-1100WAC
+    poe_pwr: Good
+    ps_module: 2B
+    serial: DEF123456GH
+    status: OK
+    sys_pwr: Good
+    watts: '1100'

--- a/tests/cisco_ios/show_environment_power_all/cisco_ios_show_environment_power_all1.raw
+++ b/tests/cisco_ios/show_environment_power_all/cisco_ios_show_environment_power_all1.raw
@@ -1,0 +1,6 @@
+SW  PID                 Serial#     Status           Sys Pwr  PoE Pwr  Watts
+--  ------------------  ----------  ---------------  -------  -------  -----
+1A  PWR-C1-1100WAC      DEF123456AB  OK              Good     Good     1100
+1B  PWR-C1-1100WAC      DEF123456CD  OK              Good     Good     1100
+2A  PWR-C1-1100WAC      DEF123456EF  OK              Good     Good     1100
+2B  PWR-C1-1100WAC      DEF123456GH  OK              Good     Good     1100


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request


##### COMPONENT
<!--- Name of the template, os and command  -->
- cisco_ios_show_environment_power_all.template, Cisco IOS, show environment power all

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Parse output to show power supply status.  This works on Cisco 3850 switches.  The command and output is different for Cisco 3750 switches.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
