### PR TITLE
CISCO_IOS_SHOW_VLAN: Add support for capturing interfaces associated …

### DIFF
--- a/templates/cisco_ios_show_vlan.template
+++ b/templates/cisco_ios_show_vlan.template
@@ -34,8 +34,8 @@ VLANS
   ^\s+(?:\S+\s+){9}${INTERFACES},* -> Continue
   ^\s+(?:\S+\s+){10}${INTERFACES},* -> Continue
   ^\s+(?:\S+\s+){11}${INTERFACES} -> Continue
-  ^\d+ -> VLANS
-  ^\s+ -> VLANS
+  ^\d+
+  ^\s+
   ^-+
   ^\S+\s+[TtYyPpEe]{4} -> Done
   ^.+ -> Error

--- a/templates/cisco_ios_show_vlan.template
+++ b/templates/cisco_ios_show_vlan.template
@@ -1,9 +1,44 @@
-Value VLAN_ID (\d+)
+Value Required VLAN_ID (\d+)
 Value NAME (\S+)
 Value STATUS (\S+)
+Value List INTERFACES ([\w\./]+)
 
 Start
-  ^VLAN\s+Type -> Done
-  ^${VLAN_ID}\s+${NAME}\s+${STATUS} -> Record
+  ^$$
+  ^\w+\s+[NnAaMmEe]{4}.*$$ -> VLANS
+
+VLANS
+  ^\d+ -> Continue.Record
+  ^${VLAN_ID}\s+${NAME}\s+${STATUS}\s*$$
+  ^${VLAN_ID}\s+${NAME}\s+${STATUS}\s+${INTERFACES},* -> Continue
+  ^\d+\s+(?:\S+\s+){3}${INTERFACES},* -> Continue
+  ^\d+\s+(?:\S+\s+){4}${INTERFACES},* -> Continue
+  ^\d+\s+(?:\S+\s+){5}${INTERFACES},* -> Continue
+  ^\d+\s+(?:\S+\s+){6}${INTERFACES},* -> Continue
+  ^\d+\s+(?:\S+\s+){7}${INTERFACES},* -> Continue
+  ^\d+\s+(?:\S+\s+){8}${INTERFACES},* -> Continue
+  ^\d+\s+(?:\S+\s+){9}${INTERFACES},* -> Continue
+  ^\d+\s+(?:\S+\s+){10}${INTERFACES},* -> Continue
+  ^\d+\s+(?:\S+\s+){11}${INTERFACES},* -> Continue
+  ^\d+\s+(?:\S+\s+){12}${INTERFACES},* -> Continue
+  ^\d+\s+(?:\S+\s+){13}${INTERFACES} -> Continue
+  ^\s+${INTERFACES},* -> Continue
+  ^\s+\S+\s+${INTERFACES},* -> Continue
+  ^\s+(?:\S+\s+){2}${INTERFACES},* -> Continue
+  ^\s+(?:\S+\s+){3}${INTERFACES},* -> Continue
+  ^\s+(?:\S+\s+){4}${INTERFACES},* -> Continue
+  ^\s+(?:\S+\s+){5}${INTERFACES},* -> Continue
+  ^\s+(?:\S+\s+){6}${INTERFACES},* -> Continue
+  ^\s+(?:\S+\s+){7}${INTERFACES},* -> Continue
+  ^\s+(?:\S+\s+){8}${INTERFACES},* -> Continue
+  ^\s+(?:\S+\s+){9}${INTERFACES},* -> Continue
+  ^\s+(?:\S+\s+){10}${INTERFACES},* -> Continue
+  ^\s+(?:\S+\s+){11}${INTERFACES} -> Continue
+  ^\d+ -> VLANS
+  ^\s+ -> VLANS
+  ^-+
+  ^\S+\s+[TtYyPpEe]{4} -> Done
+  ^.+ -> Error
 
 Done
+  ^.*

--- a/tests/cisco_ios/show_vlan/cisco_ios_show_vlan.parsed
+++ b/tests/cisco_ios/show_vlan/cisco_ios_show_vlan.parsed
@@ -4,32 +4,39 @@ parsed_sample:
  - vlan_id: '1'
    name: 'default'
    status: 'active'
+   interfaces: ['Gi0/1']
 
  - vlan_id: '10'
    name: 'Management'
    status: 'active'
+   interfaces: []
 
  - vlan_id: '50'
    name: 'VLan50'
    status: 'active'
+   interfaces: ['Fa0/1', 'Fa0/2', 'Fa0/3', 'Fa0/4', 'Fa0/5', 'Fa0/6', 'Fa0/7', 'Fa0/8', 'Fa0/9', 'Fa0/10', 'Fa0/11', 'Fa0/12']
 
  - vlan_id: '60'
    name: 'VLan60'
    status: 'active'
+   interfaces: ['Fa0/13', 'Fa0/14', 'Fa0/15', 'Fa0/16', 'Fa0/17', 'Fa0/18', 'Fa0/19', 'Fa0/20', 'Fa0/21', 'Fa0/22', 'Fa0/23', 'Fa0/24']
 
  - vlan_id: '1002'
    name: 'fddi-default'
    status: 'act/unsup'
+   interfaces: []
 
  - vlan_id: '1003'
    name: 'token-ring-default'
    status: 'act/unsup'
+   interfaces: []
 
  - vlan_id: '1004'
    name: 'fddinet-default'
    status: 'act/unsup'
+   interfaces: []
 
  - vlan_id: '1005'
    name: 'trnet-default'
    status: 'act/unsup'
-
+   interfaces: []


### PR DESCRIPTION
…with each vlan

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_vlan
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add support for capturing interfaces associated with each vlan
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #175 
<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
