### PR TITLE
removed error when an empty line exists in command output

### DIFF
--- a/templates/cisco_wlc_ssh_show_ap_config_general.template
+++ b/templates/cisco_wlc_ssh_show_ap_config_general.template
@@ -71,4 +71,3 @@ Start
   ^\d+\s+\S+\s+\S+\s+\S+\s+\S+\s*$$
   ^\d+\s+\S+\s+\S+\s+\S+\s+\S+\s*$$
   ^FlexConnect\s+Backup\s+Auth
-  ^. -> Error


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT

cisco_wlc_ssh_show_ap_config_general.template

##### SUMMARY

the template generates an error when an empty line exists in the command output but blank lines are expected