### PR TITLE
Add RELOAD_REASON to Record

### DIFF
--- a/templates/cisco_ios_show_version.template
+++ b/templates/cisco_ios_show_version.template
@@ -2,6 +2,7 @@ Value VERSION (.+?)
 Value ROMMON (\S+)
 Value HOSTNAME (\S+)
 Value UPTIME (.+)
+Value RELOAD_REASON (.+)
 Value RUNNING_IMAGE (\S+)
 Value List HARDWARE (\S+\d\S+)
 Value List SERIAL (\S+)
@@ -12,6 +13,7 @@ Start
   ^ROM: ${ROMMON}
   ^\s*${HOSTNAME}\s+uptime\s+is\s+${UPTIME}
   ^[sS]ystem\s+image\s+file\s+is\s+"(.*?):${RUNNING_IMAGE}"
+  ^[lL]ast\s+reload\s+reason:\s+${RELOAD_REASON}
   ^[Pp]rocessor\s+board\s+ID\s+${SERIAL}
   ^[Cc]isco\s+${HARDWARE}.+
   ^[Cc]onfiguration\s+register\s+is\s+${CONFIG_REGISTER}
@@ -22,4 +24,4 @@ Stack
   ^[Ss]ystem [Ss]erial [Nn]umber\s+:\s+${SERIAL}
   ^[Mm]odel\s+[Nn]umber\s+:\s+${HARDWARE}\s*
   ^[Cc]onfiguration\s+register\s+is\s+${CONFIG_REGISTER}
-
+  


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_version.template

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added RELOAD_REASON to determine why the switch was reloaded.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
  -   CONFIG_REGISTER: '0x102'
       HARDWARE:
       - C9300-48P
       HOSTNAME: ROUTER01
       RELOAD_REASON: LocalSoft
       ROMMON: IOS-XE
       RUNNING_IMAGE: packages.conf
       SERIAL:
       - XXXXXXXXXXXX
       UPTIME: 4 weeks, 15 hours, 41 minutes
       VERSION: 16.6.4
```
