### PR TITLE
Fixed cisco_ios_show_cdp_neighbors when devices has 4+ capabilities

### DIFF
--- a/templates/cisco_ios_show_cdp_neighbors.template
+++ b/templates/cisco_ios_show_cdp_neighbors.template
@@ -1,7 +1,7 @@
 Value Required NEIGHBOR (\S+)
 Value LOCAL_INTERFACE (\S+\s\S+)
-Value CAPABILITY (\w.*?)
-Value PLATFORM (\S+\s\S+|\S+)
+Value CAPABILITY ((?:\w(?:\s(?!\s))?){0,})
+Value PLATFORM (\S{2,}\s\S{2,}|\S+)
 Value NEIGHBOR_INTERFACE (\S+\s\S+)
 
 Start
@@ -9,6 +9,6 @@ Start
 
 CDP
   ^${NEIGHBOR}$$
-  ^\s+${LOCAL_INTERFACE}\s+\d+\s+${CAPABILITY}\s{2}\s*${PLATFORM}\s+${NEIGHBOR_INTERFACE} -> Record
-  ^${NEIGHBOR}\s+${LOCAL_INTERFACE}\s+\d+\s+${CAPABILITY}\s{2}\s*${PLATFORM}\s+${NEIGHBOR_INTERFACE} -> Record
+  ^\s+${LOCAL_INTERFACE}\s+\d+\s+${CAPABILITY}\s+${PLATFORM}\s+${NEIGHBOR_INTERFACE} -> Record
+  ^${NEIGHBOR}\s+${LOCAL_INTERFACE}\s+\d+\s+${CAPABILITY}\s+${PLATFORM}\s+${NEIGHBOR_INTERFACE} -> Record
 

--- a/tests/cisco_ios/show_cdp_neighbors/cisco_ios_show_cdp_neighbors_2.parsed
+++ b/tests/cisco_ios/show_cdp_neighbors/cisco_ios_show_cdp_neighbors_2.parsed
@@ -1,0 +1,59 @@
+---
+parsed_sample:
+
+-   capability: R I
+    local_interface: Ten 1/1/3
+    neighbor: asr1002-2.some.example.com
+    neighbor_interface: Ten 0/1/0
+    platform: ASR1002-H
+-   capability: H
+    local_interface: Ten 1/0/6
+    neighbor: vWAAS3b
+    neighbor_interface: Virtual 2/0
+    platform: OE-VWAAS
+-   capability: H
+    local_interface: Ten 1/0/6
+    neighbor: vWAAS3b
+    neighbor_interface: Virtual 1/0
+    platform: OE-VWAAS
+-   capability: H
+    local_interface: Ten 1/0/7
+    neighbor: vWAAS4b
+    neighbor_interface: Virtual 2/0
+    platform: OE-VWAAS
+-   capability: H
+    local_interface: Ten 1/0/7
+    neighbor: vWAAS4b
+    neighbor_interface: Virtual 1/0
+    platform: OE-VWAAS
+-   capability: S I
+    local_interface: Gig 0/0
+    neighbor: NEXTGENLABSWT01.some.example.com
+    neighbor_interface: Gig 0/23
+    platform: WS-C3560X
+-   capability: R B S I
+    local_interface: Ten 1/0/4
+    neighbor: router01.some.example.com
+    neighbor_interface: Gig 0/0
+    platform: CISCO2911
+-   capability: R S I
+    local_interface: Ten 1/1/6
+    neighbor: 9300mgig-1.some.example.com
+    neighbor_interface: Ten 1/1/7
+    platform: C9300-24U
+-   capability: R S I
+    local_interface: Ten 1/1/7
+    neighbor: 9300mgig-1.some.example.com
+    neighbor_interface: Ten 1/1/6
+    platform: C9300-24U
+-   capability: R S I
+    local_interface: Ten 1/1/8
+    neighbor: 9500-1.some.example.com
+    neighbor_interface: Ten 2/0/36
+    platform: C9500-40X
+-   capability: R S I
+    local_interface: Ten 1/1/1
+    neighbor: 9300mgig-2.some.example.com
+    neighbor_interface: Ten 1/1/2
+    platform: C9300-24U
+

--- a/tests/cisco_ios/show_cdp_neighbors/cisco_ios_show_cdp_neighbors_2.raw
+++ b/tests/cisco_ios/show_cdp_neighbors/cisco_ios_show_cdp_neighbors_2.raw
@@ -1,0 +1,25 @@
+Capability Codes: R - Router, T - Trans Bridge, B - Source Route Bridge
+                  S - Switch, H - Host, I - IGMP, r - Repeater, P - Phone,
+                  D - Remote, C - CVTA, M - Two-port Mac Relay
+
+Device ID        Local Intrfce     Holdtme    Capability  Platform  Port ID
+asr1002-2.some.example.com
+                 Ten 1/1/3         173              R I   ASR1002-H Ten 0/1/0
+vWAAS3b          Ten 1/0/6         140               H    OE-VWAAS  Virtual 2/0
+vWAAS3b          Ten 1/0/6         140               H    OE-VWAAS  Virtual 1/0
+vWAAS4b          Ten 1/0/7         162               H    OE-VWAAS  Virtual 2/0
+vWAAS4b          Ten 1/0/7         162               H    OE-VWAAS  Virtual 1/0
+NEXTGENLABSWT01.some.example.com
+                 Gig 0/0           130              S I   WS-C3560X Gig 0/23
+router01.some.example.com
+                 Ten 1/0/4         172            R B S I CISCO2911 Gig 0/0
+9300mgig-1.some.example.com
+                 Ten 1/1/6         155             R S I  C9300-24U Ten 1/1/7
+9300mgig-1.some.example.com
+                 Ten 1/1/7         140             R S I  C9300-24U Ten 1/1/6
+9500-1.some.example.com
+                 Ten 1/1/8         170             R S I  C9500-40X Ten 2/0/36
+9300mgig-2.some.example.com
+                 Ten 1/1/1         148             R S I  C9300-24U Ten 1/1/2
+
+Total cdp entries displayed : 11


### PR DESCRIPTION
Regex previously required two spaces after capabilities, but it was found this is not always the case and some hosts were being lost from the parsed output.

Additional testfile and parsed provided.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_cdp_neighbors

##### SUMMARY
Fix for IOS CDP parsing issue @fragmentedpacket encountered and I saw the same thing in the lab.
