### PR TITLE
CISCO_IOS_SHOW_IP_BGP_SUMMARY: Add collecting ROUTER_ID and LOCAL_AS to parser.

### DIFF
--- a/templates/cisco_ios_show_ip_bgp_summary.template
+++ b/templates/cisco_ios_show_ip_bgp_summary.template
@@ -1,6 +1,11 @@
+Value Filldown,Required ROUTER_ID ([0-9a-f:\.]+)
+Value Filldown LOCAL_AS (\d+)
 Value BGP_NEIGH (\d+?\.\d+?\.\d+?\.\d+?)
 Value NEIGH_AS (\d+)
 Value STATE_PFXRCD (\S+?\s+\S+?|\S+?)
 
 Start
+  ^BGP\s+router\s+identifier\s+${ROUTER_ID},\s+local\s+AS\s+number\s+${LOCAL_AS}\s*$$
   ^${BGP_NEIGH}\s+\S+\s+${NEIGH_AS}(\s+\d+?){5}\s+\S+?\s+${STATE_PFXRCD}\s*$$ -> Record
+
+EOF

--- a/tests/cisco_ios/show_ip_bgp_summary/cisco_ios_show_ip_bgp_summary.parsed
+++ b/tests/cisco_ios/show_ip_bgp_summary/cisco_ios_show_ip_bgp_summary.parsed
@@ -2,41 +2,61 @@
 parsed_sample:
 
 - bgp_neigh: '10.0.0.1'
+  local_as: '65000'
   neigh_as: '65000'
+  router_id: '10.0.0.0'
   state_pfxrcd: '558720'
 
 - bgp_neigh: '10.0.0.2'
+  local_as: '65000'
   neigh_as: '65001'
+  router_id: '10.0.0.0'
   state_pfxrcd: '558720'
 
 - bgp_neigh: '10.0.0.3'
+  local_as: '65000'
   neigh_as: '65002'
+  router_id: '10.0.0.0'
   state_pfxrcd: '0'
 
 - bgp_neigh: '10.0.0.4'
+  local_as: '65000'
   neigh_as: '65003'
+  router_id: '10.0.0.0'
   state_pfxrcd: '1351'
 
 - bgp_neigh: '10.0.0.5'
+  local_as: '65000'
   neigh_as: '65004'
+  router_id: '10.0.0.0'
   state_pfxrcd: '558720'
 
 - bgp_neigh: '10.0.0.6'
+  local_as: '65000'
   neigh_as: '65005'
+  router_id: '10.0.0.0'
   state_pfxrcd: '558720'
 
 - bgp_neigh: '10.0.0.7'
+  local_as: '65000'
   neigh_as: '65006'
+  router_id: '10.0.0.0'
   state_pfxrcd: '82'
 
 - bgp_neigh: '10.0.0.8'
+  local_as: '65000'
   neigh_as: '65007'
+  router_id: '10.0.0.0'
   state_pfxrcd: '82'
 
 - bgp_neigh: '10.0.0.9'
+  local_as: '65000'
   neigh_as: '65008'
+  router_id: '10.0.0.0'
   state_pfxrcd: '0'
 
 - bgp_neigh: '10.0.0.10'
+  local_as: '65000'
   neigh_as: '65009'
+  router_id: '10.0.0.0'
   state_pfxrcd: 'Idle (Admin)'


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_ip_bgp_summary
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add parsing two additional attributes of bgp data
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
