### PR TITLE
Update vyatta_vyos_show_interfaces.template

### DIFF
--- a/templates/vyatta_vyos_show_interfaces.template
+++ b/templates/vyatta_vyos_show_interfaces.template
@@ -1,5 +1,5 @@
 Value INTERFACE (\S+)
-Value List IP_ADDRESS ((?:[A-Fa-f0-9:\.]+\/\d+)|-)
+Value List IP_ADDRESS ((?:[A-Fa-f0-9:\.]+\/\d+)|-|[0-9\.]+)
 Value STATUS (\S+)
 Value DESCRIPTION (.+?)
 
@@ -13,6 +13,7 @@ Interface
   ^\S+\s+ -> Continue.Record
   ^${INTERFACE}\s+${IP_ADDRESS}\s+${STATUS}\s+(${DESCRIPTION}|)\s*$$
   ^\s+${IP_ADDRESS}\s*$$
+  ^\s+${DESCRIPTION}\s*$$
   ^-+\s+-+\s+-+\s+-+$$
   ^\s*$$
   ^. -> Error


### PR DESCRIPTION
add handling for when description is longer that netmiko terminal width.
add match for ipv4 address without mask.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request
 - Bugfix Pull Request
 - Additional Testing
 - Docs Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
