### PR TITLE
PARSE: Update parse module to account for new and old TextFSM packaging

### DIFF
--- a/ntc_templates/parse.py
+++ b/ntc_templates/parse.py
@@ -1,8 +1,10 @@
 """ntc_templates.parse."""
 import os
 import sys
-from textfsm.clitable import CliTableError
-import textfsm.clitable as clitable
+try:
+    from textfsm import clitable
+except ImportError:
+    import clitable
 
 
 def _get_template_dir():
@@ -36,7 +38,7 @@ def parse_output(platform=None, command=None, data=None):
     try:
         cli_table.ParseCmd(data, attrs)
         structured_data = _clitable_to_dict(cli_table)
-    except CliTableError as e:
+    except clitable.CliTableError as e:
         raise Exception('Unable to parse command "%s" on platform %s - %s' % (command, platform, str(e)))
         # Invalid or Missing template
         # module.fail_json(msg='parsing error', error=str(e))


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
parse module
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Updates to use `textfsm` instead of `gtextfsm` broke imports of textfsm. This prefers soon to be released `1.0.0` of textfsm, and attempts current module packaging of textfsm upon `ImportError`
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
