### PR TITLE
XR_SH_CDP: Reverse 'REMOTE_PORT' and 'LOCAL_PORT' Groups - Fixes #277

### DIFF
--- a/templates/cisco_xr_show_cdp_neighbors_detail.template
+++ b/templates/cisco_xr_show_cdp_neighbors_detail.template
@@ -12,8 +12,8 @@ Start
   ^SysName : ${SYSNAME}
   ^Entry address\(es\): -> GetIP
   ^Platform: ${PLATFORM},  Capabilities: ${CAPABILITIES}
-  ^Interface: ${REMOTE_PORT}
-  ^Port ID \(outgoing port\): ${LOCAL_PORT}
+  ^Interface: ${LOCAL_PORT}
+  ^Port ID \(outgoing port\): ${REMOTE_PORT}
   ^Version : -> GetVersion
 
 GetIP

--- a/tests/cisco_xr/show_cdp_neighbors_detail/cisco_xr_show_cdp_neighbors_detail.parsed
+++ b/tests/cisco_xr/show_cdp_neighbors_detail/cisco_xr_show_cdp_neighbors_detail.parsed
@@ -2,36 +2,36 @@
 parsed_sample:
 
 -   dest_host: nyc-dc-dcm005.ntc.com
-    local_port: GigabitEthernet1/9
+    local_port: MgmtEth0/RSP0/CPU0/0
     mgmt_ip: 10.100.1.54
     platform: cisco WS-C4948E
-    remote_port: MgmtEth0/RSP0/CPU0/0
+    remote_port: GigabitEthernet1/9
     sysname: ''
     version: Cisco IOS Software, Catalyst 4500 L3 Switch Software (cat4500e-ENTSERVICESK9-M),
         Version 15.0(2)SG10, RELEASE SOFTWARE (fc1)
     capabilities: "Router Switch IGMP"
 -   dest_host: nyc-dc-dcm006.ntc.com
-    local_port: GigabitEthernet1/9
+    local_port: MgmtEth0/RSP1/CPU0/0
     mgmt_ip: 10.100.1.55
     platform: cisco WS-C4948E
-    remote_port: MgmtEth0/RSP1/CPU0/0
+    remote_port: GigabitEthernet1/9
     sysname: ''
     version: Cisco IOS Software, Catalyst 4500 L3 Switch Software (cat4500e-ENTSERVICESK9-M),
         Version 15.0(2)SG10, RELEASE SOFTWARE (fc1)
     capabilities: "Router Switch IGMP"
 -   dest_host: nyc-dc-c90.ntc.com
-    local_port: FortyGigE0/0/0/2
+    local_port: FortyGigE0/0/1/0
     mgmt_ip: 10.100.100.141
     platform: cisco CRS
-    remote_port: FortyGigE0/0/1/0
+    remote_port: FortyGigE0/0/0/2
     sysname: nyc-dc-c90.ntc.com
     version: Cisco IOS XR Software, Version 5.1.2[Default]
     capabilities: "Router Switch IGMP"
 -   dest_host: nyc-dc-d02.ntc.com(FXS182XXXXX)
-    local_port: Ethernet6/1
+    local_port: FortyGigE0/0/1/1
     mgmt_ip: 10.100.100.162
     platform: N77-C7706
-    remote_port: FortyGigE0/0/1/1
+    remote_port: Ethernet6/1
     sysname: nyc-dc-d02
     version: Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
     capabilities: "Router Switch"
@@ -44,10 +44,10 @@ parsed_sample:
     version: Cisco IOS XR Software, Version 5.3.4[Default]
     capabilities: "Router"
 -   dest_host: nyc-dc-c91.ntc.com
-    local_port: FortyGigE0/0/0/2
+    local_port: FortyGigE0/0/0/1
     mgmt_ip: 10.100.100.125
     platform: cisco CRS
-    remote_port: FortyGigE0/0/0/1
+    remote_port: FortyGigE0/0/0/2
     sysname: nyc-dc-c91.ntc.com
     version: Cisco IOS XR Software, Version 5.1.2[Default]
     capabilities: "Router"
@@ -60,124 +60,124 @@ parsed_sample:
     version: Cisco IOS XR Software, Version 5.3.4[Default]
     capabilities: "Router"
 -   dest_host: nyc-dc-d03.ntc.com(FXS182XXXXX)
-    local_port: Ethernet6/1
+    local_port: FortyGigE0/1/0/1
     mgmt_ip: 10.100.100.190
     platform: N77-C7706
-    remote_port: FortyGigE0/1/0/1
+    remote_port: Ethernet6/1
     sysname: nyc-dc-d03
     version: Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
     capabilities: "Router Switch"
 -   dest_host: nyc-dc-c90.ntc.com
-    local_port: FortyGigE0/4/0/2
+    local_port: FortyGigE0/1/1/0
     mgmt_ip: 10.100.100.145
     platform: cisco CRS
-    remote_port: FortyGigE0/1/1/0
+    remote_port: FortyGigE0/4/0/2
     sysname: nyc-dc-c90.ntc.com
     version: Cisco IOS XR Software, Version 5.1.2[Default]
     capabilities: "Router"
 -   dest_host: nyc-dc-z50a.ntc.com(JAF18XXXXX)
-    local_port: Ethernet4/3
+    local_port: FortyGigE0/1/1/1
     mgmt_ip: 10.100.100.116
     platform: N77-C7710
-    remote_port: FortyGigE0/1/1/1
+    remote_port: Ethernet4/3
     sysname: nyc-dc-z50a
     version: Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
     capabilities: "Router Switch"
 -   dest_host: nyc-dc-d04.ntc.com(FXS18XXXXXX)
-    local_port: Ethernet6/1
+    local_port: FortyGigE0/2/1/0
     mgmt_ip: 10.100.100.194
     platform: N77-C7706
-    remote_port: FortyGigE0/2/1/0
+    remote_port: Ethernet6/1
     sysname: nyc-dc-d04
     version: Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
     capabilities: "Router Switch"
 -   dest_host: nyc-dc-c91.ntc.com
-    local_port: FortyGigE0/4/0/2
+    local_port: FortyGigE0/2/1/1
     mgmt_ip: 10.100.100.129
     platform: cisco CRS
-    remote_port: FortyGigE0/2/1/1
+    remote_port: FortyGigE0/4/0/2
     sysname: nyc-dc-c91.ntc.com
     version: Cisco IOS XR Software, Version 5.1.2[Default]
     capabilities: "Router"
 -   dest_host: nyc-dc-d01.ntc.com(FXS182XXXXX)
-    local_port: Ethernet6/1
+    local_port: FortyGigE0/2/0/0
     mgmt_ip: 10.100.100.158
     platform: N77-C7706
-    remote_port: FortyGigE0/2/0/0
+    remote_port: Ethernet6/1
     sysname: nyc-dc-d01
     version: Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
     capabilities: "Router Switch"
 -   dest_host: nyc-dc-z50b.ntc.com(JAF181XXXXX)
-    local_port: Ethernet4/3
+    local_port: FortyGigE0/2/0/1
     mgmt_ip: 10.100.100.111
     platform: N77-C7710
-    remote_port: FortyGigE0/2/0/1
+    remote_port: Ethernet4/3
     sysname: nyc-dc-z50b
     version: Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
     capabilities: "Router Switch"
 -   dest_host: nyc-dc-dcc001.ntc.com
-    local_port: TenGigabitEthernet6/1
+    local_port: TenGigE0/3/0/0
     mgmt_ip: 10.100.100.174
     platform: cisco WS-C4510R+E
-    remote_port: TenGigE0/3/0/0
+    remote_port: TenGigabitEthernet6/1
     sysname: ''
     version: Cisco IOS Software, Catalyst 4500 L3 Switch  Software (cat4500e-UNIVERSALK9-M),
         Version 15.2(2)E3, RELEASE SOFTWARE (fc3)
     capabilities: "Router Switch IGMP"
 -   dest_host: nyc-dc-d57
-    local_port: TenGigE0/2/0/0
+    local_port: TenGigE0/3/0/1
     mgmt_ip: 10.100.100.115
     platform: cisco ASR9K Series
-    remote_port: TenGigE0/3/0/1
+    remote_port: TenGigE0/2/0/0
     sysname: nyc-dc-d57
     version: Cisco IOS XR Software, Version 4.3.2[Default]
     capabilities: "Router"
 -   dest_host: nyc-dc-d40b.ntc.com(JAF182XXXXX)
-    local_port: Ethernet4/1
+    local_port: TenGigE0/3/0/2
     mgmt_ip: 10.100.100.114
     platform: N77-C7710
-    remote_port: TenGigE0/3/0/2
+    remote_port: Ethernet4/1
     sysname: nyc-dc-d40b
     version: Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
     capabilities: "Router Switch"
 -   dest_host: nyc-dc-d80.ntc.com(FOC184XXXXX)
-    local_port: Ethernet2/1
+    local_port: TenGigE0/3/0/3
     mgmt_ip: 10.100.100.117
     platform: N5K-C56128P
-    remote_port: TenGigE0/3/0/3
+    remote_port: Ethernet2/1
     sysname: nyc-dc-d80
     version: Cisco Nexus Operating System (NX-OS) Software, Version 7.0(7)N1(1)
     capabilities: "Router Switch IGMP"
 -   dest_host: nyc-dc-dcc002.ntc.com
-    local_port: TenGigabitEthernet6/1
+    local_port: TenGigE0/4/0/0
     mgmt_ip: 10.100.100.178
     platform: cisco WS-C4510R+E
-    remote_port: TenGigE0/4/0/0
+    remote_port: TenGigabitEthernet6/1
     sysname: ''
     version: Cisco IOS Software, Catalyst 4500 L3 Switch  Software (cat4500e-UNIVERSALK9-M),
         Version 15.2(2)E3, RELEASE SOFTWARE (fc3)
     capabilities: "Router Switch IGMP"
 -   dest_host: nyc-dc-d57
-    local_port: TenGigE1/2/0/0
+    local_port: TenGigE0/4/0/1
     mgmt_ip: 10.100.100.115
     platform: cisco ASR9K Series
-    remote_port: TenGigE0/4/0/1
+    remote_port: TenGigE1/2/0/0
     sysname: nyc-dc-d57
     version: Cisco IOS XR Software, Version 4.3.2[Default]
     capabilities: "Router"
 -   dest_host: nyc-dc-d40a.ntc.com(JAF182XXXXX)
-    local_port: Ethernet4/1
+    local_port: TenGigE0/4/0/2
     mgmt_ip: 10.100.100.113
     platform: N77-C7710
-    remote_port: TenGigE0/4/0/2
+    remote_port: Ethernet4/1
     sysname: nyc-dc-d40a
     version: Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
     capabilities: "Router Switch"
 -   dest_host: nyc-dc-d81.ntc.com(FOC182XXXXX)
-    local_port: Ethernet1/1
+    local_port: TenGigE0/4/0/3
     mgmt_ip: 10.100.100.118
     platform: N5K-C56128P
-    remote_port: TenGigE0/4/0/3
+    remote_port: Ethernet1/1
     sysname: nyc-dc-d81
     version: Cisco Nexus Operating System (NX-OS) Software, Version 7.0(7)N1(1)
     capabilities: "Router Switch IGMP"
@@ -190,10 +190,10 @@ parsed_sample:
     version: Cisco IOS XR Software, Version 5.3.4[Default]
     capabilities: "Router"
 -   dest_host: nyc-dc-c97
-    local_port: FortyGigE0/7/0/0
+    local_port: FortyGigE0/6/0/0
     mgmt_ip: 192.168.169.21
     platform: cisco ASR9K Series
-    remote_port: FortyGigE0/6/0/0
+    remote_port: FortyGigE0/7/0/0
     sysname: nyc-dc-c97
     version: Cisco IOS XR Software, Version 5.3.4[Default]
     capabilities: "Router"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_xr_show_cdp_neighbors_detal
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #277 where the capture groups for neighbor interfaces are reversed. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
