### PR TITLE
Eigrp top

### DIFF
--- a/templates/cisco_ios_show_ip_eigrp_topology.template
+++ b/templates/cisco_ios_show_ip_eigrp_topology.template
@@ -1,0 +1,46 @@
+Value Filldown PROCESS_ID (\d+)
+Value Filldown ROUTER_ID (\d+\.\d+\.\d+\.\d+)
+Value Required CODE (\S+)
+Value ROUTE (\d+\.\d+\.\d+\.\d+)
+Value MASK (\d+)
+Value SUCCESSORS (\d+)
+Value FD (\d+)
+Value TAG (\d+)
+Value List ADV_ROUTER (\d+\.\d+\.\d+\.\d+|\w+)
+Value List OUT_INTERFACE (\S+)
+
+Start
+  # Captures Process ID and Router ID
+  ^.+AS\(${PROCESS_ID}\)/ID\(${ROUTER_ID}\)
+  # Skips over the code line that explains what each code means
+  ^Codes:
+  # Skips over the definitions for the codes
+  ^\s+\S+\s+-\s+
+  # Matches a route and captures if ${TAG} is use for the route and then moves to Gateway section
+  ^${CODE}\s+${ROUTE}/${MASK},\s+${SUCCESSORS}\s+successors,\s+FD\s+is\s+${FD},\s+tag\s+is\s+${TAG} -> Gateway
+  # Matches a route and captures it and then moves to Gateway section
+  ^${CODE}\s+${ROUTE}/${MASK},\s+${SUCCESSORS}\s+successors,\s+FD\s+is\s+${FD} -> Gateway
+  # If it doesn't match anything above, this just acknowledges a new line
+  ^\s*$$
+  # This will throw an error if there are no matches
+  ^. -> Error
+
+Gateway
+  # This captures the advertising router and outgoing interface
+  ^\s+via\s+${ADV_ROUTER},\s+${OUT_INTERFACE}
+  # This will not capture anything but if it encounters another route, it will continue and record what it already captured
+  ^\S+\s+(?:\d+(?:\.|)){4}/\d+,\s+\d+\s+successors -> Continue.Record
+  # These are the same as above and capture the next set of routes
+  ^${CODE}\s+${ROUTE}/${MASK},\s+${SUCCESSORS}\s+successors,\s+FD\s+is\s+${FD},\s+tag\s+is\s+${TAG}
+  ^${CODE}\s+${ROUTE}/${MASK},\s+${SUCCESSORS}\s+successors,\s+FD\s+is\s+${FD}
+  # If it encounters another AS/Router ID it will continue and record what it just captured
+  ^.+AS\(\d+\)/ID -> Continue.Record
+  # If it encounters it again, it will continue, but clear all captured data other than Filldown Values
+  ^.+AS\(\d+\)/ID -> Continue.Clearall
+  # It will start the process over again if it encounters a new process ID / router id
+  ^.+AS\(${PROCESS_ID}\)/ID\(${ROUTER_ID}\)
+  ^Codes: -> Start
+  # If it doesn't match anything above, this just acknowledges a new line
+  ^\s*$$
+  # This will throw an error if there are no matches
+  ^. -> Error

--- a/templates/index
+++ b/templates/index
@@ -117,6 +117,7 @@ cisco_ios_show_mac-address-table.template, .*, cisco_ios, sh[[ow]] m[[ac-address
 cisco_ios_show_ip_ospf_database.template, .*, cisco_ios, sh[[ow]] ip ospf data[[base]]
 cisco_ios_show_ip_ospf_neighbor.template, .*, cisco_ios, sh[[ow]] ip ospf nei[[ghbor]]
 cisco_ios_show_ip_access-lists.template, .*, cisco_ios, sh[[ow]] ip acce[[ss-lists]]
+cisco_ios_show_ip_eigrp_topology.template, .*, cisco_ios, sh[[ow]] ip eigrp top[[ology]]
 cisco_ios_show_power_available.template,  .*, cisco_ios, sh[[ow]] pow[[er]] a[[vailable]]
 cisco_ios_show_ip_bgp_summary.template, .*, cisco_ios, sh[[ow]] ip bgp sum[[mary]]
 cisco_ios_show_ipv6_int_brief.template, .*, cisco_ios, sh[[ow]] ipv[[6]] i[[nterface]] b[[rief]]

--- a/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology.parsed
+++ b/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology.parsed
@@ -1,81 +1,81 @@
 ---
 parsed_sampled:
 
-- "adv_router": ['10.254.11.9', '10.254.11.33']
-  "code": "P"
-  "fd": "264448"
-  "mask": "32"
-  "out_interface": ['TenGigabitEthernet1/1', 'TenGigabitEthernet2/1']
-  "process_id": "100"
-  "route": "66.128.208.232"
-  "router_id": "10.255.11.6"
-  "successors": "2"
-  "tag": ""
+- adv_router: ['10.254.11.9', '10.254.11.33']
+  code: "P"
+  fd: "264448"
+  mask: "32"
+  out_interface: ['TenGigabitEthernet1/1', 'TenGigabitEthernet2/1']
+  process_id: "100"
+  route: "66.128.208.232"
+  router_id: "10.255.11.6"
+  successors: "2"
+  tag: ""
   
-- "adv_router": ['10.254.6.14']
-  "code": "P"
-  "fd": "1024"
-  "mask": "30"
-  "out_interface": ['Port-channel10']
-  "process_id": "100"
-  "route": "10.254.6.8"
-  "router_id": "10.255.11.6"
-  "successors": "1"
-  "tag": ""
+- adv_router: ['10.254.6.14']
+  code: "P"
+  fd: "1024"
+  mask: "30"
+  out_interface: ['Port-channel10']
+  process_id: "100"
+  route: "10.254.6.8"
+  router_id: "10.255.11.6"
+  successors: "1"
+  tag: ""
   
-- "adv_router": ['10.254.11.9', '10.254.11.33']
-  "code": "P"
-  "fd": "5632"
-  "mask": "28"
-  "out_interface": ['TenGigabitEthernet1/1', 'TenGigabitEthernet2/1']
-  "process_id": "100"
-  "route": "67.230.223.128"
-  "router_id": "10.255.11.6"
-  "successors": "2"
-  "tag": "53471"
+- adv_router: ['10.254.11.9', '10.254.11.33']
+  code: "P"
+  fd: "5632"
+  mask: "28"
+  out_interface: ['TenGigabitEthernet1/1', 'TenGigabitEthernet2/1']
+  process_id: "100"
+  route: "67.230.223.128"
+  router_id: "10.255.11.6"
+  successors: "2"
+  tag: "53471"
   
-- "adv_router": ['10.254.10.34']
-  "code": "P"
-  "fd": "130816"
-  "mask": "32"
-  "out_interface": ['GigabitEthernet9/29']
-  "process_id": "100"
-  "route": "10.255.10.5"
-  "router_id": "10.255.11.6"
-  "successors": "1"
-  "tag": ""
+- adv_router: ['10.254.10.34']
+  code: "P"
+  fd: "130816"
+  mask: "32"
+  out_interface: ['GigabitEthernet9/29']
+  process_id: "100"
+  route: "10.255.10.5"
+  router_id: "10.255.11.6"
+  successors: "1"
+  tag: ""
   
-- "adv_router": ['10.254.1.34']
-  "code": "P"
-  "fd": "128768"
-  "mask": "32"
-  "out_interface": ['Port-channel3']
-  "process_id": "100"
-  "route": "10.255.1.14"
-  "router_id": "10.255.11.6"
-  "successors": "1"
-  "tag": ""
-  
-  
-- "adv_router": ['10.254.2.22']
-  "code": "P"
-  "fd": "768"
-  "mask": "30"
-  "out_interface": ['TenGigabitEthernet3/3']
-  "process_id": "100"
-  "route": "10.254.2.12"
-  "router_id": "10.255.11.6"
-  "successors": "1"
-  "tag": ""
+- adv_router: ['10.254.1.34']
+  code: "P"
+  fd: "128768"
+  mask: "32"
+  out_interface: ['Port-channel3']
+  process_id: "100"
+  route: "10.255.1.14"
+  router_id: "10.255.11.6"
+  successors: "1"
+  tag: ""
   
   
-- "adv_router": ['10.254.56.6', '10.254.55.6', '10.254.11.33', '10.254.11.9', '10.254.52.6', '10.254.4.10', '10.254.4.14', '10.254.54.6']
-  "code": "P"
-  "fd": "128768"
-  "mask": "32"
-  "out_interface": ['TenGigabitEthernet1/4', 'TenGigabitEthernet1/6', 'TenGigabitEthernet2/1', 'TenGigabitEthernet1/1', 'TenGigabitEthernet1/5', 'TenGigabitEthernet4/4', 'TenGigabitEthernet4/5', 'TenGigabitEthernet1/3']
-  "process_id": "100"
-  "route": "10.255.11.4"
-  "router_id": "10.255.11.6"
-  "successors": "4"
-  "tag": ""
+- adv_router: ['10.254.2.22']
+  code: "P"
+  fd: "768"
+  mask: "30"
+  out_interface: ['TenGigabitEthernet3/3']
+  process_id: "100"
+  route: "10.254.2.12"
+  router_id: "10.255.11.6"
+  successors: "1"
+  tag: ""
+  
+  
+- adv_router: ['10.254.56.6', '10.254.55.6', '10.254.11.33', '10.254.11.9', '10.254.52.6', '10.254.4.10', '10.254.4.14', '10.254.54.6']
+  code: "P"
+  fd: "128768"
+  mask: "32"
+  out_interface: ['TenGigabitEthernet1/4', 'TenGigabitEthernet1/6', 'TenGigabitEthernet2/1', 'TenGigabitEthernet1/1', 'TenGigabitEthernet1/5', 'TenGigabitEthernet4/4', 'TenGigabitEthernet4/5', 'TenGigabitEthernet1/3']
+  process_id: "100"
+  route: "10.255.11.4"
+  router_id: "10.255.11.6"
+  successors: "4"
+  tag: ""

--- a/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology.parsed
+++ b/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology.parsed
@@ -1,0 +1,81 @@
+---
+parsed_sampled:
+
+- "adv_router": ['10.254.11.9', '10.254.11.33']
+  "code": "P"
+  "fd": "264448"
+  "mask": "32"
+  "out_interface": ['TenGigabitEthernet1/1', 'TenGigabitEthernet2/1']
+  "process_id": "100"
+  "route": "66.128.208.232"
+  "router_id": "10.255.11.6"
+  "successors": "2"
+  "tag": ""
+  
+- "adv_router": ['10.254.6.14']
+  "code": "P"
+  "fd": "1024"
+  "mask": "30"
+  "out_interface": ['Port-channel10']
+  "process_id": "100"
+  "route": "10.254.6.8"
+  "router_id": "10.255.11.6"
+  "successors": "1"
+  "tag": ""
+  
+- "adv_router": ['10.254.11.9', '10.254.11.33']
+  "code": "P"
+  "fd": "5632"
+  "mask": "28"
+  "out_interface": ['TenGigabitEthernet1/1', 'TenGigabitEthernet2/1']
+  "process_id": "100"
+  "route": "67.230.223.128"
+  "router_id": "10.255.11.6"
+  "successors": "2"
+  "tag": "53471"
+  
+- "adv_router": ['10.254.10.34']
+  "code": "P"
+  "fd": "130816"
+  "mask": "32"
+  "out_interface": ['GigabitEthernet9/29']
+  "process_id": "100"
+  "route": "10.255.10.5"
+  "router_id": "10.255.11.6"
+  "successors": "1"
+  "tag": ""
+  
+- "adv_router": ['10.254.1.34']
+  "code": "P"
+  "fd": "128768"
+  "mask": "32"
+  "out_interface": ['Port-channel3']
+  "process_id": "100"
+  "route": "10.255.1.14"
+  "router_id": "10.255.11.6"
+  "successors": "1"
+  "tag": ""
+  
+  
+- "adv_router": ['10.254.2.22']
+  "code": "P"
+  "fd": "768"
+  "mask": "30"
+  "out_interface": ['TenGigabitEthernet3/3']
+  "process_id": "100"
+  "route": "10.254.2.12"
+  "router_id": "10.255.11.6"
+  "successors": "1"
+  "tag": ""
+  
+  
+- "adv_router": ['10.254.56.6', '10.254.55.6', '10.254.11.33', '10.254.11.9', '10.254.52.6', '10.254.4.10', '10.254.4.14', '10.254.54.6']
+  "code": "P"
+  "fd": "128768"
+  "mask": "32"
+  "out_interface": ['TenGigabitEthernet1/4', 'TenGigabitEthernet1/6', 'TenGigabitEthernet2/1', 'TenGigabitEthernet1/1', 'TenGigabitEthernet1/5', 'TenGigabitEthernet4/4', 'TenGigabitEthernet4/5', 'TenGigabitEthernet1/3']
+  "process_id": "100"
+  "route": "10.255.11.4"
+  "router_id": "10.255.11.6"
+  "successors": "4"
+  "tag": ""

--- a/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology.parsed
+++ b/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology.parsed
@@ -1,81 +1,79 @@
 ---
-parsed_sampled:
+parsed_sample:
 
-- adv_router: ['10.254.11.9', '10.254.11.33']
+- router_id: "10.255.11.6"
   code: "P"
-  fd: "264448"
-  mask: "32"
   out_interface: ['TenGigabitEthernet1/1', 'TenGigabitEthernet2/1']
-  process_id: "100"
   route: "66.128.208.232"
-  router_id: "10.255.11.6"
-  successors: "2"
+  mask: "32"
+  adv_router: ['10.254.11.9', '10.254.11.33']
+  process_id: "100"
+  fd: "264448"
   tag: ""
-  
-- adv_router: ['10.254.6.14']
+  successors: "2"
+
+- router_id: "10.255.11.6"
   code: "P"
-  fd: "1024"
-  mask: "30"
   out_interface: ['Port-channel10']
-  process_id: "100"
   route: "10.254.6.8"
-  router_id: "10.255.11.6"
-  successors: "1"
-  tag: ""
-  
-- adv_router: ['10.254.11.9', '10.254.11.33']
-  code: "P"
-  fd: "5632"
-  mask: "28"
-  out_interface: ['TenGigabitEthernet1/1', 'TenGigabitEthernet2/1']
-  process_id: "100"
-  route: "67.230.223.128"
-  router_id: "10.255.11.6"
-  successors: "2"
-  tag: "53471"
-  
-- adv_router: ['10.254.10.34']
-  code: "P"
-  fd: "130816"
-  mask: "32"
-  out_interface: ['GigabitEthernet9/29']
-  process_id: "100"
-  route: "10.255.10.5"
-  router_id: "10.255.11.6"
-  successors: "1"
-  tag: ""
-  
-- adv_router: ['10.254.1.34']
-  code: "P"
-  fd: "128768"
-  mask: "32"
-  out_interface: ['Port-channel3']
-  process_id: "100"
-  route: "10.255.1.14"
-  router_id: "10.255.11.6"
-  successors: "1"
-  tag: ""
-  
-  
-- adv_router: ['10.254.2.22']
-  code: "P"
-  fd: "768"
   mask: "30"
-  out_interface: ['TenGigabitEthernet3/3']
+  adv_router: ['10.254.6.14']
   process_id: "100"
-  route: "10.254.2.12"
-  router_id: "10.255.11.6"
+  fd: "1024"
+  tag: ""  
   successors: "1"
-  tag: ""
-  
-  
-- adv_router: ['10.254.56.6', '10.254.55.6', '10.254.11.33', '10.254.11.9', '10.254.52.6', '10.254.4.10', '10.254.4.14', '10.254.54.6']
+
+- router_id: "10.255.11.6"
   code: "P"
-  fd: "128768"
-  mask: "32"
-  out_interface: ['TenGigabitEthernet1/4', 'TenGigabitEthernet1/6', 'TenGigabitEthernet2/1', 'TenGigabitEthernet1/1', 'TenGigabitEthernet1/5', 'TenGigabitEthernet4/4', 'TenGigabitEthernet4/5', 'TenGigabitEthernet1/3']
+  out_interface: ['TenGigabitEthernet1/1', 'TenGigabitEthernet2/1']
+  route: "67.230.223.128"
+  mask: "28"
+  adv_router: ['10.254.11.9', '10.254.11.33']
   process_id: "100"
+  fd: "5632"
+  tag: "53471"  
+  successors: "2"
+
+- router_id: "10.255.11.6"
+  code: "P"
+  out_interface: ['GigabitEthernet9/29']
+  route: "10.255.10.5"
+  mask: "32"
+  adv_router: ['10.254.10.34']
+  process_id: "100"
+  fd: "130816"
+  tag: ""  
+  successors: "1"
+
+- router_id: "10.255.11.6"
+  code: "P"
+  out_interface: ['Port-channel3']
+  route: "10.255.1.14"
+  mask: "32"
+  adv_router: ['10.254.1.34']
+  process_id: "100"
+  fd: "128768"
+  tag: ""  
+  successors: "1"
+
+- router_id: "10.255.11.6"
+  code: "P"
+  out_interface: ['TenGigabitEthernet3/3']
+  route: "10.254.2.12"
+  mask: "30"
+  adv_router: ['10.254.2.22']
+  process_id: "100"
+  fd: "768"
+  tag: ""  
+  successors: "1"
+
+- router_id: "10.255.11.6"
+  code: "P"
+  out_interface: ['TenGigabitEthernet1/4', 'TenGigabitEthernet1/6', 'TenGigabitEthernet2/1', 'TenGigabitEthernet1/1', 'TenGigabitEthernet1/5', 'TenGigabitEthernet4/4', 'TenGigabitEthernet4/5', 'TenGigabitEthernet1/3']
   route: "10.255.11.4"
-  router_id: "10.255.11.6"
+  mask: "32"
+  adv_router: ['10.254.56.6', '10.254.55.6', '10.254.11.33', '10.254.11.9', '10.254.52.6', '10.254.4.10', '10.254.4.14', '10.254.54.6']
+  process_id: "100"
+  fd: "128768"
+  tag: ""  
   successors: "4"
-  tag: ""

--- a/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology.raw
+++ b/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology.raw
@@ -1,0 +1,28 @@
+IP-EIGRP Topology Table for AS(100)/ID(10.255.11.6)
+
+Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply,
+       r - reply Status, s - sia Status
+
+P 66.128.208.232/32, 2 successors, FD is 264448
+        via 10.254.11.9, TenGigabitEthernet1/1
+        via 10.254.11.33, TenGigabitEthernet2/1
+P 10.254.6.8/30, 1 successors, FD is 1024
+        via 10.254.6.14, Port-channel10
+P 67.230.223.128/28, 2 successors, FD is 5632, tag is 53471
+        via 10.254.11.9, TenGigabitEthernet1/1
+        via 10.254.11.33, TenGigabitEthernet2/1
+P 10.255.10.5/32, 1 successors, FD is 130816
+        via 10.254.10.34, GigabitEthernet9/29
+P 10.255.1.14/32, 1 successors, FD is 128768
+        via 10.254.1.34, Port-channel3
+P 10.254.2.12/30, 1 successors, FD is 768
+        via 10.254.2.22, TenGigabitEthernet3/3
+P 10.255.11.4/32, 4 successors, FD is 128768
+        via 10.254.56.6, TenGigabitEthernet1/4
+        via 10.254.55.6, TenGigabitEthernet1/6
+        via 10.254.11.33, TenGigabitEthernet2/1
+        via 10.254.11.9, TenGigabitEthernet1/1
+        via 10.254.52.6, TenGigabitEthernet1/5
+        via 10.254.4.10, TenGigabitEthernet4/4
+        via 10.254.4.14, TenGigabitEthernet4/5
+        via 10.254.54.6, TenGigabitEthernet1/3


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding template to parse EIGRP topology information. This was useful for parsing CDP neighbor data and then correlating that to parsed EIGRP topology information to create some reports as to which neighbors are advertising which routes and will be useful for other structured data from this output.
