### PR TITLE
Fix for VLANs with 4 digits

### DIFF
--- a/templates/cisco_ios_show_mac-address-table.template
+++ b/templates/cisco_ios_show_mac-address-table.template
@@ -16,8 +16,7 @@ TYPE2
   ^[\*|\s]\s+${VLAN}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+${DESTINATION_PORT} -> Record
 
 TYPE3
-  ^\s+${VLAN}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+${DESTINATION_PORT} -> Record
+  ^\s*${VLAN}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+${DESTINATION_PORT} -> Record
 
 TYPE4
-  ^\s+${VLAN}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+${DESTINATION_PORT} -> Record
-
+  ^\s*${VLAN}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+${DESTINATION_PORT} -> Record

--- a/tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table3.parsed
+++ b/tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table3.parsed
@@ -35,10 +35,10 @@ parsed_sample:
 - destination_address: 30a3.30a3.a1c9
   destination_port: Port-channel1
   type: dynamic
-  vlan: '99'
+  vlan: '999'
 
 - destination_address: 30a3.30a3.a1ca
   destination_port: Port-channel1
   type: dynamic
-  vlan: '99'
+  vlan: '1999'
 

--- a/tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table3.raw
+++ b/tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table3.raw
@@ -7,5 +7,5 @@ Unicast Entries
   99      30a3.30a3.a1c6   dynamic ip,ipx,assigned,other Port-channel1
   99      30a3.30a3.a1c7   dynamic ip,ipx,assigned,other Port-channel1
   99      30a3.30a3.a1c8   dynamic ip,ipx,assigned,other Port-channel1
-  99      30a3.30a3.a1c9   dynamic ip,ipx,assigned,other Port-channel1
-  99      30a3.30a3.a1ca   dynamic ip,ipx,assigned,other Port-channel1
+ 999      30a3.30a3.a1c9   dynamic ip,ipx,assigned,other Port-channel1
+1999      30a3.30a3.a1ca   dynamic ip,ipx,assigned,other Port-channel1

--- a/tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table4.parsed
+++ b/tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table4.parsed
@@ -75,10 +75,10 @@ parsed_sample:
 - destination_address: 30a3.30a3.a1cc
   destination_port: Vl99
   type: STATIC
-  vlan: '99'
+  vlan: '999'
 
 - destination_address: 30a3.30a3.a1cd
   destination_port: Po6
   type: DYNAMIC
-  vlan: '99'
+  vlan: '1999'
 

--- a/tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table4.raw
+++ b/tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table4.raw
@@ -17,6 +17,6 @@ Vlan    Mac Address       Type        Ports
   99    30a3.30a3.a1c9    DYNAMIC     Te1/1/3
   99    30a3.30a3.a1ca    DYNAMIC     Te1/1/3
   99    30a3.30a3.a1cb    DYNAMIC     Te1/1/3
-  99    30a3.30a3.a1cc    STATIC      Vl99
-  99    30a3.30a3.a1cd    DYNAMIC     Po6
+ 999    30a3.30a3.a1cc    STATIC      Vl99
+1999    30a3.30a3.a1cd    DYNAMIC     Po6
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
cisco_ios_show_mac-address-table

##### SUMMARY
This is fix for show mac address table on Cisco IOS. In the existing template it is looking for one or more spaces in front of the VLAN ID. But VLANs with 4 digits don't have any space before them.
