### PR TITLE
Fix standard regular expressions to skip headers

### DIFF
--- a/templates/cisco_ios_show_mac-address-table.template
+++ b/templates/cisco_ios_show_mac-address-table.template
@@ -1,6 +1,6 @@
-Value DESTINATION_ADDRESS (\w+.\w+.\w+)
+Value DESTINATION_ADDRESS ([0-9a-f]{4}\.[0-9a-f]{4}\.[0-9a-f]{4})
 Value TYPE (\w+)
-Value VLAN (\w+)
+Value VLAN (\d{1,4})
 Value DESTINATION_PORT (\S+)
 
 Start
@@ -20,4 +20,4 @@ TYPE3
 
 TYPE4
   ^\s+${VLAN}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+${DESTINATION_PORT} -> Record
-
+  


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
templates/cisco_ios_show_mac-address-table.template

##### SUMMARY
So we had an issue with the below output as it would repeat the headers as part of the returned values.

The solution is to fix the regular expressions, as they would match too broad. For instance the expression `(\w+.\w+.\w+)` would match things like `A B C` or `Nightmare|On|ElmStreet`. Dots should be matched using `\.` and for a mac-address the regexp could be much more strict.

Same for vlan numbers we know it's between 1 and 4 digits.

```
Legend: * - primary entry
        age - seconds since last seen
        n/a - not available
        S - secure entry
        R - router's gateway mac address entry
        D - Duplicate mac address entry

Displaying entries from DFC switch [1] linecard [1]:

     vlan   mac address    type   learn    age                 ports
----+----+---------------+-------+-----+----------+-----------------------------
      420 009e.1ead.eadd  dynamic  Yes      160     Po140


Displaying entries from DFC switch [1] linecard [2]:

     vlan   mac address    type   learn    age                 ports
----+----+---------------+-------+-----+----------+-----------------------------
*     420 009e.1ead.eadd  dynamic  Yes        5     Po140


Displaying entries from DFC switch [1] linecard [3]:

     vlan   mac address    type   learn    age                 ports
----+----+---------------+-------+-----+----------+-----------------------------
      420 009e.1ead.eadd  dynamic  Yes       45     Po140


Displaying entries from DFC switch [1] linecard [4]:

     vlan   mac address    type   learn    age                 ports
----+----+---------------+-------+-----+----------+-----------------------------
      420 009e.1ead.eadd  dynamic  Yes      175     Po140


Displaying entries from active supervisor:

     vlan   mac address    type   learn    age                 ports
----+----+---------------+-------+-----+----------+-----------------------------
      420 009e.1ead.eadd  dynamic  Yes       65     Po140


Displaying entries from DFC switch [2] linecard [1]:

     vlan   mac address    type   learn    age                 ports
----+----+---------------+-------+-----+----------+-----------------------------
      420 009e.1ead.eadd  dynamic  Yes      140     Po140


Displaying entries from DFC switch [2] linecard [2]:

     vlan   mac address    type   learn    age                 ports
----+----+---------------+-------+-----+----------+-----------------------------
*     420 009e.1ead.eadd  dynamic  Yes        5     Po140


Displaying entries from DFC switch [2] linecard [3]:

     vlan   mac address    type   learn    age                 ports
----+----+---------------+-------+-----+----------+-----------------------------
      420 009e.1ead.eadd  dynamic  Yes      120     Po140


Displaying entries from DFC switch [2] linecard [4]:

     vlan   mac address    type   learn    age                 ports
----+----+---------------+-------+-----+----------+-----------------------------
      420 009e.1ead.eadd  dynamic  Yes      180     Po140


Displaying entries from standby supervisor:

     vlan   mac address    type   learn    age                 ports
----+----+---------------+-------+-----+----------+-----------------------------
      420 009e.1ead.eadd  dynamic  Yes      115     Po140
```