### PR TITLE
Update the file to support Cap F on output

### DIFF
--- a/templates/juniper_junos_show_interfaces.template
+++ b/templates/juniper_junos_show_interfaces.template
@@ -9,6 +9,6 @@ Start
   ^Physical\s+interface:\s+${INTERFACE},\s+${ADMIN_STATE},\s+Physical\s+link\s+is\s+${LINK_STATUS}
   ^.*ype:\s+${HARDWARE_TYPE},.*MTU:\s+${MTU}.* -> Record
   ^.*MTU:\s+${MTU}.* -> Record
-  ^.*flags -> Record
+  ^.*[fF]lags -> Record
 
 EOF


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT
juniper_junos_show_interfaces.template

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Support the matching of subinterfaces on Juniper 2200 switches. 

