### PR TITLE
XR_SHOW_INTF: Correct capturing of IP Address info - Fixes #280

### DIFF
--- a/templates/cisco_xr_show_interfaces.template
+++ b/templates/cisco_xr_show_interfaces.template
@@ -5,7 +5,7 @@ Value HARDWARE_TYPE (\w+)
 Value ADDRESS ([a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+)
 Value BIA ([a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+)
 Value DESCRIPTION (.*)
-Value IP_ADDRESS (\d+\.\d+\.\d+\.\d+\/\d+)
+Value IP_ADDRESS (.*?)
 Value MTU (\d+)
 Value DUPLEX (.+?)
 Value SPEED (.+?)
@@ -16,7 +16,7 @@ Start
   ^${INTERFACE}\sis\s+${LINK_STATUS},\s+line\sprotocol\sis\s+${ADMIN_STATE}
   ^\s+Hardware\s+is\s+${HARDWARE_TYPE}(\s+)?(Ethernet)?(,)?(\s+address\s+is\s+${ADDRESS}\s+\(bia\s+${BIA})?
   ^\s+Description:\s+${DESCRIPTION}
-  ^\s+Internet\s+Address\s+is\s+${IP_ADDRESS}
+  ^\s+[Ii]nternet\s+[Aa]ddress\s+is\s+${IP_ADDRESS}\s*$$
   ^\s+MTU\s+${MTU}.*BW\s+${BANDWIDTH}
   ^\s+${DUPLEX}, ${SPEED},.+link 
   ^\s+Encapsulation\s+${ENCAPSULATION}

--- a/tests/cisco_xr/show_interfaces/cisco_xr_show_interfaces.parsed
+++ b/tests/cisco_xr/show_interfaces/cisco_xr_show_interfaces.parsed
@@ -10,7 +10,7 @@ parsed_sample:
     encapsulation: Loopback
     hardware_type: Loopback
     interface: Loopback5
-    ip_address: ''
+    ip_address: '192.168.169.21/32'
     link_status: up
     mtu: '1500'
     speed: ''
@@ -23,7 +23,7 @@ parsed_sample:
     encapsulation: 'Null'
     hardware_type: 'Null'
     interface: Null0
-    ip_address: ''
+    ip_address: 'Unknown'
     link_status: up
     mtu: '1500'
     speed: ''
@@ -36,7 +36,7 @@ parsed_sample:
     encapsulation: TUNNEL
     hardware_type: Tunnel
     interface: tunnel-te300
-    ip_address: ''
+    ip_address: '192.168.169.21/32'
     link_status: up
     mtu: '1500'
     speed: ''
@@ -49,7 +49,7 @@ parsed_sample:
     encapsulation: ARPA
     hardware_type: Management
     interface: MgmtEth0/RSP1/CPU0/0
-    ip_address: ''
+    ip_address: '10.253.3.18/25'
     link_status: up
     mtu: '1514'
     speed: 1000Mb/s
@@ -62,7 +62,7 @@ parsed_sample:
     encapsulation: ARPA
     hardware_type: FortyGigE
     interface: FortyGigE0/0/0/0
-    ip_address: ''
+    ip_address: '192.168.166.9/30'
     link_status: up
     mtu: '9216'
     speed: 40000Mb/s
@@ -75,7 +75,7 @@ parsed_sample:
     encapsulation: ARPA
     hardware_type: TenGigE
     interface: TenGigE0/3/0/0
-    ip_address: ''
+    ip_address: '192.168.166.65/30'
     link_status: up
     mtu: '9216'
     speed: 10000Mb/s


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_xr_show_interfaces
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #280 Allow for `[Ii]` and `[Aa]` for matching addresses
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
