### PR TITLE
CISCO_IOS_SHOW_RUNNING-CONFIG_PARTITION_ROUTE-MAP: Update record stat…

### DIFF
--- a/templates/cisco_ios_show_running-config_partition_route-map.template
+++ b/templates/cisco_ios_show_running-config_partition_route-map.template
@@ -8,7 +8,7 @@ Value SET_LOCAL_PREF_VALUE (\d+)
 Value SET_PREPEND_AS_PATH (\w+.*\w+.*\w+|\w+)
 
 Start
-  ^route-map -> Continue.Clearall
+  ^route-map -> Continue.Record
   ^route-map\s+${ROUTE_MAP_NAME}\s+permit\s+${SEQUENCE}
   ^\smatch\smetric\s${MATCH_METRIC_VALUE}
   ^\sset\s+community\s+${SET_COMMUNITY_VALUE}
@@ -16,7 +16,7 @@ Start
   ^\sset\s+local-preference\s+${SET_LOCAL_PREF_VALUE}
   ^\smatch\s+community\s+${MATCH_COMMUNITY_VALUE}
   ^\sset\s+as-path\s+prepend\s+${SET_PREPEND_AS_PATH}
-  ^! -> Record
+  ^!
   # Catch all unuseful raw data
   ^(!\s*|$$|Building configuration.*|Current configuration.*|Configuration.*|end.*)
   # Error out if raw data does not match any above rules.

--- a/tests/cisco_ios/show_running-config_partition_route-map/cisco_ios_show_running-config_partition_route-map2.parsed
+++ b/tests/cisco_ios/show_running-config_partition_route-map/cisco_ios_show_running-config_partition_route-map2.parsed
@@ -1,0 +1,41 @@
+parsed_sample:
+  - match_community_value: ''
+    match_metric_value: ''
+    match_prefix_list: BGP_IN
+    route_map_name: BGP_IN
+    sequence: '100'
+    set_community_value: ''
+    set_local_pref_value: '200'
+    set_prepend_as_path: ''
+  - match_community_value: '500'
+    match_metric_value: ''
+    match_prefix_list: ''
+    route_map_name: BGP_IN
+    sequence: '110'
+    set_community_value: no-advertise
+    set_local_pref_value: ''
+    set_prepend_as_path: ''
+  - match_community_value: '11167_4000'
+    match_metric_value: ''
+    match_prefix_list: ''
+    route_map_name: BGP_IN
+    sequence: '120'
+    set_community_value: ''
+    set_local_pref_value: '200'
+    set_prepend_as_path: ''
+  - match_community_value: '4'
+    match_metric_value: ''
+    match_prefix_list: ''
+    route_map_name: BGP_OUT
+    sequence: '50'
+    set_community_value: 11167:5000 additive
+    set_local_pref_value: ''
+    set_prepend_as_path: 65005 65005 65005
+  - match_community_value: ''
+    match_metric_value: ''
+    match_prefix_list: BGP_OUT
+    route_map_name: BGP_OUT
+    sequence: '100'
+    set_community_value: 11167:5000
+    set_local_pref_value: ''
+    set_prepend_as_path: ''

--- a/tests/cisco_ios/show_running-config_partition_route-map/cisco_ios_show_running-config_partition_route-map2.raw
+++ b/tests/cisco_ios/show_running-config_partition_route-map/cisco_ios_show_running-config_partition_route-map2.raw
@@ -1,0 +1,16 @@
+route-map BGP_IN permit 100
+ match ip address prefix-list BGP_IN
+ set local-preference 200
+route-map BGP_IN permit 110
+ match community 500
+ set community no-advertise
+route-map BGP_IN permit 120
+ match community 11167_4000
+ set local-preference 200
+route-map BGP_OUT permit 50
+ match community 4
+ set as-path prepend 65005 65005 65005
+ set community 11167:5000 additive
+route-map BGP_OUT permit 100
+ match ip address prefix-list BGP_OUT
+ set community 11167:5000


### PR DESCRIPTION
…e to record each entry in the config (#232)

* Change record logic for cisco_ios_show_running-config_partition_route-map

* Add new test files to account for data that demonstrated a bug

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_running-config_partition_route-map
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When piping the command, the `!` are not returned as part of the output, so record on new route-map entried
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
