### PR TITLE
update cisco_nxos_show_version to support 5ks

### DIFF
--- a/templates/cisco_nxos_show_version.template
+++ b/templates/cisco_nxos_show_version.template
@@ -7,6 +7,11 @@ Value PLATFORM (\w+)
 Start
   ^\s+(NXOS: version|system:\s+version)\s${OS}
   ^\s+(NXOS|kickstart) image file is:\s${BOOT_IMAGE}
+  ^\s+cisco\s+${PLATFORM}\s+[cC]hassis
+  ^Kernel uptime is\s${UPTIME}
+  ^\s+Reason:\s${LAST_REBOOT_REASON} -> Record
+  ^\s+(NXOS: version|system:\s+version)\s${OS}
+  ^\s+(NXOS|kickstart) image file is:\s${BOOT_IMAGE}
   ^\s+cisco Nexus\d+\s${PLATFORM}
   ^Kernel uptime is\s${UPTIME}
   ^\s+Reason:\s${LAST_REBOOT_REASON} -> Record

--- a/templates/cisco_nxos_show_version.template
+++ b/templates/cisco_nxos_show_version.template
@@ -5,13 +5,9 @@ Value BOOT_IMAGE (.*)
 Value PLATFORM (\w+)
 
 Start
-  ^\s+(NXOS: version|system:\s+version)\s${OS}
-  ^\s+(NXOS|kickstart) image file is:\s${BOOT_IMAGE}
+  ^\s+(NXOS: version|system:\s+version)\s+${OS}\s*$$
+  ^\s+(NXOS|kickstart)\s+image\s+file\s+is:\s+${BOOT_IMAGE}\s*$$
   ^\s+cisco\s+${PLATFORM}\s+[cC]hassis
-  ^Kernel uptime is\s${UPTIME}
-  ^\s+Reason:\s${LAST_REBOOT_REASON} -> Record
-  ^\s+(NXOS: version|system:\s+version)\s${OS}
-  ^\s+(NXOS|kickstart) image file is:\s${BOOT_IMAGE}
-  ^\s+cisco Nexus\d+\s${PLATFORM}
-  ^Kernel uptime is\s${UPTIME}
+  ^\s+cisco\s+Nexus\d+\s+${PLATFORM}
+  ^Kernel\s+uptime\s+is\s+${UPTIME}
   ^\s+Reason:\s${LAST_REBOOT_REASON} -> Record


### PR DESCRIPTION
The current version will not match 5ks platforms. I made a change to support the old 5ks to match the platform.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT
<!--- Name of the template, os and command  -->
 cisco_nxos_show_version 
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
Make a more specific rule on top to match 5ks platform
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Just the platform messages:
ok: [n9k02.doubleverify.prod] => {
    "msg": "C9504"
}
ok: [10.30.153.126] => {
    "msg": "C92160YC"
}
ok: [n9k01.doubleverify.prod] => {
    "msg": "C9504"
}
ok: [10.30.153.9] => {
    "msg": "C9372PX"
}
ok: [10.30.153.127] => {
    "msg": "C92160YC"
}
ok: [10.30.153.11] => {
    "msg": "C9372PX"
}
ok: [10.30.153.15] => {
    "msg": "Chassis"
}
ok: [10.30.153.16] => {
    "msg": "Chassis"
}
ok: [10.30.151.211] => {
    "msg": "Chassis"
}
ok: [10.30.151.212] => {
    "msg": "Chassis"
}

After:
ok: [n9k01.doubleverify.prod] => {
    "msg": "C9504"
}
ok: [10.30.153.127] => {
    "msg": "C92160YC"
}
ok: [n9k02.doubleverify.prod] => {
    "msg": "C9504"
}
ok: [10.30.153.9] => {
    "msg": "C9372PX"
}
ok: [10.30.153.126] => {
    "msg": "C92160YC"
}
ok: [10.30.153.11] => {
    "msg": "C9372PX"
}
ok: [10.30.153.15] => {
    "msg": "Nexus5548"
}
ok: [10.30.153.16] => {
    "msg": "Nexus5548"
}
ok: [10.30.151.211] => {
    "msg": "Nexus5020"
}
ok: [10.30.151.212] => {
    "msg": "Nexus5020"
}

```
