### PR TITLE
Update cisco_nxos_show_lldp_neighbors.template & index file

### DIFF
--- a/templates/cisco_nxos_show_lldp_neighbors.template
+++ b/templates/cisco_nxos_show_lldp_neighbors.template
@@ -6,7 +6,6 @@ Start
   ^Device.*ID -> LLDP
 
 LLDP
-  ^${NEIGHBOR}\s+${LOCAL_INTERFACE}\s+\d+\s+[\w+\s]+\S+\s+${NEIGHBOR_INTERFACE}$$ -> Record
-  ^\S+$$ -> Continue.Record
   ^${NEIGHBOR}$$
-  ^\s+${LOCAL_INTERFACE}\s+\d+\s+[\w+\s]+\S+\s+${NEIGHBOR_INTERFACE}$$ -> Record
+  ^${NEIGHBOR}\s+${LOCAL_INTERFACE}\s+\d+\s+(\w+?\s)+\s+${NEIGHBOR_INTERFACE} -> Record
+  ^\s+${LOCAL_INTERFACE}\s+\d+\s+(\w+?\s)+\s+${NEIGHBOR_INTERFACE} -> Record

--- a/templates/index
+++ b/templates/index
@@ -42,10 +42,10 @@ arista_eos_show_vlan.template, .*, arista_eos, sh[[ow]] vl[[an]]
 aruba_os_show_ipv6_interface_brief.template, .*, aruba_os, sh[[ow]] ipv6 in[[terface]] b[[rief]]
 aruba_os_show_ip_interface_brief.template, .*, aruba_os, sh[[ow]] ip in[[terface]] b[[rief]]
 
-avaya_ers_show_vlan.template, .*, avaya_ers, sh[[ow]] vlan
-avaya_ers_show_sys-info.template, .*, avaya_ers, sh[[ow]] sys-[[info]]
-avaya_ers_show_interface_name.template, .*, avaya_ers, sh[[ow]] in[[terfaces]] n[[ame]]
 avaya_ers_show_mac-address-table.template, .*, avaya_ers, sh[[ow]] mac-a[[ddress-table]]
+avaya_ers_show_interface_name.template, .*, avaya_ers, sh[[ow]] in[[terfaces]] n[[ame]]
+avaya_ers_show_sys-info.template, .*, avaya_ers, sh[[ow]] sys-[[info]]
+avaya_ers_show_vlan.template, .*, avaya_ers, sh[[ow]] vlan
 
 brocade_fastiron_show_lldp_neighbors_detail.template, .*, brocade_fastiron, sh[[ow]] ll[[dp]] n[[eighbors]] d[[etail]]
 brocade_fastiron_show_interfaces_brief.template, .*, brocade_fastiron, sh[[ow]] in[[terfaces]] b[[rief]]

--- a/tests/cisco_nxos/show_lldp_neighbors/cisco_nxos_show_lldp_neighbors.parsed
+++ b/tests/cisco_nxos/show_lldp_neighbors/cisco_nxos_show_lldp_neighbors.parsed
@@ -1,23 +1,15 @@
 ---
 parsed_sample:
-- neighbor: "PERIMETER.cisco.com"
-  local_interface: "mgmt0"
-  neighbor_interface: "Fa1/0/10"
-
-- neighbor: "n9k1.cisconxapi.com"
+- neighbor: "nx-osv9000-3-long-name.com"
   local_interface: "Eth1/1"
   neighbor_interface: "Ethernet1/1"
 
-- neighbor: "n9k1.cisconxapi.com"
+- neighbor: "nx-osv9000-4-extremely-long-name"
   local_interface: "Eth1/2"
-  neighbor_interface: "Ethernet1/2"
+  neighbor_interface: "Ethernet1/1"
 
-- neighbor: "n9k1.cisconxapi.com"
-  local_interface: "Eth1/2"
+- neighbor: "nx-osv9000-2"
+  local_interface: "Eth1/3"
   neighbor_interface: "Ethernet1/3"
-
-- neighbor: "neighbor.with.long.hostname.n9k2.cisconxapi.com"
-  local_interface: "Eth1/21"
-  neighbor_interface: "Te5/1"
 
 

--- a/tests/cisco_nxos/show_lldp_neighbors/cisco_nxos_show_lldp_neighbors.raw
+++ b/tests/cisco_nxos/show_lldp_neighbors/cisco_nxos_show_lldp_neighbors.raw
@@ -1,12 +1,10 @@
 Capability codes:
   (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
   (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other
-Device ID            Local Intf      Hold-time  Capability  Port ID
-PERIMETER.cisco.com  mgmt0           120        BR          Fa1/0/10
-n9k1.cisconxapi.com  Eth1/1          120        BR          Ethernet1/1
-n9k1.cisconxapi.com  Eth1/2          120        BR          Ethernet1/2
-n9k1.cisconxapi.com  Eth1/2          120        BR T        Ethernet1/3
-neighbor.with.long.hostname.n9k2.cisconxapi.com
-		     Eth1/21         120        BR          Te5/1
-Total entries displayed: 4
-
+Device ID            Local Intf      Hold-time  Capability  Port ID  
+nx-osv9000-3-long-name.com
+                     Eth1/1          120        BR          Ethernet1/1   
+nx-osv9000-4-extremely-long-name
+                     Eth1/2          120        BR          Ethernet1/1   
+nx-osv9000-2         Eth1/3          120        BR          Ethernet1/3   
+Total entries displayed: 3


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request


##### COMPONENT
<!--- Name of the template, os and command  -->
 cisco_nxos_show_lldp_neighbors.template, NXOS, show lldp neighbors

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The existing template is broken. Tested against 2 input raw files:

### Input 1:

```
Capability codes:
  (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
  (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other
Device ID            Local Intf      Hold-time  Capability  Port ID  
nx-osv9000-3         Eth1/1          120        BR          Ethernet1/1   
nx-osv9000-4         Eth1/2          120        BR          Ethernet1/1   
nx-osv9000-2         Eth1/3          120        BR          Ethernet1/3   
Total entries displayed: 3
```

#### Input 2:

```
Capability codes:
  (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
  (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other
Device ID            Local Intf      Hold-time  Capability  Port ID  
nx-osv9000-3-long-name.com
                     Eth1/1          120        BR          Ethernet1/1   
nx-osv9000-4-extremely-long-name
                     Eth1/2          120        BR          Ethernet1/1   
nx-osv9000-2         Eth1/3          120        BR          Ethernet1/3   
Total entries displayed: 3
```

The proposed template works with both:

#### Output 1
```
FSM Table:
['NEIGHBOR', 'LOCAL_INTERFACE', 'NEIGHBOR_INTERFACE']
['nx-osv9000-3', 'Eth1/1', 'Ethernet1/1']
['nx-osv9000-4', 'Eth1/2', 'Ethernet1/1']
['nx-osv9000-2', 'Eth1/3', 'Ethernet1/3']
```
#### Output 2
```
FSM Table:
['NEIGHBOR', 'LOCAL_INTERFACE', 'NEIGHBOR_INTERFACE']
['nx-osv9000-3-long-name.com', 'Eth1/1', 'Ethernet1/1']
['nx-osv9000-4-extremely-long-name', 'Eth1/2', 'Ethernet1/1']
['nx-osv9000-2', 'Eth1/3', 'Ethernet1/3']
```
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

#### Before:
```
(venv2) ~/P/misc ❯❯❯ python textfsm/textfsm.py ntc-original/templates/cisco_nxos_show_lldp_neighbors.template nxos_raw_file.raw
FSM Template:
Value NEIGHBOR (\S+)
Value LOCAL_INTERFACE (\S+)
Value NEIGHBOR_INTERFACE (\S+)

Start
  ^Device.*ID -> LLDP

LLDP
  ^${NEIGHBOR}\s+${LOCAL_INTERFACE}\s+\d+\s+[\w+\s]+\S+\s+${NEIGHBOR_INTERFACE}$$ -> Record
  ^\S+$$ -> Continue.Record
  ^${NEIGHBOR}$$
  ^\s+${LOCAL_INTERFACE}\s+\d+\s+[\w+\s]+\S+\s+${NEIGHBOR_INTERFACE}$$ -> Record


FSM Table:
['NEIGHBOR', 'LOCAL_INTERFACE', 'NEIGHBOR_INTERFACE']
['nx-osv9000-3-long-name.com', '', '']
['nx-osv9000-4-extremely-long-name', '', '']
```
#### After
```
(venv2) ~/P/misc ❯❯❯ python textfsm/textfsm.py ntc-templates/templates/cisco_nxos_show_lldp_neighbors.template nxos_raw_file.raw
FSM Template:
Value NEIGHBOR (\S+)
Value LOCAL_INTERFACE (\S+)
Value NEIGHBOR_INTERFACE (\S+)

Start
  ^Device.*ID -> LLDP

LLDP
  ^${NEIGHBOR}$$
  ^${NEIGHBOR}\s+${LOCAL_INTERFACE}\s+\d+\s+(\w+?\s)+\s+${NEIGHBOR_INTERFACE} -> Record
  ^\s+${LOCAL_INTERFACE}\s+\d+\s+(\w+?\s)+\s+${NEIGHBOR_INTERFACE} -> Record


FSM Table:
['NEIGHBOR', 'LOCAL_INTERFACE', 'NEIGHBOR_INTERFACE']
['nx-osv9000-3-long-name.com', 'Eth1/1', 'Ethernet1/1']
['nx-osv9000-4-extremely-long-name', 'Eth1/2', 'Ethernet1/1']
['nx-osv9000-2', 'Eth1/3', 'Ethernet1/3']

```
