### PR TITLE
add alcatel AOS6 template (tested on OS6250/6450)

### DIFF
--- a/templates/alcatel_aos_show_vlan.template
+++ b/templates/alcatel_aos_show_vlan.template
@@ -12,3 +12,7 @@ Value NAME ((\S+\s*)+\S+)
 
 Start
   ^\s*${VLAN}\s+${TYPE}\s+${ADMIN}\s+${OPER}\s+${STREE1X1}\s+${STREEFLAT}\s+${AUTH}\s+${IP}\s+${MBLETAG}\s+${SRCLRN}\s+${NAME}\s+ -> Record
+  ^\s*stree\s+mble\s+src
+  ^\s*vlan\s+type\s+admin\s+oper\s+1x1\s+flat\s+auth\s+ip\s+tag\s+lrn\s+name
+  ^-----\+-----\+------\+------\+------\+------\+----\+-----\+-----\+------\+----------
+  ^.*$$ -> Error

--- a/templates/alcatel_aos_show_vlan.template
+++ b/templates/alcatel_aos_show_vlan.template
@@ -1,0 +1,14 @@
+Value VLAN (\d+)
+Value TYPE (std|vstk|gvrp|ipmv)
+Value ADMIN (on|off)
+Value OPER (on|off)
+Value STREE1X1 (on|off)
+Value STREEFLAT (on|off)
+Value AUTH (on|off)
+Value IP (on|off)
+Value MBLETAG (on|off)
+Value SRCLRN (on|off)
+Value NAME ((\S+\s*)+\S+)
+
+Start
+  ^\s*${VLAN}\s+${TYPE}\s+${ADMIN}\s+${OPER}\s+${STREE1X1}\s+${STREEFLAT}\s+${AUTH}\s+${IP}\s+${MBLETAG}\s+${SRCLRN}\s+${NAME}\s+ -> Record

--- a/templates/index
+++ b/templates/index
@@ -12,6 +12,8 @@
 #
 Template, Hostname, Platform, Command
 
+alcatel_aos_show_vlan.template, .*, alcatel_aos, show vlan
+
 alcatel_sros_show_router_bgp_routes_vpn-ipv4.template, .*, alcatel_sros, sh[[ow]] router bgp rou[[tes]] vpn-ipv4
 alcatel_sros_show_service_id_base.template, .*, alcatel_sros, sh[[ow]] serv[[ice]] id ba[[se]]
 alcatel_sros_oam_mac-ping.template, .*, alcatel_sros, oam mac-pi[[ng]]

--- a/tests/alcatel_aos/show_vlan/alcatel_aos_show_vlan.parsed
+++ b/tests/alcatel_aos/show_vlan/alcatel_aos_show_vlan.parsed
@@ -1,0 +1,50 @@
+---
+parsed_sample:
+
+ - admin: "on", 
+   auth: "off", 
+   ip: "off", 
+   mbletag: "off", 
+   name: "VLAN 1", 
+   oper: "on", 
+   srclrn: "on", 
+   stree1x1: "on", 
+   streeflat: "on", 
+   type: "std", 
+   vlan: "1"
+
+ - admin: "on", 
+   auth: "off", 
+   ip: "off", 
+   mbletag: "off", 
+   name: "name with spaces", 
+   oper: "off", 
+   srclrn: "on", 
+   stree1x1: "on", 
+   streeflat: "on", 
+   type: "std", 
+   vlan: "10"
+
+ - admin: "on", 
+   auth: "off", 
+   ip: "on", 
+   mbletag: "off", 
+   name: "name-with-dashes", 
+   oper: "on", 
+   srclrn: "on", 
+   stree1x1: "on", 
+   streeflat: "on", 
+   type: "std", 
+   vlan: "100"
+
+-  admin: "on", 
+   auth: "off", 
+   ip: "on", 
+   mbletag: "off", 
+   name: "namewithoutnothing", 
+   oper: "on", 
+   srclrn: "on", 
+   stree1x1: "on", 
+   streeflat: "on", 
+   type: "std", 
+   vlan: "1000"

--- a/tests/alcatel_aos/show_vlan/alcatel_aos_show_vlan.parsed
+++ b/tests/alcatel_aos/show_vlan/alcatel_aos_show_vlan.parsed
@@ -46,5 +46,5 @@ parsed_sample:
    srclrn: 'on' 
    stree1x1: 'on' 
    streeflat: 'on' 
-   type: 'std' 
+   type: 'gvrp' 
    vlan: '1000'

--- a/tests/alcatel_aos/show_vlan/alcatel_aos_show_vlan.parsed
+++ b/tests/alcatel_aos/show_vlan/alcatel_aos_show_vlan.parsed
@@ -37,7 +37,7 @@ parsed_sample:
    type: 'std' 
    vlan: '100'
 
--  admin: 'on' 
+ - admin: 'on' 
    auth: 'off' 
    ip: 'on' 
    mbletag: 'off' 

--- a/tests/alcatel_aos/show_vlan/alcatel_aos_show_vlan.parsed
+++ b/tests/alcatel_aos/show_vlan/alcatel_aos_show_vlan.parsed
@@ -1,50 +1,50 @@
 ---
 parsed_sample:
 
- - admin: "on", 
-   auth: "off", 
-   ip: "off", 
-   mbletag: "off", 
-   name: "VLAN 1", 
-   oper: "on", 
-   srclrn: "on", 
-   stree1x1: "on", 
-   streeflat: "on", 
-   type: "std", 
-   vlan: "1"
+ - admin: 'on' 
+   auth: 'off' 
+   ip: 'off' 
+   mbletag: 'off' 
+   name: 'VLAN 1' 
+   oper: 'on' 
+   srclrn: 'on' 
+   stree1x1: 'on' 
+   streeflat: 'on' 
+   type: 'std' 
+   vlan: '1'
 
- - admin: "on", 
-   auth: "off", 
-   ip: "off", 
-   mbletag: "off", 
-   name: "name with spaces", 
-   oper: "off", 
-   srclrn: "on", 
-   stree1x1: "on", 
-   streeflat: "on", 
-   type: "std", 
-   vlan: "10"
+ - admin: 'on' 
+   auth: 'off' 
+   ip: 'off' 
+   mbletag: 'off' 
+   name: 'name with spaces' 
+   oper: 'off' 
+   srclrn: 'on' 
+   stree1x1: 'on' 
+   streeflat: 'on' 
+   type: 'std' 
+   vlan: '10'
 
- - admin: "on", 
-   auth: "off", 
-   ip: "on", 
-   mbletag: "off", 
-   name: "name-with-dashes", 
-   oper: "on", 
-   srclrn: "on", 
-   stree1x1: "on", 
-   streeflat: "on", 
-   type: "std", 
-   vlan: "100"
+ - admin: 'on' 
+   auth: 'off' 
+   ip: 'on' 
+   mbletag: 'off' 
+   name: 'name-with-dashes' 
+   oper: 'on' 
+   srclrn: 'on' 
+   stree1x1: 'on' 
+   streeflat: 'on' 
+   type: 'std' 
+   vlan: '100'
 
--  admin: "on", 
-   auth: "off", 
-   ip: "on", 
-   mbletag: "off", 
-   name: "namewithoutnothing", 
-   oper: "on", 
-   srclrn: "on", 
-   stree1x1: "on", 
-   streeflat: "on", 
-   type: "std", 
-   vlan: "1000"
+-  admin: 'on' 
+   auth: 'off' 
+   ip: 'on' 
+   mbletag: 'off' 
+   name: 'namewithoutnothing' 
+   oper: 'on' 
+   srclrn: 'on' 
+   stree1x1: 'on' 
+   streeflat: 'on' 
+   type: 'std' 
+   vlan: '1000'

--- a/tests/alcatel_aos/show_vlan/alcatel_aos_show_vlan.raw
+++ b/tests/alcatel_aos/show_vlan/alcatel_aos_show_vlan.raw
@@ -1,0 +1,7 @@
+                              stree                 mble   src        
+ vlan  type  admin   oper   1x1   flat   auth   ip   tag   lrn   name
+-----+-----+------+------+------+------+----+-----+-----+------+----------
+   1    std   on     on     on    on     off   off   off     on   VLAN 1                          
+  10    std   on    off     on    on     off   off   off     on   name with spaces                
+ 100    std   on     on     on    on     off    on   off     on   name-with-dashes                  
+1000    std   on     on     on    on     off    on   off     on   namewithoutnothing                  

--- a/tests/alcatel_aos/show_vlan/alcatel_aos_show_vlan.raw
+++ b/tests/alcatel_aos/show_vlan/alcatel_aos_show_vlan.raw
@@ -4,4 +4,4 @@
    1    std   on     on     on    on     off   off   off     on   VLAN 1                          
   10    std   on    off     on    on     off   off   off     on   name with spaces                
  100    std   on     on     on    on     off    on   off     on   name-with-dashes                  
-1000    std   on     on     on    on     off    on   off     on   namewithoutnothing                  
+1000   gvrp   on     on     on    on     off    on   off     on   namewithoutnothing                  


### PR DESCRIPTION
##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
Template: alcatel_aos_show_vlan
OS: Alcatel AOS6
Command: 'show vlan'

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added template for alcatel OS6x50 series switches.
Debut with "show vlan" command, extracting all fields, in particular the name of the vlan.