### PR TITLE
Handle out-of-bound case where IOS splits lines

### DIFF
--- a/templates/cisco_ios_show_cdp_neighbors.template
+++ b/templates/cisco_ios_show_cdp_neighbors.template
@@ -1,15 +1,15 @@
 Value NEIGHBOR (\S+)
 Value LOCAL_INTERFACE (\S+\s\S+)
-Value CAPABILITY (([A-Z]\s)*?[A-Z]??)
+Value CAPABILITY (([A-Z]\s)*?[A-Z]?)
 Value PLATFORM (\S+\s\S+|\S+)
 Value NEIGHBOR_INTERFACE (\S+\s\S+)
-·
+
 Start
   ^Device.*ID -> CDP
-·
+
 CDP
+  ^${NEIGHBOR}$$ -> CDP2
   ^${NEIGHBOR}\s+${LOCAL_INTERFACE}\s+\d+\s+${CAPABILITY}\s\s+${PLATFORM}\s+${NEIGHBOR_INTERFACE} -> Record
-  ^${NEIGHBOR} -> CDP2
-·
+
 CDP2
   ^\s+${LOCAL_INTERFACE}\s+\d+\s+${CAPABILITY}\s\s+${PLATFORM}\s+${NEIGHBOR_INTERFACE} -> Record CDP

--- a/templates/cisco_ios_show_cdp_neighbors.template
+++ b/templates/cisco_ios_show_cdp_neighbors.template
@@ -1,11 +1,15 @@
 Value NEIGHBOR (\S+)
 Value LOCAL_INTERFACE (\S+\s\S+)
-Value CAPABILITY ([\w\s]+?)
+Value CAPABILITY (([A-Z]\s)*[A-Z]?)
 Value PLATFORM (\S+\s\S+|\S+)
 Value NEIGHBOR_INTERFACE (\S+\s\S+)
-
+·
 Start
   ^Device.*ID -> CDP
-
+·
 CDP
-  ^${NEIGHBOR}\s+${LOCAL_INTERFACE}\s+\d+\s+${CAPABILITY}\s{2}\s+${PLATFORM}\s+${NEIGHBOR_INTERFACE} -> Record
+  ^${NEIGHBOR}\s+${LOCAL_INTERFACE}\s+\d+\s+${CAPABILITY}\s\s+${PLATFORM}\s+${NEIGHBOR_INTERFACE} -> Record
+  ^${NEIGHBOR} -> CDP2
+·
+CDP2
+  ^\s+${LOCAL_INTERFACE}\s+\d+\s+${CAPABILITY}\s\s+${PLATFORM}\s+${NEIGHBOR_INTERFACE} -> Record CDP

--- a/templates/cisco_ios_show_cdp_neighbors.template
+++ b/templates/cisco_ios_show_cdp_neighbors.template
@@ -1,6 +1,6 @@
 Value NEIGHBOR (\S+)
 Value LOCAL_INTERFACE (\S+\s\S+)
-Value CAPABILITY (([A-Z]\s)*[A-Z]?)
+Value CAPABILITY (([A-Z]\s)*?[A-Z]??)
 Value PLATFORM (\S+\s\S+|\S+)
 Value NEIGHBOR_INTERFACE (\S+\s\S+)
 ·

--- a/templates/cisco_ios_show_cdp_neighbors.template
+++ b/templates/cisco_ios_show_cdp_neighbors.template
@@ -1,6 +1,6 @@
 Value NEIGHBOR (\S+)
 Value LOCAL_INTERFACE (\S+\s\S+)
-Value CAPABILITY (([A-Z]\s)*?[A-Z]?)
+Value CAPABILITY (([A-Za-z]\s)*?[A-Za-z]?)
 Value PLATFORM (\S+\s\S+|\S+)
 Value NEIGHBOR_INTERFACE (\S+\s\S+)
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
templates/cisco_ios_show_cdp_neighbors.template

##### SUMMARY
So the output we got was this, which was not handled with the current textfsm template.
```
Capability Codes: R - Router, T - Trans Bridge, B - Source Route Bridge
                  S - Switch, H - Host, I - IGMP, r - Repeater, P - Phone,
                  D - Remote, C - CVTA, M - Two-port Mac Relay
Device ID        Local Intrfce     Holdtme    Capability  Platform  Port ID
switch01.example.com
                 Ten 2/2/8         179             R S I  WS-C4510R Ten 6/1
switch02.example.com
                 Ten 1/2/8         169             R S I  WS-C4510R Ten 5/1
```