### PR TITLE
Change requirements to use `textfsm` instead of `gtextfsm`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ config = {
     'author_email': 'info@networktocode.com',
     'url': 'https://github.com/networktocode/ntc-templates',
     'install_requires': [
-        'gtextfsm',
+        'textfsm',
         'terminal',
     ],
     'classifiers': ['Development Status :: 4 - Beta',


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
setup.py
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`gtextfsm` does not work with py3 installs, and `textfsm` works with py2 and py3
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
