### PR TITLE
Update the regex to match space+ or end of line

### DIFF
--- a/templates/cisco_nxos_show_lldp_neighbors.template
+++ b/templates/cisco_nxos_show_lldp_neighbors.template
@@ -9,4 +9,4 @@ LLDP
   ^${NEIGHBOR}\s+${LOCAL_INTERFACE}\s+\d+\s+[\w+\s]+\S+\s+${NEIGHBOR_INTERFACE}$$ -> Record
   ^\S+$$ -> Continue.Record
   ^${NEIGHBOR}$$
-  ^\s+${LOCAL_INTERFACE}\s+\d+\s+[\w+\s]+\S+\s+${NEIGHBOR_INTERFACE}$$ -> Record
+  ^\s+${LOCAL_INTERFACE}\s+\d+\s+[\w+\s]+\S+\s+${NEIGHBOR_INTERFACE}[\s+|$$] -> Record


### PR DESCRIPTION
Nexus 9504 Show LLDP Neighbor has spaces at the end of the output.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
cisco_nxos_show_lldp_neighbors

##### SUMMARY
The template did not match the show lldp neighbors output on my Nexus 9504.
My output has spaces at the end and the current template has $$ to match the end of the line. I changed to match either spaces or end of line, so I don't break any other devices
<!-- Paste verbatim command output below, e.g. before and after your change -->
Before
```
"response": [
            {
                "local_interface": "",
                "neighbor": "si-ny-us-c2960s-48ts-oobsw01.prod",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "si-ny-us-c9504-prod-spine02",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "si-ny-us-asr-9001-edge01",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "dv-lb05.prod",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "dv-lb05.prod",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "si-ny-us-5548-stg-rnd-n5k01",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "si-ny-us-c92160-prod-ssl-leaf01",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "si-ny-us-c92160-prod-ssl-leaf02",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "si-ny-us-5020-nexus01-legacy",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "si-ny-us-c9504-prod-spine02",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "si-ny-us-asr-9001-edge02",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "dv-lb05.prod",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "dv-lb05.prod",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "si-ny-us-5548-stg-rnd-n5k02",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "si-ny-us-c92160-prod-ssl-leaf01",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "si-ny-us-c92160-prod-ssl-leaf02",
                "neighbor_interface": ""
            },
            {
                "local_interface": "",
                "neighbor": "si-ny-us-5020-nexus01-legacy",
                "neighbor_interface": ""
            }
        ]
```
After:
```
"response": [
            {
                "local_interface": "mgmt0",
                "neighbor": "si-ny-us-c2960s-48ts-oobsw01.prod",
                "neighbor_interface": "Gi0/6"
            },
            {
                "local_interface": "Eth1/1",
                "neighbor": "si-ny-us-c9504-prod-spine02",
                "neighbor_interface": "Ethernet1/1"
            },
            {
                "local_interface": "Eth1/2",
                "neighbor": "si-ny-us-asr-9001-edge01",
                "neighbor_interface": "Te0/0/2/0"
            },
            {
                "local_interface": "Eth1/8",
                "neighbor": "dv-lb05.prod",
                "neighbor_interface": "1.1"
            },
            {
                "local_interface": "Eth1/9",
                "neighbor": "dv-lb05.prod",
                "neighbor_interface": "1.2"
            },
            {
                "local_interface": "Eth1/11",
                "neighbor": "si-ny-us-5548-stg-rnd-n5k01",
                "neighbor_interface": "Eth1/29"
            },
            {
                "local_interface": "Eth1/15",
                "neighbor": "si-ny-us-c92160-prod-ssl-leaf01",
                "neighbor_interface": "Ethernet1/43"
            },
            {
                "local_interface": "Eth1/16",
                "neighbor": "si-ny-us-c92160-prod-ssl-leaf02",
                "neighbor_interface": "Ethernet1/43"
            },
            {
                "local_interface": "Eth1/27",
                "neighbor": "",
                "neighbor_interface": "Ethernet1/2"
            },
            {
                "local_interface": "Eth1/35",
                "neighbor": "",
                "neighbor_interface": "Ethernet1/1"
            },
            {
                "local_interface": "Eth1/46",
                "neighbor": "si-ny-us-5020-nexus01-legacy",
                "neighbor_interface": "Eth1/30"
            },
            {
                "local_interface": "Eth2/1",
                "neighbor": "si-ny-us-c9504-prod-spine02",
                "neighbor_interface": "Ethernet2/1"
            },
            {
                "local_interface": "Eth2/2",
                "neighbor": "si-ny-us-asr-9001-edge02",
                "neighbor_interface": "Te0/0/2/0"
            },
            {
                "local_interface": "Eth2/8",
                "neighbor": "dv-lb05.prod",
                "neighbor_interface": "1.5"
            },
            {
                "local_interface": "Eth2/9",
                "neighbor": "dv-lb05.prod",
                "neighbor_interface": "1.6"
            },
            {
                "local_interface": "Eth2/11",
                "neighbor": "si-ny-us-5548-stg-rnd-n5k02",
                "neighbor_interface": "Eth1/29"
            },
            {
                "local_interface": "Eth2/15",
                "neighbor": "si-ny-us-c92160-prod-ssl-leaf01",
                "neighbor_interface": "Ethernet1/44"
            },
            {
                "local_interface": "Eth2/16",
                "neighbor": "si-ny-us-c92160-prod-ssl-leaf02",
                "neighbor_interface": "Ethernet1/44"
            },
            {
                "local_interface": "Eth2/46",
                "neighbor": "si-ny-us-5020-nexus01-legacy",
                "neighbor_interface": "Eth1/31"
            }
        ]
```
