### PR TITLE
XR_SH_INTF: Update regex to properly capture data - Fixes #282

### DIFF
--- a/templates/cisco_xr_show_interfaces.template
+++ b/templates/cisco_xr_show_interfaces.template
@@ -1,10 +1,10 @@
 Value Required INTERFACE (\S+)
-Value LINK_STATUS (\w+)
-Value ADMIN_STATE (\S+)
-Value HARDWARE_TYPE (\w+)
-Value ADDRESS ([a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+)
-Value BIA ([a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+)
-Value DESCRIPTION (.*)
+Value LINK_STATUS (.+?)
+Value ADMIN_STATE (.+?)
+Value HARDWARE_TYPE (\S+?(?:\s+Ethernet|))
+Value ADDRESS ((?:\w{4}\.){2}\w{4})
+Value BIA ((?:\w{4}\.){2}\w{4})
+Value DESCRIPTION (.*?)
 Value IP_ADDRESS (.*?)
 Value MTU (\d+)
 Value DUPLEX (.+?)
@@ -13,11 +13,11 @@ Value BANDWIDTH (\d+\s+\w+)
 Value ENCAPSULATION (\w+)
 
 Start
-  ^${INTERFACE}\sis\s+${LINK_STATUS},\s+line\sprotocol\sis\s+${ADMIN_STATE}
-  ^\s+Hardware\s+is\s+${HARDWARE_TYPE}(\s+)?(Ethernet)?(,)?(\s+address\s+is\s+${ADDRESS}\s+\(bia\s+${BIA})?
-  ^\s+Description:\s+${DESCRIPTION}
+  ^\S+\s+is -> Continue.Record
+  ^${INTERFACE}\sis\s+${LINK_STATUS},\s+line\sprotocol\sis\s+${ADMIN_STATE}\s*$$
+  ^\s+Hardware\s+is\s+${HARDWARE_TYPE}(?:,\s+address\s+is\s+${ADDRESS}\s+\(bia\s+${BIA}\)\s*$$|\s.+|\s*$$)
+  ^\s+Description:\s+${DESCRIPTION}\s*$$
   ^\s+[Ii]nternet\s+[Aa]ddress\s+is\s+${IP_ADDRESS}\s*$$
   ^\s+MTU\s+${MTU}.*BW\s+${BANDWIDTH}
-  ^\s+${DUPLEX}, ${SPEED},.+link 
   ^\s+Encapsulation\s+${ENCAPSULATION}
-  ^\s+Last -> Record
+  ^\s+(?:[Dd]uplex\s+|)${DUPLEX}(?:-[Dd]uplex|),\s+${SPEED},.+link

--- a/tests/cisco_xr/show_interfaces/cisco_xr_show_interfaces.parsed
+++ b/tests/cisco_xr/show_interfaces/cisco_xr_show_interfaces.parsed
@@ -1,81 +1,106 @@
 ---
 parsed_sample:
-
--   address: ''
-    admin_state: up
-    bandwidth: 0 Kbit
-    bia: ''
-    description: $DCI ~Loopback for OSPF/LDP/BGP/TE
-    duplex: ''
-    encapsulation: Loopback
-    hardware_type: Loopback
-    interface: Loopback5
-    ip_address: '192.168.169.21/32'
-    link_status: up
-    mtu: '1500'
-    speed: ''
--   address: ''
-    admin_state: up
-    bandwidth: 0 Kbit
-    bia: ''
-    description: ''
-    duplex: ''
-    encapsulation: 'Null'
-    hardware_type: 'Null'
-    interface: Null0
-    ip_address: 'Unknown'
-    link_status: up
-    mtu: '1500'
-    speed: ''
--   address: ''
-    admin_state: up
-    bandwidth: 0 Kbit
-    bia: ''
-    description: $DCI TE Tunnel For REPLICATION to P-YB19-C95
-    duplex: ''
-    encapsulation: TUNNEL
-    hardware_type: Tunnel
-    interface: tunnel-te300
-    ip_address: '192.168.169.21/32'
-    link_status: up
-    mtu: '1500'
-    speed: ''
--   address: f09e.6340.1420
-    admin_state: up
-    bandwidth: 1000000 Kbit
-    bia: f09e.6340.1420
-    description: Management Interface
-    duplex: Full-duplex
-    encapsulation: ARPA
-    hardware_type: Management
-    interface: MgmtEth0/RSP1/CPU0/0
-    ip_address: '10.253.3.18/25'
-    link_status: up
-    mtu: '1514'
-    speed: 1000Mb/s
--   address: 5087.895f.81a0
-    admin_state: up
-    bandwidth: 40000000 Kbit
-    bia: 5087.895f.81a0
-    description: $DCI ~QTS Richmond DCI @CRDC %P-CRDC-C98 +Fort0/0/0/0 !CRIT
-    duplex: Full-duplex
-    encapsulation: ARPA
-    hardware_type: FortyGigE
-    interface: FortyGigE0/0/0/0
-    ip_address: '192.168.166.9/30'
-    link_status: up
-    mtu: '9216'
-    speed: 40000Mb/s
--   address: 5087.8964.53b0
-    admin_state: up
-    bandwidth: 10000000 Kbit
-    bia: 5087.8964.53b0
-    description: $DCI ~QTS Richmond Prod @CRDC %Z-CRDC-Dcc001 +Te5/1 !CRIT
-    duplex: Full-duplex
-    encapsulation: ARPA
-    hardware_type: TenGigE
-    interface: TenGigE0/3/0/0
-    ip_address: '192.168.166.65/30'
-    link_status: up
-    mtu: '9216'
-    speed: 10000Mb/s
+  - address: ""
+    admin_state: "up"
+    bandwidth: "0 Kbit"
+    bia: ""
+    description: "$DCI ~Loopback for OSPF/LDP/BGP/TE"
+    duplex: ""
+    encapsulation: "Loopback"
+    hardware_type: "Loopback"
+    interface: "Loopback5"
+    ip_address: "192.168.169.21/32"
+    link_status: "up"
+    mtu: "1500"
+    speed: ""
+  - address: ""
+    admin_state: "up"
+    bandwidth: "0 Kbit"
+    bia: ""
+    description: ""
+    duplex: ""
+    encapsulation: "Null"
+    hardware_type: "Null"
+    interface: "Null0"
+    ip_address: "Unknown"
+    link_status: "up"
+    mtu: "1500"
+    speed: ""
+  - address: ""
+    admin_state: "up"
+    bandwidth: "0 Kbit"
+    bia: ""
+    description: "$DCI TE Tunnel For REPLICATION to P-YB19-C95"
+    duplex: ""
+    encapsulation: "TUNNEL"
+    hardware_type: "Tunnel-TE"
+    interface: "tunnel-te300"
+    ip_address: "192.168.169.21/32"
+    link_status: "up"
+    mtu: "1500"
+    speed: ""
+  - address: "5087.8966.5329"
+    admin_state: "administratively down"
+    bandwidth: "0 Kbit"
+    bia: "5087.8966.5329"
+    description: "$DCI"
+    duplex: "unknown"
+    encapsulation: "ARPA"
+    hardware_type: "Management Ethernet"
+    interface: "MgmtEth0/RSP0/CPU0/1"
+    ip_address: "Unknown"
+    link_status: "administratively down"
+    mtu: "1514"
+    speed: "0Kb/s"
+  - address: "f09e.6340.1420"
+    admin_state: "up"
+    bandwidth: "1000000 Kbit"
+    bia: "f09e.6340.1420"
+    description: "Management Interface"
+    duplex: "Full"
+    encapsulation: "ARPA"
+    hardware_type: "Management Ethernet"
+    interface: "MgmtEth0/RSP1/CPU0/0"
+    ip_address: "10.253.3.18/25"
+    link_status: "up"
+    mtu: "1514"
+    speed: "1000Mb/s"
+  - address: "5087.895f.81a0"
+    admin_state: "up"
+    bandwidth: "40000000 Kbit"
+    bia: "5087.895f.81a0"
+    description: "$DCI ~QTS Richmond DCI @CRDC %P-CRDC-C98 +Fort0/0/0/0 !CRIT"
+    duplex: "Full"
+    encapsulation: "ARPA"
+    hardware_type: "FortyGigE"
+    interface: "FortyGigE0/0/0/0"
+    ip_address: "192.168.166.9/30"
+    link_status: "up"
+    mtu: "9216"
+    speed: "40000Mb/s"
+  - address: "5087.8964.53b0"
+    admin_state: "up"
+    bandwidth: "10000000 Kbit"
+    bia: "5087.8964.53b0"
+    description: "$DCI ~QTS Richmond Prod @CRDC %Z-CRDC-Dcc001 +Te5/1 !CRIT"
+    duplex: "Full"
+    encapsulation: "ARPA"
+    hardware_type: "TenGigE"
+    interface: "TenGigE0/3/0/0"
+    ip_address: "192.168.166.65/30"
+    link_status: "up"
+    mtu: "9216"
+    speed: "10000Mb/s"
+  - address: "5087.8964.53b4"
+    admin_state: "administratively down"
+    bandwidth: "10000000 Kbit"
+    bia: "5087.8964.53b4"
+    description: ""
+    duplex: "Full"
+    encapsulation: "ARPA"
+    hardware_type: "TenGigE"
+    interface: "TenGigE0/3/0/4"
+    ip_address: "Unknown"
+    link_status: "administratively down"
+    mtu: "1514"
+    speed: "10000Mb/s"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_xr_show_interfaces
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The current raw file has 2 interfaces not being captured. This change moves the record to the interface's opening line to ensure capture is on a line that is always present. I have also updated regex to properly capture all the groups.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #282 
<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
