### PR TITLE
change travis and tox to use textfsm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 
 install:
   - pip install netmiko
-  - pip install gtextfsm
+  - pip install textfsm
   - export PYTHONPATH=$PYTHONPATH:/home/travis/build/networktocode/ntc-templates/gtextfsm-0.2.1/textfsm
   - pip install ansible==1.9.2
   - pip install terminal

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest
     PyYAML
     netmiko
-    gtextfsm
+    textfsm
     ansible==1.9.2
     terminal
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
tox and travis
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Update tox and travis to install `textfsm` instead of `gtextfsm`.
<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
