### PR TITLE
Move Record to Interface opening line to ensure each unaccounted for …

### DIFF
--- a/templates/cisco_nxos_show_interface.template
+++ b/templates/cisco_nxos_show_interface.template
@@ -14,6 +14,7 @@ Value DELAY (\d+\s+\w+)
 Value ENCAPSULATION (\w+)
 
 Start
+  ^\S+\s+is.+ -> Continue.Record
   ^${INTERFACE}\s+is\s+${LINK_STATUS},\sline\sprotocol\sis\s${ADMIN_STATE}$$
   ^${INTERFACE}\s+is\s+${LINK_STATUS}$$
   ^admin\s+state\s+is\s+${ADMIN_STATE},
@@ -23,4 +24,4 @@ Start
   ^\s+${DUPLEX}, ${SPEED}(,|$$)
   ^\s+MTU\s+${MTU}.*BW\s+${BANDWIDTH}.*DLY\s+${DELAY}
   ^\s+Encapsulation\s+${ENCAPSULATION}
-  ^\s*$$ -> Record
+  ^\s*$$


### PR DESCRIPTION
…data doesn't interfere with properly capturing each interface

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_nxos_show_interface
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
IOS template recently had issues with captureing interface data because record happened on a lline that wasn't present in all interfaces (sub-interfaces). To keep similar problem from happening with NXOS, I propose moving the Record to the opening line with Required field.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
