### PR TITLE
IOS DIR: Account for spaces in permissions

### DIFF
--- a/templates/cisco_ios_dir.template
+++ b/templates/cisco_ios_dir.template
@@ -1,19 +1,15 @@
 Value Filldown FILE_SYSTEM (\S+)
 Value ID (\d+)
-Value PERMISSIONS (\S+)
+Value PERMISSIONS (.+?)
 Value SIZE (\d+)
 Value Fillup TOTAL_SIZE (\d+)
 Value Fillup TOTAL_FREE (\d+)
-Value DATE_TIME ((<no date>)|(\w+\s\d+\s\d+\s\S+\s\S+))
+Value DATE_TIME (.+?)
 Value NAME (\S+)
 
 Start
-  ^Directory of\s+${FILE_SYSTEM} -> DIR
-
-DIR
-  ^Directory of\s+${FILE_SYSTEM} -> DIR
-  ^((\s+)*${ID})\s+${PERMISSIONS}\s+${SIZE}\s+${DATE_TIME}\s+${NAME} -> Record
+  ^\s*${ID}\s+${PERMISSIONS}\s+${SIZE}\s+${DATE_TIME}\s+${NAME}\s*$$ -> Record
+  ^Directory of\s+${FILE_SYSTEM}
   ^${TOTAL_SIZE}\s+\S+\s+\S+\s\(${TOTAL_FREE} bytes free\)
 
-#
 EOF

--- a/tests/cisco_ios/dir/cisco_ios_dir.parsed
+++ b/tests/cisco_ios/dir/cisco_ios_dir.parsed
@@ -75,7 +75,7 @@ parsed_sample:
 
 - file_system: 'bootflash:/'
   id: '519171'
-  permissions: '-rw-'
+  permissions: '-rw  -'
   size: '5681'
   date_time: 'Mar 2 2015 08:48:31 +00:00'
   name: 'packages.conf'

--- a/tests/cisco_ios/dir/cisco_ios_dir.raw
+++ b/tests/cisco_ios/dir/cisco_ios_dir.raw
@@ -8,7 +8,7 @@ Directory of bootflash:/
    15  -rw-        161136640   Mar 2 2015 08:47:34 +00:00  iosxe-remote-mgmt.03.14.01.S.155-1.S1-std.ova
 519172  -rw-        250578048   Mar 2 2015 08:48:31 +00:00  csr1000v-mono-universalk9.03.14.01.S.155-1.S1-std.SPA.pkg
 519170  -rw-             4892   Mar 2 2015 08:48:30 +00:00  csr1000v-packages-universalk9.03.14.01.S.155-1.S1-std.conf
-519171  -rw-             5681   Mar 2 2015 08:48:31 +00:00  packages.conf
+519171  -rw  -             5681   Mar 2 2015 08:48:31 +00:00  packages.conf
 827425  drwx             4096   Mar 2 2015 08:49:40 +00:00  .prst_sync
 730081  drwx             4096   Mar 2 2015 08:49:43 +00:00  .rollback_timer
    16  -rw-                0   Mar 2 2015 08:49:46 +00:00  tracelogs.394


### PR DESCRIPTION
* New data was found that had spaces in permissions data.

* Update template to allow for this space using `(.+?)`.

* Remove state change as it does not seem to be doing much.

* Simplify `date_time` to use `(.+?)` and add end of line, `\s*$$` to
capture whatever text shows up between `SIZE` and `NAME`.

* Remove unnecesarry capture groups that were not assigned to named
capture groups.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request
 - Bugfix Pull Request
 - Additional Testing
 - Docs Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
