### PR TITLE
CISCO ASA SHOW FAILOVER: Add template for failover status

### DIFF
--- a/templates/cisco_asa_show_failover.template
+++ b/templates/cisco_asa_show_failover.template
@@ -1,0 +1,79 @@
+Value STATE (\S+)
+Value ROLE (\S+)
+Value LAN_INTF_NAME (\S+)
+Value LAN_INTF (\S+)
+Value LAN_INTF_STATE (\S+)
+Value SW_VERSION (\S+)
+Value SW_VERSION_MATE (\S+)
+Value List FAILOVER_GROUP (\d+)
+Value List LAST_FAILOVER_TIME (\d+:\d+:\d+)
+Value List LAST_FAILOVER_TIMEZONE (\w+)
+Value List LAST_FAILOVER_MONTH (\w+)
+Value List LAST_FAILOVER_DAY (\d+)
+Value List LAST_FAILOVER_YEAR (\d+)
+Value List SERVICE (\S+)
+Value List SERVICE_STATE (\S+|)
+Value List SERVICE_MATE (\S+)
+Value List SERVICE_STATE_MATE (\S+|)
+Value List SSP_SLOT (\d+)
+Value List SSP_MODEL (\S+)
+Value List SSP_STATUS (\S+)
+Value List SSP_SLOT_MATE (\d+)
+Value List SSP_MODEL_MATE (\S+)
+Value List SSP_STATUS_MATE (\S+)
+Value List INTERFACES_CONTEXT (\S+)
+Value List INTERFACES (\S+)
+Value List INTERFACES_STATUS (.+?)
+Value List INTERFACES_STATE (\S+)
+Value List INTERFACES_CONTEXT_MATE (\S+)
+Value List INTERFACES_MATE (\S+)
+Value List INTERFACES_STATUS_MATE (.+?)
+Value List INTERFACES_STATE_MATE (\S+)
+
+Start
+  ^Failover\s+${STATE}\s*$$
+  ^Failover\s+unit\s+${ROLE}\s*$$
+  ^Failover\s+LAN\s+Interface:\s+${LAN_INTF_NAME}\s+${LAN_INTF}\s+\(${LAN_INTF_STATE}\)\s*$$
+  ^Version:\s+Ours\s+${SW_VERSION},\s+Mate\s+${SW_VERSION_MATE}\s*$$
+  ^(?:Group\s+${FAILOVER_GROUP}\s+|)[Ll]ast\s+[Ff]ailover\s+at:\s+${LAST_FAILOVER_TIME}\s+${LAST_FAILOVER_TIMEZONE}\s+${LAST_FAILOVER_MONTH}\s+${LAST_FAILOVER_DAY}\s+${LAST_FAILOVER_YEAR}\s*$$
+  ^This\s+host:.+?-\s+${SERVICE}\s*${SERVICE_STATE}\s*$$ -> ThisHost
+  ^This\s+host:\s+\S+\s*$$ -> ThisHost
+  ^Reconnect\s+timeout
+  ^Unit\s+Poll\s+frequency
+  ^Interface\s+Poll\s+frequency
+  ^Interface\s+Policy
+  ^Monitored\s+Interfaces
+  ^MAC\s+Address\s+Move\s+Notification\s+Interval
+  ^Serial\s+Number
+  ^failover\s+replication
+  ^\s*$$
+  ^. -> Error
+
+ThisHost
+  ^Group\s+\d+\s+State:\s+${SERVICE}\s*${SERVICE_STATE}\s*$$
+  ^Active\s+time
+  ^slot\s+${SSP_SLOT}:\s+${SSP_MODEL}\s+.+?status\s+\(${SSP_STATUS}.*?\)\s*$$
+  ^(${INTERFACES_CONTEXT}\s+|)Interface\s+${INTERFACES}.+?:\s+${INTERFACES_STATUS}(?:\s+\(${INTERFACES_STATE}\)|)\s*$$
+  ^Other\s+host:.+?-\s+${SERVICE_MATE}\s*${SERVICE_STATE_MATE}\s*$$ -> OtherHost
+  ^Other\s+host:\s+\S+\s*$$ -> OtherHost
+  ^slot\s+\d+:\s+empty\s*$$
+  ^\s*$$
+  ^. -> Error
+
+OtherHost
+  ^Group\s+\d+\s+State:\s+${SERVICE_MATE}\s*${SERVICE_STATE_MATE}\s*$$
+  ^Active\s+time
+  ^slot\s+${SSP_SLOT_MATE}:\s+${SSP_MODEL_MATE}\s+.+?status\s+\(${SSP_STATUS_MATE}.*?\)\s*$$
+  ^(${INTERFACES_CONTEXT_MATE}\s+|)Interface\s+${INTERFACES_MATE}.+?:\s+${INTERFACES_STATUS_MATE}(?:\s+\(${INTERFACES_STATE_MATE}\)|)\s*$$
+  ^slot\s+\d+:\s+empty\s*$$
+  ^Stateful\s+Failover\s+Logical\s+Update\s+Statistics\s*$$ -> Stats
+  ^\s*$$
+  ^. -> Error
+
+Stats
+  ^Link\s*:\s+
+  ^Stateful\s+Obj\s+xmit\s+xerr\s+rcv\s+rerr\s*$$
+  ^.+?\d+\s+\d+\s+\d+\s+\d+\s*$$
+  ^Logical\s+Update\s+Queue\s+Information\s*$$
+  ^Cur\s+Max\s+Total\s*$$
+  ^.+?:\s+\d+\s+\d+\s+\d+\s*$$

--- a/templates/index
+++ b/templates/index
@@ -101,6 +101,7 @@ cisco_asa_show_crypto_ipsec_sa.template, .*, cisco_asa, sh[[ow]] cry[[pto]] ip[[
 cisco_asa_show_access-list.template, .*, cisco_asa, sh[[ow]] ac[[cess-list]]
 cisco_asa_show_interface.template, .*, cisco_asa, sh[[ow]] int[[erface]]
 cisco_asa_show_inventory.template, .*, cisco_asa, sh[[ow]] inven[[tory]]
+cisco_asa_show_failover.template, .*, cisco_asa, sh[[ow]] fa[[ilover]]
 cisco_asa_show_version.template, .*, cisco_asa, sh[[ow]] ver[[sion]]
 cisco_asa_show_route.template, .*, cisco_asa, sh[[ow]] ro[[ute]]
 cisco_asa_show_name.template, .*, cisco_asa, sh[[ow]] nam[[e]]

--- a/tests/cisco_asa/show_failover/cisco_asa_show_failover.parsed
+++ b/tests/cisco_asa/show_failover/cisco_asa_show_failover.parsed
@@ -1,0 +1,33 @@
+---
+parsed_sample:
+  - state: "On"
+    role: "Primary"
+    lan_intf_name: "failover"
+    lan_intf: "GigabitEthernet0/4"
+    lan_intf_state: "up"
+    sw_version: "98.1(1)86"
+    sw_version_mate: "98.1(1)86"
+    failover_group: [None]
+    last_failover_time: ["12:52:34"]
+    last_failover_timezone: ["UTC"]
+    last_failover_month: ["Apr"]
+    last_failover_day: ["26"]
+    last_failover_year: ["2017"]
+    service: ["Active"]
+    service_state: [""]
+    service_mate: ["Standby"]
+    service_state_mate: ["Ready"]
+    ssp_slot: ["0"]
+    ssp_model: ["ASA5585-SSP-10"]
+    ssp_status: ["Up"]
+    ssp_slot_mate: ["0"]
+    ssp_model_mate: ["ASA5585-SSP-10"]
+    ssp_status_mate: ["Up"]
+    interfaces_context: [None, None, None]
+    interfaces: ["inside", "outside", "dmz"]
+    interfaces_status: ["Normal", "No Link", "No Link"]
+    interfaces_state: ["Monitored", "Waiting", "Waiting"]
+    interfaces_context_mate: [None, None, None]
+    interfaces_mate: ["inside", "outside", "dmz"]
+    interfaces_status_mate: ["Normal", "No Link", "No Link"]
+    interfaces_state_mate: ["Waiting", "Waiting", "Waiting"]

--- a/tests/cisco_asa/show_failover/cisco_asa_show_failover.raw
+++ b/tests/cisco_asa/show_failover/cisco_asa_show_failover.raw
@@ -1,0 +1,64 @@
+Failover On
+Failover unit Primary
+Failover LAN Interface: failover GigabitEthernet0/4 (up)
+Reconnect timeout 0:00:00
+Unit Poll frequency 1 seconds, holdtime 15 seconds
+Interface Poll frequency 5 seconds, holdtime 25 seconds
+Interface Policy 1
+Monitored Interfaces 3 of 1049 maximum
+MAC Address Move Notification Interval not set
+Version: Ours 98.1(1)86, Mate 98.1(1)86
+Serial Number: Ours JAF1610APKQ, Mate JAF1610ALGM
+Last Failover at: 12:52:34 UTC Apr 26 2017
+This host: Primary - Active
+Active time: 87 (sec)
+slot 0: ASA5585-SSP-10 hw/sw rev (2.0/98.1(1)86) status (Up Sys)
+Interface inside (10.86.118.1): Normal (Monitored)
+Interface outside (192.168.77.1): No Link (Waiting)
+Interface dmz (192.168.67.1): No Link (Waiting)
+slot 1: empty
+slot 1: empty
+Other host: Secondary - Standby Ready
+Active time: 0 (sec)
+slot 0: ASA5585-SSP-10 hw/sw rev (2.0/98.1(1)86) status (Up Sys)
+Interface inside (10.86.118.2): Normal (Waiting)
+Interface outside (192.168.77.2): No Link (Waiting)
+Interface dmz (192.168.67.2): No Link (Waiting)
+slot 1: empty
+slot 1: empty
+ 
+Stateful Failover Logical Update Statistics
+Link : failover GigabitEthernet0/4 (up)
+Stateful Obj xmit xerr rcv rerr
+General 22 0 6 0
+sys cmd 6 0 6 0
+up time 0 0 0 0
+RPC services 0 0 0 0
+TCP conn 0 0 0 0
+UDP conn 0 0 0 0
+ARP tbl 14 0 0 0
+Xlate_Timeout 0 0 0 0
+IPv6 ND tbl 0 0 0 0
+VPN IKEv1 SA 0 0 0 0
+VPN IKEv1 P2 0 0 0 0
+VPN IKEv2 SA 0 0 0 0
+VPN IKEv2 P2 0 0 0 0
+VPN CTCP upd 0 0 0 0
+VPN SDI upd 0 0 0 0
+VPN DHCP upd 0 0 0 0
+SIP Session 0 0 0 0
+SIP Tx 0 0 0 0
+SIP Pinhole 0 0 0 0
+Route Session 0 0 0 0
+Router ID 1 0 0 0
+User-Identity 1 0 0 0
+CTS SGTNAME 0 0 0 0
+CTS PAC 0 0 0 0
+TrustSec-SXP 0 0 0 0
+IPv6 Route 0 0 0 0
+STS Table 0 0 0 0
+ 
+Logical Update Queue Information
+Cur Max Total
+Recv Q: 0 5 6
+Xmit Q: 0 27 86

--- a/tests/cisco_asa/show_failover/cisco_asa_show_failover5505.parsed
+++ b/tests/cisco_asa/show_failover/cisco_asa_show_failover5505.parsed
@@ -1,0 +1,33 @@
+---
+parsed_sample:
+  - state: "On"
+    role: "Primary"
+    lan_intf_name: "fover"
+    lan_intf: "Vlan150"
+    lan_intf_state: "up"
+    sw_version: "7.2(0)55"
+    sw_version_mate: "7.2(0)55"
+    failover_group: [None]
+    last_failover_time: ["19:59:58"]
+    last_failover_timezone: ["PST"]
+    last_failover_month: ["Apr"]
+    last_failover_day: ["6"]
+    last_failover_year: ["2006"]
+    service: ["Active"]
+    service_state: [""]
+    service_mate: ["Standby"]
+    service_state_mate: ["Ready"]
+    ssp_slot: ["0"]
+    ssp_model: ["ASA5505"]
+    ssp_status: ["Up"]
+    ssp_slot_mate: ["0"]
+    ssp_model_mate: ["ASA5505"]
+    ssp_status_mate: ["Up"]
+    interfaces_context: [None, None, None, None]
+    interfaces: ["inside", "outside", "dmz", "test"]
+    interfaces_status: ["Normal", "Normal", "Normal", "Normal"]
+    interfaces_state: [None, None, None, None]
+    interfaces_context_mate: [None, None, None, None]
+    interfaces_mate: ["inside", "outside", "dmz", "test"]
+    interfaces_status_mate: ["Normal", "Normal", "Normal", "Normal"]
+    interfaces_state_mate: [None, None, None, None]

--- a/tests/cisco_asa/show_failover/cisco_asa_show_failover5505.raw
+++ b/tests/cisco_asa/show_failover/cisco_asa_show_failover5505.raw
@@ -1,0 +1,27 @@
+Failover On
+Failover unit Primary
+Failover LAN Interface: fover Vlan150 (up)
+Unit Poll frequency 1 seconds, holdtime 15 seconds
+Interface Poll frequency 5 seconds, holdtime 25 seconds
+Interface Policy 1
+Monitored Interfaces 4 of 250 maximum
+Version: Ours 7.2(0)55, Mate 7.2(0)55
+Last Failover at: 19:59:58 PST Apr 6 2006
+ 
+This host: Primary - Active
+Active time: 34 (sec)
+slot 0: ASA5505 hw/sw rev (1.0/7.2(0)55) status (Up Sys)
+Interface inside (192.168.1.1): Normal
+Interface outside (192.168.2.201): Normal
+Interface dmz (172.16.0.1): Normal
+Interface test (172.23.62.138): Normal
+slot 1: empty
+ 
+Other host: Secondary - Standby Ready
+Active time: 0 (sec)
+slot 0: ASA5505 hw/sw rev (1.0/7.2(0)55) status (Up Sys)
+Interface inside (192.168.1.2): Normal
+Interface outside (192.168.2.211): Normal
+Interface dmz (172.16.0.2): Normal
+Interface test (172.23.62.137): Normal
+slot 1: empty

--- a/tests/cisco_asa/show_failover/cisco_asa_show_failoveractiveactive.parsed
+++ b/tests/cisco_asa/show_failover/cisco_asa_show_failoveractiveactive.parsed
@@ -1,0 +1,33 @@
+---
+parsed_sample:
+  - state: "On"
+    role: "Primary"
+    lan_intf_name: "folink"
+    lan_intf: "GigabitEthernet0/2"
+    lan_intf_state: "up"
+    sw_version: ""
+    sw_version_mate: ""
+    failover_group: ["1", "2"]
+    last_failover_time: ["13:40:18", "13:40:06"]
+    last_failover_timezone: ["UTC", "UTC"]
+    last_failover_month: ["Dec", "Dec"]
+    last_failover_day: ["9", "9"]
+    last_failover_year: ["2004", "2004"]
+    service: ["Active", "Standby"]
+    service_state: ["", "Ready"]
+    service_mate: ["Standby", "Active"]
+    service_state_mate: ["Ready", ""]
+    ssp_slot: ["0"]
+    ssp_model: ["ASA-5545"]
+    ssp_status: ["Up"]
+    ssp_slot_mate: ["0"]
+    ssp_model_mate: ["ASA-5545"]
+    ssp_status_mate: ["Up"]
+    interfaces_context: ["admin", "admin", "admin", "admin", "ctx1", "ctx1", "ctx2", "ctx2"]
+    interfaces: ["outside", "folink", "inside", "fourth", "outside", "inside", "outside", "inside"]
+    interfaces_status: ["Normal", "Normal", "Normal", "Normal", "Normal", "Normal", "Normal", "Normal"]
+    interfaces_state: [None, None, None, None, None, None, None, None]
+    interfaces_context_mate: ["admin", "admin", "admin", "admin", "ctx1", "ctx1", "ctx2", "ctx2"]
+    interfaces_mate: ["outside", "folink", "inside", "fourth", "outside", "inside", "outside", "inside"]
+    interfaces_status_mate: ["Normal", "Normal", "Normal", "Normal", "Normal", "Normal", "Normal", "Normal"]
+    interfaces_state_mate: [None, None, None, None, None, None, None, None]

--- a/tests/cisco_asa/show_failover/cisco_asa_show_failoveractiveactive.raw
+++ b/tests/cisco_asa/show_failover/cisco_asa_show_failoveractiveactive.raw
@@ -1,0 +1,66 @@
+Failover On
+Failover unit Primary
+Failover LAN Interface: folink GigabitEthernet0/2 (up)
+Unit Poll frequency 1 seconds, holdtime 15 seconds
+Interface Poll frequency 4 seconds
+Interface Policy 1
+Monitored Interfaces 8 of 250 maximum
+failover replication http
+Group 1 last failover at: 13:40:18 UTC Dec 9 2004
+Group 2 last failover at: 13:40:06 UTC Dec 9 2004
+ 
+This host: Primary
+Group 1 State: Active
+Active time: 2896 (sec)
+Group 2 State: Standby Ready
+Active time: 0 (sec)
+ 
+slot 0: ASA-5545 hw/sw rev (1.0/7.0(0)79) status (Up Sys)
+admin Interface outside (10.132.8.5): Normal
+admin Interface folink (10.132.9.5/fe80::2a0:c9ff:fe03:101): Normal
+admin Interface inside (10.130.8.5/fe80::2a0:c9ff:fe01:101): Normal
+admin Interface fourth (10.130.9.5/fe80::3eff:fe11:6670): Normal
+ctx1 Interface outside (10.1.1.1): Normal
+ctx1 Interface inside (10.2.2.1): Normal
+ctx2 Interface outside (10.3.3.2): Normal
+ctx2 Interface inside (10.4.4.2): Normal
+ 
+Other host: Secondary
+Group 1 State: Standby Ready
+Active time: 190 (sec)
+Group 2 State: Active
+Active time: 3322 (sec)
+ 
+slot 0: ASA-5545 hw/sw rev (1.0/7.0(0)79) status (Up Sys)
+admin Interface outside (10.132.8.6): Normal
+admin Interface folink (10.132.9.6/fe80::2a0:c9ff:fe03:102): Normal
+admin Interface inside (10.130.8.6/fe80::2a0:c9ff:fe01:102): Normal
+admin Interface fourth (10.130.9.6/fe80::3eff:fe11:6671): Normal
+ctx1 Interface outside (10.1.1.2): Normal
+ctx1 Interface inside (10.2.2.2): Normal
+ctx2 Interface outside (10.3.3.1): Normal
+ctx2 Interface inside (10.4.4.1): Normal
+ 
+Stateful Failover Logical Update Statistics
+Link : third GigabitEthernet0/2 (up)
+Stateful Obj xmit xerr rcv rerr
+General 0 0 0 0
+sys cmd 380 0 380 0
+up time 0 0 0 0
+RPC services 0 0 0 0
+TCP conn 1435 0 1450 0
+UDP conn 0 0 0 0
+ARP tbl 124 0 65 0
+Xlate_Timeout 0 0 0 0
+IPv6 ND tbl 22 0 0 0
+VPN IKE upd 15 0 0 0
+VPN IPSEC upd 90 0 0 0
+VPN CTCP upd 0 0 0 0
+VPN SDI upd 0 0 0 0
+VPN DHCP upd 0 0 0 0
+SIP Session 0 0 0 0
+ 
+Logical Update Queue Information
+Cur Max Total
+Recv Q: 0 1 1895
+Xmit Q: 0 0 1940


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_asa_show_failover
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add template for Cisco ASA `show failover`
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
