### PR TITLE
ASA INTF DETAIL: Updates to new template

### DIFF
--- a/templates/cisco_asa_show_interface_detail.template
+++ b/templates/cisco_asa_show_interface_detail.template
@@ -5,15 +5,16 @@ Value PROTOCOL_STATUS (.*)
 Value HARDWARE_TYPE ([\w ]+)
 Value BANDWIDTH (\d+\s+\w+)
 Value DELAY (\d+\s+\w+)
-Value DUPLEX (\w+\-\w+)
-Value SPEED (\d+\w+\s\w+)
+Value DUPLEX ([Ff][Uu][Ll]{2}|[Hh][Aa][Ll][Ff]|[Aa][Uu][Tt][Oo])
+Value SPEED (\d+\s*\S+|[Aa][Uu][Tt][Oo])
 Value FLOWCONTROL_IN (\w+)
 Value FLOWCONTROL_OUT (\w+)
+Value BONDED_PORT (.+?)
 Value DESCRIPTION (.*)
-Value ADDRESS ([a-zA-Z0-9]+.[a-zA-Z0-9]+.[a-zA-Z0-9]+)
-Value MTU (\d+)
-Value IP_ADDRESS (\d+\.\d+\.\d+\.\d+)
-Value NET_MASK (\d+\.\d+\.\d+\.\d+)
+Value ADDRESS ([a-zA-Z0-9]+\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+)
+Value MTU (.+?)
+Value IP_ADDRESS (.+?)
+Value NET_MASK (.+?)
 Value IN_PACKETS (\d+)
 Value IN_BYTES (\d+)
 Value NO_BUFFER (\d+)
@@ -42,6 +43,7 @@ Value COLLISIONS (\d+)
 Value INTERFACE_RESETS (\d+)
 Value LATE_COLLISIONS (\d+)
 Value DEFFERED (\d+)
+Value OUT_DECODE_DROPS (\d+)
 Value RATE_LIMIT_DROPS (\d+)
 Value SWITCH_EGRESS_POLICY_DROPS (\d+)
 Value IN_RESET_DROPS (\d+)
@@ -63,6 +65,7 @@ Value List RXRING_BYTES (\d+)
 Value List RXRING_OVERRUN (\d+)
 Value List RXRING_BLOCKS_FREE_CURR (\d+)
 Value List RXRING_BLOCKS_FREE_LOW (\d+)
+Value List RXRING_INTERFACE (.+?)
 #
 # TXRING
 Value List TXRING_NUMBER (\d+)
@@ -71,49 +74,89 @@ Value List TXRING_BYTES (\d+)
 Value List TXRING_UNDERRUN (\d+)
 Value List TXRING_BLOCKS_FREE_CURR (\d+)
 Value List TXRING_BLOCKS_FREE_LOW (\d+)
+Value List TXRING_INTERFACE (.+?)
 
 
 Start
-  ^.*Interface ${INTERFACE} "${INTERFACE_NAME}", is ${LINK_STATUS}, line protocol is ${PROTOCOL_STATUS}
-  ^\s+Hardware is ${HARDWARE_TYPE} -> Continue
-  ^.*BW ${BANDWIDTH}.*DLY ${DELAY}
-  ^.*\(${DUPLEX}.*Auto-Speed\(${SPEED}\)
-  ^\s+Input flow control is ${FLOWCONTROL_IN}, output flow control is ${FLOWCONTROL_OUT}
-  ^.*Description: ${DESCRIPTION}
-  ^.*MAC address ${ADDRESS}.*MTU ${MTU}
-  ^.*IP address ${IP_ADDRESS}, .*subnet mask ${NET_MASK}
-  ^\s+${IN_PACKETS} packets input, ${IN_BYTES} bytes, ${NO_BUFFER} no buffer
-  ^\s+Received ${BROADCASTS} broadcasts, ${RUNTS} runts, ${GIANTS} giants
-  ^\s+${IN_ERRORS} input errors, ${CRC} CRC, ${FRAME} frame, ${OVERRUN} overrun, ${IGNORED} ignored, ${ABORT} abort
-  ^\s+${IN_PAUSE_RESUME} pause/resume input
-  ^\s+${IN_PAUSE} pause input, ${IN_RESUME} resume input
-  ^\s+${L2_DECODE_DROPS} L2 decode drops
-  ^\s+${SWITCH_INGRESS_POLICY_DROPS} switch ingress policy drops
-  ^\s+${OUT_PACKETS} packets output, ${OUT_BYTES} bytes, ${UNDERRUNS} underruns
-  ^\s+${OUT_PAUSE_RESUME} pause/resume output
-  ^\s+${OUT_PAUSE} pause output, ${OUT_RESUME} resume output
-  ^\s+${OUT_ERRORS} output errors, ${COLLISIONS} collisions, ${INTERFACE_RESETS} interface resets
-  ^\s+${LATE_COLLISIONS} late collisions, ${DEFFERED} deferred
-  ^\s+${RATE_LIMIT_DROPS} rate limit drops
-  ^\s+${SWITCH_EGRESS_POLICY_DROPS} switch egress policy drops
-  ^\s+${IN_RESET_DROPS} input reset drops, ${OUT_RESET_DROPS} output reset drops
-  ^\s+VLAN identifier ${VLAN}
-  ^\s+Control Point Interface States -> ControlPoint
-  ^\s+Queue Stats -> QueueStats
-  ^\s+Available for allocation to a context -> Record
+  ^Interface -> Continue.Record
+  ^Interface\s+${INTERFACE}\s+"${INTERFACE_NAME}",\s+is\s+${LINK_STATUS},\s+line\s+protocol\s+is\s+${PROTOCOL_STATUS}
+  ^\s+Hardware\s+is\s+${HARDWARE_TYPE}.*BW\s+${BANDWIDTH}.*DLY\s+${DELAY}
+  ^\s+\S*${DUPLEX}\S*,\s+\S*?${SPEED}(?:\)|\S+)\s*$$
+  ^\s+Input\s+flow\s+control\s+is\s+${FLOWCONTROL_IN},\s+output\s+flow\s+control\s+is\s+${FLOWCONTROL_OUT}
+  ^\s+Active\s+member\s+of\s+${BONDED_PORT}\s*$$
+  ^\s+Description:\s+${DESCRIPTION}
+  ^\s+MAC\s+address\s+${ADDRESS}.*MTU\s+${MTU}\s*$$
+  ^\s+IP\s+[Aa]ddress\s+${IP_ADDRESS}(?:,\s+[Ss]ubnet\s+[Mm]ask\s+${NET_MASK})?\s*$$
+  ^\s+${IN_PACKETS}\s+packets\s+input,\s+${IN_BYTES}\s+bytes,\s+${NO_BUFFER}\s+no\s+buffer
+  ^\s+Received\s+${BROADCASTS}\s+broadcasts,\s+${RUNTS}\s+runts,\s+${GIANTS}\s+giants
+  ^\s+${IN_ERRORS}\s+input\s+errors,\s+${CRC}\s+CRC,\s+${FRAME}\s+frame,\s+${OVERRUN}\s+overrun,\s+${IGNORED}\s+ignored,\s+${ABORT}\s+abort
+  ^\s+${IN_PAUSE_RESUME}\s+pause/resume\s+input
+  ^\s+${IN_PAUSE}\s+pause\s+input,\s+${IN_RESUME}\s+resume\s+input
+  ^\s+${L2_DECODE_DROPS}\s+L2\s+decode\s+drops
+  ^\s+${SWITCH_INGRESS_POLICY_DROPS}\s+switch\s+ingress\s+policy\s+drops
+  ^\s+${OUT_PACKETS}\s+packets\s+output,\s+${OUT_BYTES}\s+bytes,\s+${UNDERRUNS}\s+underruns
+  ^\s+${OUT_PAUSE_RESUME}\s+pause/resume\s+output
+  ^\s+${OUT_PAUSE}\s+pause\s+output,\s+${OUT_RESUME}\s+resume\s+output
+  ^\s+${OUT_ERRORS}\s+output\s+errors,\s+${COLLISIONS}\s+collisions,\s+${INTERFACE_RESETS}\s+interface\s+resets
+  ^\s+${LATE_COLLISIONS}\s+late\s+collisions,\s+${DEFFERED}\s+deferred
+  ^\s+${OUT_DECODE_DROPS}\s+output\s+decode\s+drops
+  ^\s+${RATE_LIMIT_DROPS}\s+rate\s+limit\s+drops
+  ^\s+${SWITCH_EGRESS_POLICY_DROPS}\s+switch\s+egress\s+policy\s+drops
+  ^\s+${IN_RESET_DROPS}\s+input\s+reset\s+drops,\s+${OUT_RESET_DROPS}\s+output\s+reset\s+drops
+  ^\s+input\s+queue
+  ^\s+output\s+queue
+  ^\s+Queue\s+Stats:
+  ^\s+VLAN\s+identifier\s+${VLAN}
+  ^\s+Control\s+Point\s+Interface\s+States -> ControlPoint
+  ^\s+RX\[${RXRING_NUMBER}\]:\s+${RXRING_PACKETS}\s+packets,\s+${RXRING_BYTES}\s+bytes,\s+${RXRING_OVERRUN}\s+overrun -> RXRingBlocks
+  ^\s+TX\[${TXRING_NUMBER}\]:\s+${TXRING_PACKETS}\s+packets,\s+${TXRING_BYTES}\s+bytes,\s+${TXRING_UNDERRUN}\s+underruns -> TXRingBlocks
+  ^\s+Available\s+for\s+allocation\s+to\s+a\s+context
+  ^Interface -> Continue.Record
+  ^Interface\s+${INTERFACE}\s+"${INTERFACE_NAME}",\s+is\s+${LINK_STATUS},\s+line\s+protocol\s+is\s+${PROTOCOL_STATUS}
+  ^\s+Topology\s+Information: -> Topology
+  ^\s*$$
+  ^. -> Error
 
 ControlPoint
-  ^\s+Interface number is ${CONTROL_INTERFACE_NUMBER}
-  ^\s+Interface config status is ${CONTROL_INTERFACE_CONFIG_STATUS}
-  ^\s+Interface state is ${CONTROL_INTERFACE_STATE} -> Record Start
-
-QueueStats
-  ^\s+RX\[${RXRING_NUMBER}\]: ${RXRING_PACKETS} packets, ${RXRING_BYTES} bytes, ${RXRING_OVERRUN} overrun -> RXRingBlocks
-  ^\s+TX\[${TXRING_NUMBER}\]: ${TXRING_PACKETS} packets, ${TXRING_BYTES} bytes, ${TXRING_UNDERRUN} underruns -> TXRingBlocks
-  ^\s+Control Point Interface States -> ControlPoint
+  ^\s+Interface\s+number\s+is\s+${CONTROL_INTERFACE_NUMBER}
+  ^\s+Interface\s+config\s+status\s+is\s+${CONTROL_INTERFACE_CONFIG_STATUS}
+  ^\s+Interface\s+state\s+is\s+${CONTROL_INTERFACE_STATE}
+  ^Interface -> Continue.Record
+  ^Interface\s+${INTERFACE}\s+"${INTERFACE_NAME}",\s+is\s+${LINK_STATUS},\s+line\s+protocol\s+is\s+${PROTOCOL_STATUS} -> Start
+  ^\s+Queue\s+Stats:
+  ^\s+RX\[${RXRING_NUMBER}\]:\s+${RXRING_PACKETS}\s+packets,\s+${RXRING_BYTES}\s+bytes,\s+${RXRING_OVERRUN}\s+overrun -> RXRingBlocks
+  ^\s+TX\[${TXRING_NUMBER}\]:\s+${TXRING_PACKETS}\s+packets,\s+${TXRING_BYTES}\s+bytes,\s+${TXRING_UNDERRUN}\s+underruns -> TXRingBlocks
 
 RXRingBlocks
-  ^\s+Blocks free curr/low: ${RXRING_BLOCKS_FREE_CURR}/${RXRING_BLOCKS_FREE_LOW} -> QueueStats
+  ^\s+RX\[${RXRING_NUMBER}\]:\s+${RXRING_PACKETS}\s+packets,\s+${RXRING_BYTES}\s+bytes,\s+${RXRING_OVERRUN}\s+overrun
+  ^\s+Blocks\s+free\s+curr/low:\s+${RXRING_BLOCKS_FREE_CURR}/${RXRING_BLOCKS_FREE_LOW}
+  ^\s+Used\s+by\s+${RXRING_INTERFACE}\s*$$
+  ^\s+TX\[${TXRING_NUMBER}\]:\s+${TXRING_PACKETS}\s+packets,\s+${TXRING_BYTES}\s+bytes,\s+${TXRING_UNDERRUN}\s+underruns -> TXRingBlocks
+  ^\s+Topology\s+Information: -> Topology
+  ^\s+Control\s+Point\s+Interface\s+States -> ControlPoint
+  ^Interface -> Continue.Record
+  ^Interface\s+${INTERFACE}\s+"${INTERFACE_NAME}",\s+is\s+${LINK_STATUS},\s+line\s+protocol\s+is\s+${PROTOCOL_STATUS} -> Start
+  ^\s*$$
+  ^. -> Error
 
 TXRingBlocks
-  ^\s+Blocks free curr/low: ${TXRING_BLOCKS_FREE_CURR}/${TXRING_BLOCKS_FREE_LOW} -> QueueStats
+  ^\s+TX\[${TXRING_NUMBER}\]:\s+${TXRING_PACKETS}\s+packets,\s+${TXRING_BYTES}\s+bytes,\s+${TXRING_UNDERRUN}\s+underruns
+  ^\s+Blocks\s+free\s+curr/low:\s+${TXRING_BLOCKS_FREE_CURR}/${TXRING_BLOCKS_FREE_LOW}
+  ^\s+Used\s+by\s+${TXRING_INTERFACE}\s*$$
+  ^\s+Topology\s+Information: -> Topology
+  ^\s+RX\[${RXRING_NUMBER}\]:\s+${RXRING_PACKETS}\s+packets,\s+${RXRING_BYTES}\s+bytes,\s+${RXRING_OVERRUN}\s+overrun -> RXRingBlocks
+  ^\s+Control\s+Point\s+Interface\s+States -> ControlPoint
+  ^Interface -> Continue.Record
+  ^Interface\s+${INTERFACE}\s+"${INTERFACE_NAME}",\s+is\s+${LINK_STATUS},\s+line\s+protocol\s+is\s+${PROTOCOL_STATUS} -> Start
+  ^\s*$$
+  ^. -> Error
+
+Topology
+  ^\s{4,}\S+
+  ^\s+Control\s+Point\s+Interface\s+States -> ControlPoint
+  ^Interface -> Continue.Record
+  ^Interface\s+${INTERFACE}\s+"${INTERFACE_NAME}",\s+is\s+${LINK_STATUS},\s+line\s+protocol\s+is\s+${PROTOCOL_STATUS} -> Start
+  ^\s+RX\[${RXRING_NUMBER}\]:\s+${RXRING_PACKETS}\s+packets,\s+${RXRING_BYTES}\s+bytes,\s+${RXRING_OVERRUN}\s+overrun -> RXRingBlocks
+  ^\s+TX\[${TXRING_NUMBER}\]:\s+${TXRING_PACKETS}\s+packets,\s+${TXRING_BYTES}\s+bytes,\s+${TXRING_UNDERRUN}\s+underruns -> TXRingBlocks
+  ^\s*$$
+  ^. -> Error

--- a/tests/cisco_asa/show_interface_detail/cisco_asa_show_interface_detail.parsed
+++ b/tests/cisco_asa/show_interface_detail/cisco_asa_show_interface_detail.parsed
@@ -4,6 +4,7 @@ parsed_sample:
 -   abort: '0'
     address: f0f7.5543.a522
     bandwidth: 1000 Mbps
+    bonded_port: ''
     broadcasts: '18'
     collisions: '0'
     control_interface_config_status: active
@@ -13,7 +14,7 @@ parsed_sample:
     deffered: '0'
     delay: 10 usec
     description: LAN Failover Interface
-    duplex: Full-duplex
+    duplex: Full
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
     frame: '0'
@@ -38,6 +39,7 @@ parsed_sample:
     net_mask: 255.255.255.252
     no_buffer: '0'
     out_bytes: '23362268244'
+    out_decode_drops: ''
     out_errors: '0'
     out_packets: '164279548'
     out_pause: ''
@@ -51,6 +53,7 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
@@ -60,6 +63,7 @@ parsed_sample:
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
@@ -68,6 +72,7 @@ parsed_sample:
 -   abort: '0'
     address: f0f7.5543.a523
     bandwidth: 1000 Mbps
+    bonded_port: ''
     broadcasts: '2'
     collisions: '0'
     control_interface_config_status: active
@@ -77,7 +82,7 @@ parsed_sample:
     deffered: '0'
     delay: 10 usec
     description: STATE Failover Interface
-    duplex: Full-duplex
+    duplex: Full
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
     frame: '0'
@@ -102,6 +107,7 @@ parsed_sample:
     net_mask: 255.255.255.252
     no_buffer: '0'
     out_bytes: '834717617298'
+    out_decode_drops: ''
     out_errors: '0'
     out_packets: '758965289'
     out_pause: ''
@@ -115,6 +121,7 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
@@ -124,270 +131,288 @@ parsed_sample:
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
     underruns: '0'
     vlan: ''
--   abort: ''
-    address: ''
+-   abort: '0'
+    address: 'f0f7.5543.a524'
     bandwidth: 1000 Mbps
-    broadcasts: ''
-    collisions: ''
-    control_interface_config_status: ''
-    control_interface_number: ''
-    control_interface_state: ''
-    crc: ''
-    deffered: ''
+    bonded_port: ''
+    broadcasts: '0'
+    collisions: '0'
+    control_interface_config_status: 'not active'
+    control_interface_number: '10'
+    control_interface_state: 'not active'
+    crc: '0'
+    deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Auto'
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
-    frame: ''
-    giants: ''
+    frame: '0'
+    giants: '0'
     hardware_type: bcm56800 rev 01
-    ignored: ''
-    in_bytes: ''
-    in_errors: ''
-    in_packets: ''
+    ignored: '0'
+    in_bytes: '0'
+    in_errors: '0'
+    in_packets: '0'
     in_pause: ''
-    in_pause_resume: ''
-    in_reset_drops: ''
+    in_pause_resume: '0'
+    in_reset_drops: '0'
     in_resume: ''
     interface: GigabitEthernet0/2
     interface_name: ''
-    interface_resets: ''
-    ip_address: ''
-    l2_decode_drops: ''
-    late_collisions: ''
+    interface_resets: '0'
+    ip_address: 'unassigned'
+    l2_decode_drops: '0'
+    late_collisions: '0'
     link_status: administratively down
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
-    no_buffer: ''
-    out_bytes: ''
-    out_errors: ''
-    out_packets: ''
+    no_buffer: '0'
+    out_bytes: '0'
+    out_decode_drops: ''
+    out_errors: '0'
+    out_packets: '0'
     out_pause: ''
-    out_pause_resume: ''
-    out_reset_drops: ''
+    out_pause_resume: '0'
+    out_reset_drops: '0'
     out_resume: ''
-    overrun: ''
+    overrun: '0'
     protocol_status: down
-    rate_limit_drops: ''
-    runts: ''
+    rate_limit_drops: '0'
+    runts: '0'
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
-    speed: ''
-    switch_egress_policy_drops: ''
-    switch_ingress_policy_drops: ''
+    speed: 'Auto'
+    switch_egress_policy_drops: '0'
+    switch_ingress_policy_drops: '0'
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
-    underruns: ''
+    underruns: '0'
     vlan: ''
--   abort: ''
-    address: ''
+-   abort: '0'
+    address: 'f0f7.5543.a525'
     bandwidth: 1000 Mbps
-    broadcasts: ''
-    collisions: ''
-    control_interface_config_status: ''
-    control_interface_number: ''
-    control_interface_state: ''
-    crc: ''
-    deffered: ''
+    bonded_port: ''
+    broadcasts: '0'
+    collisions: '0'
+    control_interface_config_status: 'not active'
+    control_interface_number: '11'
+    control_interface_state: 'not active'
+    crc: '0'
+    deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Auto'
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
-    frame: ''
-    giants: ''
+    frame: '0'
+    giants: '0'
     hardware_type: bcm56800 rev 01
-    ignored: ''
-    in_bytes: ''
-    in_errors: ''
-    in_packets: ''
+    ignored: '0'
+    in_bytes: '0'
+    in_errors: '0'
+    in_packets: '0'
     in_pause: ''
-    in_pause_resume: ''
-    in_reset_drops: ''
+    in_pause_resume: '0'
+    in_reset_drops: '0'
     in_resume: ''
     interface: GigabitEthernet0/3
     interface_name: ''
-    interface_resets: ''
-    ip_address: ''
-    l2_decode_drops: ''
-    late_collisions: ''
+    interface_resets: '0'
+    ip_address: 'unassigned'
+    l2_decode_drops: '0'
+    late_collisions: '0'
     link_status: administratively down
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
-    no_buffer: ''
-    out_bytes: ''
-    out_errors: ''
-    out_packets: ''
+    no_buffer: '0'
+    out_bytes: '0'
+    out_decode_drops: ''
+    out_errors: '0'
+    out_packets: '0'
     out_pause: ''
-    out_pause_resume: ''
-    out_reset_drops: ''
+    out_pause_resume: '0'
+    out_reset_drops: '0'
     out_resume: ''
-    overrun: ''
+    overrun: '0'
     protocol_status: down
-    rate_limit_drops: ''
-    runts: ''
+    rate_limit_drops: '0'
+    runts: '0'
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
-    speed: ''
-    switch_egress_policy_drops: ''
-    switch_ingress_policy_drops: ''
+    speed: 'Auto'
+    switch_egress_policy_drops: '0'
+    switch_ingress_policy_drops: '0'
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
-    underruns: ''
+    underruns: '0'
     vlan: ''
--   abort: ''
-    address: ''
+-   abort: '0'
+    address: 'f0f7.5543.a526'
     bandwidth: 1000 Mbps
-    broadcasts: ''
-    collisions: ''
-    control_interface_config_status: ''
-    control_interface_number: ''
-    control_interface_state: ''
-    crc: ''
-    deffered: ''
+    bonded_port: ''
+    broadcasts: '0'
+    collisions: '0'
+    control_interface_config_status: 'not active'
+    control_interface_number: '12'
+    control_interface_state: 'not active'
+    crc: '0'
+    deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Auto'
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
-    frame: ''
-    giants: ''
+    frame: '0'
+    giants: '0'
     hardware_type: bcm56800 rev 01
-    ignored: ''
-    in_bytes: ''
-    in_errors: ''
-    in_packets: ''
+    ignored: '0'
+    in_bytes: '0'
+    in_errors: '0'
+    in_packets: '0'
     in_pause: ''
-    in_pause_resume: ''
-    in_reset_drops: ''
+    in_pause_resume: '0'
+    in_reset_drops: '0'
     in_resume: ''
     interface: GigabitEthernet0/4
     interface_name: ''
-    interface_resets: ''
-    ip_address: ''
-    l2_decode_drops: ''
-    late_collisions: ''
+    interface_resets: '0'
+    ip_address: 'unassigned'
+    l2_decode_drops: '0'
+    late_collisions: '0'
     link_status: administratively down
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
-    no_buffer: ''
-    out_bytes: ''
-    out_errors: ''
-    out_packets: ''
+    no_buffer: '0'
+    out_bytes: '0'
+    out_decode_drops: ''
+    out_errors: '0'
+    out_packets: '0'
     out_pause: ''
-    out_pause_resume: ''
-    out_reset_drops: ''
+    out_pause_resume: '0'
+    out_reset_drops: '0'
     out_resume: ''
-    overrun: ''
+    overrun: '0'
     protocol_status: down
-    rate_limit_drops: ''
-    runts: ''
+    rate_limit_drops: '0'
+    runts: '0'
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
-    speed: ''
-    switch_egress_policy_drops: ''
-    switch_ingress_policy_drops: ''
+    speed: 'Auto'
+    switch_egress_policy_drops: '0'
+    switch_ingress_policy_drops: '0'
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
-    underruns: ''
+    underruns: '0'
     vlan: ''
--   abort: ''
-    address: ''
+-   abort: '0'
+    address: 'f0f7.5543.a527'
     bandwidth: 1000 Mbps
-    broadcasts: ''
-    collisions: ''
-    control_interface_config_status: ''
-    control_interface_number: ''
-    control_interface_state: ''
-    crc: ''
-    deffered: ''
+    bonded_port: ''
+    broadcasts: '0'
+    collisions: '0'
+    control_interface_config_status: 'not active'
+    control_interface_number: '13'
+    control_interface_state: 'not active'
+    crc: '0'
+    deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Auto'
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
-    frame: ''
-    giants: ''
+    frame: '0'
+    giants: '0'
     hardware_type: bcm56800 rev 01
-    ignored: ''
-    in_bytes: ''
-    in_errors: ''
-    in_packets: ''
+    ignored: '0'
+    in_bytes: '0'
+    in_errors: '0'
+    in_packets: '0'
     in_pause: ''
-    in_pause_resume: ''
-    in_reset_drops: ''
+    in_pause_resume: '0'
+    in_reset_drops: '0'
     in_resume: ''
     interface: GigabitEthernet0/5
     interface_name: ''
-    interface_resets: ''
-    ip_address: ''
-    l2_decode_drops: ''
-    late_collisions: ''
+    interface_resets: '0'
+    ip_address: 'unassigned'
+    l2_decode_drops: '0'
+    late_collisions: '0'
     link_status: administratively down
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
-    no_buffer: ''
-    out_bytes: ''
-    out_errors: ''
-    out_packets: ''
+    no_buffer: '0'
+    out_bytes: '0'
+    out_decode_drops: ''
+    out_errors: '0'
+    out_packets: '0'
     out_pause: ''
-    out_pause_resume: ''
-    out_reset_drops: ''
+    out_pause_resume: '0'
+    out_reset_drops: '0'
     out_resume: ''
-    overrun: ''
+    overrun: '0'
     protocol_status: down
-    rate_limit_drops: ''
-    runts: ''
+    rate_limit_drops: '0'
+    runts: '0'
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
-    speed: ''
-    switch_egress_policy_drops: ''
-    switch_ingress_policy_drops: ''
+    speed: 'Auto'
+    switch_egress_policy_drops: '0'
+    switch_ingress_policy_drops: '0'
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
-    underruns: ''
+    underruns: '0'
     vlan: ''
 -   abort: '0'
-    address: ''
+    address: '0000.0001.0001'
     bandwidth: 10000 Mbps
+    bonded_port: ''
     broadcasts: '193961'
     collisions: '0'
     control_interface_config_status: active
@@ -397,7 +422,7 @@ parsed_sample:
     deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Full'
     flowcontrol_in: 'on'
     flowcontrol_out: 'off'
     frame: '0'
@@ -414,14 +439,15 @@ parsed_sample:
     interface: Internal-Data0/0
     interface_name: ''
     interface_resets: '1'
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: '0'
     late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: '0'
     out_bytes: '19710792216623'
+    out_decode_drops: '0'
     out_errors: '0'
     out_packets: '22840594539'
     out_pause: '0'
@@ -432,92 +458,29 @@ parsed_sample:
     protocol_status: up
     rate_limit_drops: ''
     runts: '0'
-    rxring_blocks_free_curr:
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    rxring_blocks_free_low:
-    - '311'
-    - '311'
-    - '339'
-    - '369'
-    - '507'
-    rxring_bytes:
-    - '8613178051164'
-    - '6924744308770'
-    - '5930247361074'
-    - '6508202351390'
-    - '22945468790'
-    rxring_number:
-    - '00'
-    - '01'
-    - '02'
-    - '03'
-    - '04'
-    rxring_overrun:
-    - '33671'
-    - '3892'
-    - '5983'
-    - '6471'
-    - '0'
-    rxring_packets:
-    - '11928867434'
-    - '9936555115'
-    - '8885121010'
-    - '9774040102'
-    - '170322028'
-    speed: ''
+    rxring_blocks_free_curr: ['511', '511', '511', '511', '511']
+    rxring_blocks_free_low: ['311', '311', '339', '369', '507']
+    rxring_bytes: ['8613178051164', '6924744308770', '5930247361074', '6508202351390', '22945468790']
+    rxring_interface: []
+    rxring_number: ['00', '01', '02', '03', '04']
+    rxring_overrun: ['33671', '3892', '5983', '6471', '0']
+    rxring_packets: ['11928867434', '9936555115', '8885121010', '9774040102', '170322028']
+    speed: '10000 Mbps'
     switch_egress_policy_drops: ''
     switch_ingress_policy_drops: ''
-    txring_blocks_free_curr:
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    txring_blocks_free_low:
-    - '349'
-    - '350'
-    - '350'
-    - '350'
-    - '507'
-    - '486'
-    txring_bytes:
-    - '6276748798963'
-    - '4562626128086'
-    - '3813812735685'
-    - '4195831926616'
-    - '24019250372'
-    - '837753453654'
-    txring_number:
-    - '00'
-    - '01'
-    - '02'
-    - '03'
-    - '04'
-    - '05'
-    txring_packets:
-    - '7034786488'
-    - '5193693399'
-    - '4620598548'
-    - '5068271291'
-    - '164279550'
-    - '758965324'
-    txring_underrun:
-    - '0'
-    - '0'
-    - '0'
-    - '0'
-    - '0'
-    - '0'
+    txring_blocks_free_curr: ['511', '511', '511', '511', '511', '511']
+    txring_blocks_free_low: ['349', '350', '350', '350', '507', '486']
+    txring_bytes: ['6276748798963', '4562626128086', '3813812735685', '4195831926616', '24019250372', '837753453654']
+    txring_interface: ['GigabitEthernet0/0', 'GigabitEthernet0/1']
+    txring_number: ['00', '01', '02', '03', '04', '05']
+    txring_packets: ['7034786488', '5193693399', '4620598548', '5068271291', '164279550', '758965324']
+    txring_underrun: ['0', '0', '0', '0', '0', '0']
     underruns: '0'
     vlan: ''
 -   abort: '0'
-    address: ''
+    address: '0000.0001.0002'
     bandwidth: 10000 Mbps
+    bonded_port: ''
     broadcasts: '237991'
     collisions: '0'
     control_interface_config_status: active
@@ -527,7 +490,7 @@ parsed_sample:
     deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Full'
     flowcontrol_in: 'on'
     flowcontrol_out: 'off'
     frame: '0'
@@ -544,14 +507,15 @@ parsed_sample:
     interface: Internal-Data0/1
     interface_name: ''
     interface_resets: '1'
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: '0'
     late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: '0'
     out_bytes: '20171793812896'
+    out_decode_drops: '0'
     out_errors: '0'
     out_packets: '29187689876'
     out_pause: '0'
@@ -562,92 +526,29 @@ parsed_sample:
     protocol_status: up
     rate_limit_drops: ''
     runts: '0'
-    rxring_blocks_free_curr:
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    rxring_blocks_free_low:
-    - '358'
-    - '394'
-    - '359'
-    - '389'
-    rxring_bytes:
-    - '12717109454320'
-    - '6735149484197'
-    - '8351432550533'
-    - '7130518429589'
-    rxring_number:
-    - '00'
-    - '01'
-    - '02'
-    - '03'
-    rxring_overrun:
-    - '1026'
-    - '2704'
-    - '801'
-    - '542'
-    rxring_packets:
-    - '15538406285'
-    - '9970135924'
-    - '17849754640'
-    - '10110661702'
-    speed: ''
+    rxring_blocks_free_curr: ['511', '511', '511', '511']
+    rxring_blocks_free_low: ['358', '394', '359', '389']
+    rxring_bytes: ['12717109454320', '6735149484197', '8351432550533', '7130518429589']
+    rxring_interface: []
+    rxring_number: ['00', '01', '02', '03']
+    rxring_overrun: ['1026', '2704', '801', '542']
+    rxring_packets: ['15538406285', '9970135924', '17849754640', '10110661702']
+    speed: '10000 Mbps'
     switch_egress_policy_drops: ''
     switch_ingress_policy_drops: ''
-    txring_blocks_free_curr:
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    txring_blocks_free_low:
-    - '349'
-    - '351'
-    - '345'
-    - '342'
-    - '511'
-    - '511'
-    - '511'
-    txring_bytes:
-    - '4975556841210'
-    - '4268946532826'
-    - '6045848459484'
-    - '4881441983697'
-    - '0'
-    - '0'
-    - '0'
-    txring_number:
-    - '00'
-    - '01'
-    - '02'
-    - '03'
-    - '04'
-    - '05'
-    - '06'
-    txring_packets:
-    - '5792237421'
-    - '4768859986'
-    - '12970769201'
-    - '5655823274'
-    - '0'
-    - '0'
-    - '0'
-    txring_underrun:
-    - '0'
-    - '0'
-    - '0'
-    - '0'
-    - '0'
-    - '0'
-    - '0'
+    txring_blocks_free_curr: ['511', '511', '511', '511', '511', '511', '511']
+    txring_blocks_free_low: ['349', '351', '345', '342', '511', '511', '511']
+    txring_bytes: ['4975556841210', '4268946532826', '6045848459484', '4881441983697', '0', '0', '0']
+    txring_interface: ['GigabitEthernet0/2', 'GigabitEthernet0/3', 'GigabitEthernet0/4']
+    txring_number: ['00', '01', '02', '03', '04', '05', '06']
+    txring_packets: ['5792237421', '4768859986', '12970769201', '5655823274', '0', '0', '0']
+    txring_underrun: ['0', '0', '0', '0', '0', '0', '0']
     underruns: '0'
     vlan: ''
 -   abort: '0'
-    address: ''
+    address: '0000.0001.0004'
     bandwidth: 10000 Mbps
+    bonded_port: ''
     broadcasts: '98334'
     collisions: '0'
     control_interface_config_status: active
@@ -657,7 +558,7 @@ parsed_sample:
     deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Full'
     flowcontrol_in: 'on'
     flowcontrol_out: 'off'
     frame: '0'
@@ -674,14 +575,15 @@ parsed_sample:
     interface: Internal-Data0/2
     interface_name: ''
     interface_resets: '1'
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: '0'
     late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: '0'
     out_bytes: '173237932025004'
+    out_decode_drops: '0'
     out_errors: '0'
     out_packets: '472460832718'
     out_pause: '0'
@@ -692,92 +594,29 @@ parsed_sample:
     protocol_status: up
     rate_limit_drops: ''
     runts: '0'
-    rxring_blocks_free_curr:
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    rxring_blocks_free_low:
-    - '384'
-    - '396'
-    - '384'
-    - '394'
-    rxring_bytes:
-    - '8861585758086'
-    - '14845677833920'
-    - '7489829408483'
-    - '8285221609828'
-    rxring_number:
-    - '00'
-    - '01'
-    - '02'
-    - '03'
-    rxring_overrun:
-    - '5515'
-    - '3134'
-    - '858'
-    - '1400'
-    rxring_packets:
-    - '13231072890'
-    - '20193376457'
-    - '12027933127'
-    - '13154587757'
-    speed: ''
+    rxring_blocks_free_curr: ['511', '511', '511', '511']
+    rxring_blocks_free_low: ['384', '396', '384', '394']
+    rxring_bytes: ['8861585758086', '14845677833920', '7489829408483', '8285221609828']
+    rxring_interface: []
+    rxring_number: ['00', '01', '02', '03']
+    rxring_overrun: ['5515', '3134', '858', '1400']
+    rxring_packets: ['13231072890', '20193376457', '12027933127', '13154587757']
+    speed: '10000 Mbps'
     switch_egress_policy_drops: ''
     switch_ingress_policy_drops: ''
-    txring_blocks_free_curr:
-    - '511'
-    - '510'
-    - '511'
-    - '505'
-    - '511'
-    - '508'
-    - '511'
-    txring_blocks_free_low:
-    - '349'
-    - '349'
-    - '342'
-    - '311'
-    - '511'
-    - '0'
-    - '170'
-    txring_bytes:
-    - '6472090504001'
-    - '12645630943922'
-    - '5085252075635'
-    - '4988646702498'
-    - '0'
-    - '127322520663605'
-    - '16723791170491'
-    txring_number:
-    - '00'
-    - '01'
-    - '02'
-    - '03'
-    - '04'
-    - '05'
-    - '06'
-    txring_packets:
-    - '7589052992'
-    - '15755071022'
-    - '6680981379'
-    - '6484398780'
-    - '0'
-    - '415140458466'
-    - '20810870169'
-    txring_underrun:
-    - '0'
-    - '0'
-    - '0'
-    - '0'
-    - '0'
-    - '2905646'
-    - '0'
+    txring_blocks_free_curr: ['511', '510', '511', '505', '511', '508', '511']
+    txring_blocks_free_low: ['349', '349', '342', '311', '511', '0', '170']
+    txring_bytes: ['6472090504001', '12645630943922', '5085252075635', '4988646702498', '0', '127322520663605', '16723791170491']
+    txring_interface: ['TenGigabitEthernet0/6', 'TenGigabitEthernet0/9', 'TenGigabitEthernet0/8']
+    txring_number: ['00', '01', '02', '03', '04', '05', '06']
+    txring_packets: ['7589052992', '15755071022', '6680981379', '6484398780', '0', '415140458466', '20810870169']
+    txring_underrun: ['0', '0', '0', '0', '0', '2905646', '0']
     underruns: '2905646'
     vlan: ''
 -   abort: '0'
-    address: ''
+    address: '0000.0001.0003'
     bandwidth: 10000 Mbps
+    bonded_port: ''
     broadcasts: '53915'
     collisions: '0'
     control_interface_config_status: active
@@ -787,7 +626,7 @@ parsed_sample:
     deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Full'
     flowcontrol_in: 'on'
     flowcontrol_out: 'off'
     frame: '0'
@@ -804,14 +643,15 @@ parsed_sample:
     interface: Internal-Data0/3
     interface_name: ''
     interface_resets: '1'
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: '0'
     late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: '0'
     out_bytes: '439462480886576'
+    out_decode_drops: '0'
     out_errors: '0'
     out_packets: '479068686555'
     out_pause: '0'
@@ -822,86 +662,29 @@ parsed_sample:
     protocol_status: up
     rate_limit_drops: ''
     runts: '0'
-    rxring_blocks_free_curr:
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    rxring_blocks_free_low:
-    - '377'
-    - '340'
-    - '152'
-    - '362'
-    rxring_bytes:
-    - '6455848237095'
-    - '7108517208857'
-    - '528392087186847'
-    - '7694773726910'
-    rxring_number:
-    - '00'
-    - '01'
-    - '02'
-    - '03'
-    rxring_overrun:
-    - '11242'
-    - '8535'
-    - '457881225'
-    - '9369'
-    rxring_packets:
-    - '9317849354'
-    - '12456612163'
-    - '818537242486'
-    - '11414151630'
-    speed: ''
+    rxring_blocks_free_curr: ['511', '511', '511', '511']
+    rxring_blocks_free_low: ['377', '340', '152', '362']
+    rxring_bytes: ['6455848237095', '7108517208857', '528392087186847', '7694773726910']
+    rxring_interface: []
+    rxring_number: ['00', '01', '02', '03']
+    rxring_overrun: ['11242', '8535', '457881225', '9369']
+    rxring_packets: ['9317849354', '12456612163', '818537242486', '11414151630']
+    speed: '10000 Mbps'
     switch_egress_policy_drops: ''
     switch_ingress_policy_drops: ''
-    txring_blocks_free_curr:
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    - '511'
-    txring_blocks_free_low:
-    - '349'
-    - '349'
-    - '282'
-    - '313'
-    - '511'
-    - '511'
-    txring_bytes:
-    - '4204729002116'
-    - '4487948642586'
-    - '425299352333798'
-    - '5470450911421'
-    - '0'
-    - '0'
-    txring_number:
-    - '00'
-    - '01'
-    - '02'
-    - '03'
-    - '04'
-    - '05'
-    txring_packets:
-    - '4776785546'
-    - '6150915656'
-    - '460988499302'
-    - '7152486058'
-    - '0'
-    - '0'
-    txring_underrun:
-    - '0'
-    - '0'
-    - '0'
-    - '0'
-    - '0'
-    - '0'
+    txring_blocks_free_curr: ['511', '511', '511', '511', '511', '511']
+    txring_blocks_free_low: ['349', '349', '282', '313', '511', '511']
+    txring_bytes: ['4204729002116', '4487948642586', '425299352333798', '5470450911421', '0', '0']
+    txring_interface: ['GigabitEthernet0/5', 'TenGigabitEthernet0/7']
+    txring_number: ['00', '01', '02', '03', '04', '05']
+    txring_packets: ['4776785546', '6150915656', '460988499302', '7152486058', '0', '0']
+    txring_underrun: ['0', '0', '0', '0', '0', '0']
     underruns: '0'
     vlan: ''
 -   abort: '0'
-    address: ''
+    address: '0000.0100.001d'
     bandwidth: 10000 Mbps
+    bonded_port: ''
     broadcasts: '5014'
     collisions: '0'
     control_interface_config_status: active
@@ -911,7 +694,7 @@ parsed_sample:
     deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Full'
     flowcontrol_in: 'on'
     flowcontrol_out: 'on'
     frame: '0'
@@ -928,14 +711,15 @@ parsed_sample:
     interface: Internal-Data0/4
     interface_name: ''
     interface_resets: '0'
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: ''
     late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: '0'
     out_bytes: '27999352911090'
+    out_decode_drops: ''
     out_errors: '0'
     out_packets: '40694946838'
     out_pause: ''
@@ -949,23 +733,26 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
-    speed: ''
+    speed: '10000 Mbps'
     switch_egress_policy_drops: '0'
     switch_ingress_policy_drops: '0'
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
     underruns: '0'
     vlan: ''
 -   abort: '0'
-    address: ''
+    address: '0000.0100.001e'
     bandwidth: 10000 Mbps
+    bonded_port: ''
     broadcasts: '4'
     collisions: '0'
     control_interface_config_status: active
@@ -975,7 +762,7 @@ parsed_sample:
     deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Full'
     flowcontrol_in: 'on'
     flowcontrol_out: 'on'
     frame: '0'
@@ -992,14 +779,15 @@ parsed_sample:
     interface: Internal-Data0/5
     interface_name: ''
     interface_resets: '0'
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: ''
     late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: '0'
     out_bytes: '34934208273981'
+    out_decode_drops: ''
     out_errors: '0'
     out_packets: '53468957755'
     out_pause: ''
@@ -1013,23 +801,26 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
-    speed: ''
+    speed: '10000 Mbps'
     switch_egress_policy_drops: '0'
     switch_ingress_policy_drops: '0'
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
     underruns: '0'
     vlan: ''
 -   abort: '0'
-    address: ''
+    address: '0000.0100.001f'
     bandwidth: 10000 Mbps
+    bonded_port: ''
     broadcasts: '22'
     collisions: '0'
     control_interface_config_status: active
@@ -1039,7 +830,7 @@ parsed_sample:
     deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Full'
     flowcontrol_in: 'on'
     flowcontrol_out: 'on'
     frame: '0'
@@ -1056,14 +847,15 @@ parsed_sample:
     interface: Internal-Data0/6
     interface_name: ''
     interface_resets: '0'
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: ''
     late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: '0'
     out_bytes: '39482316159290'
+    out_decode_drops: ''
     out_errors: '0'
     out_packets: '58606973721'
     out_pause: ''
@@ -1077,23 +869,26 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
-    speed: ''
+    speed: '10000 Mbps'
     switch_egress_policy_drops: '0'
     switch_ingress_policy_drops: '0'
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
     underruns: '0'
     vlan: ''
 -   abort: '0'
-    address: ''
+    address: '0000.0100.0020'
     bandwidth: 10000 Mbps
+    bonded_port: ''
     broadcasts: '5'
     collisions: '0'
     control_interface_config_status: active
@@ -1103,7 +898,7 @@ parsed_sample:
     deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Full'
     flowcontrol_in: 'on'
     flowcontrol_out: 'on'
     frame: '0'
@@ -1120,14 +915,15 @@ parsed_sample:
     interface: Internal-Data0/7
     interface_name: ''
     interface_resets: '0'
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: ''
     late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: '0'
     out_bytes: '549964199797166'
+    out_decode_drops: ''
     out_errors: '0'
     out_packets: '852183755510'
     out_pause: ''
@@ -1141,70 +937,75 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
-    speed: ''
+    speed: '10000 Mbps'
     switch_egress_policy_drops: '0'
     switch_ingress_policy_drops: '0'
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
     underruns: '0'
     vlan: ''
--   abort: ''
-    address: ''
+-   abort: '0'
+    address: 'f0f7.5543.a520'
     bandwidth: 1000 Mbps
-    broadcasts: ''
-    collisions: ''
-    control_interface_config_status: ''
-    control_interface_number: ''
-    control_interface_state: ''
-    crc: ''
-    deffered: ''
+    bonded_port: ''
+    broadcasts: '33364282'
+    collisions: '0'
+    control_interface_config_status: 'active'
+    control_interface_number: '6'
+    control_interface_state: 'active'
+    crc: '0'
+    deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: Full-duplex
+    duplex: Full
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
-    frame: ''
-    giants: ''
+    frame: '0'
+    giants: '0'
     hardware_type: i82574L rev00
-    ignored: ''
-    in_bytes: ''
-    in_errors: ''
-    in_packets: ''
-    in_pause: ''
+    ignored: '0'
+    in_bytes: '18346216501'
+    in_errors: '0'
+    in_packets: '187312178'
+    in_pause: '0'
     in_pause_resume: ''
-    in_reset_drops: ''
-    in_resume: ''
+    in_reset_drops: '3'
+    in_resume: '0'
     interface: Management0/0
     interface_name: ''
-    interface_resets: ''
-    ip_address: ''
-    l2_decode_drops: ''
-    late_collisions: ''
+    interface_resets: '2'
+    ip_address: 'unassigned'
+    l2_decode_drops: '0'
+    late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
-    no_buffer: ''
-    out_bytes: ''
-    out_errors: ''
-    out_packets: ''
-    out_pause: ''
+    no_buffer: '0'
+    out_bytes: '69865717975'
+    out_decode_drops: ''
+    out_errors: '0'
+    out_packets: '365077501'
+    out_pause: '0'
     out_pause_resume: ''
-    out_reset_drops: ''
-    out_resume: ''
-    overrun: ''
+    out_reset_drops: '0'
+    out_resume: '0'
+    overrun: '0'
     protocol_status: up
     rate_limit_drops: ''
-    runts: ''
+    runts: '0'
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
@@ -1214,78 +1015,84 @@ parsed_sample:
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
-    underruns: ''
+    underruns: '0'
     vlan: ''
--   abort: ''
-    address: ''
+-   abort: '0'
+    address: 'f0f7.5543.a521'
     bandwidth: 1000 Mbps
-    broadcasts: ''
-    collisions: ''
-    control_interface_config_status: ''
-    control_interface_number: ''
-    control_interface_state: ''
-    crc: ''
-    deffered: ''
+    bonded_port: ''
+    broadcasts: '0'
+    collisions: '0'
+    control_interface_config_status: 'not active'
+    control_interface_number: '7'
+    control_interface_state: 'not active'
+    crc: '0'
+    deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Auto'
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
-    frame: ''
-    giants: ''
+    frame: '0'
+    giants: '0'
     hardware_type: i82574L rev00
-    ignored: ''
-    in_bytes: ''
-    in_errors: ''
-    in_packets: ''
-    in_pause: ''
+    ignored: '0'
+    in_bytes: '0'
+    in_errors: '0'
+    in_packets: '0'
+    in_pause: '0'
     in_pause_resume: ''
-    in_reset_drops: ''
-    in_resume: ''
+    in_reset_drops: '0'
+    in_resume: '0'
     interface: Management0/1
     interface_name: ''
-    interface_resets: ''
-    ip_address: ''
-    l2_decode_drops: ''
-    late_collisions: ''
+    interface_resets: '2'
+    ip_address: 'unassigned'
+    l2_decode_drops: '0'
+    late_collisions: '0'
     link_status: administratively down
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
-    no_buffer: ''
-    out_bytes: ''
-    out_errors: ''
-    out_packets: ''
-    out_pause: ''
+    no_buffer: '0'
+    out_bytes: '0'
+    out_decode_drops: ''
+    out_errors: '0'
+    out_packets: '0'
+    out_pause: '0'
     out_pause_resume: ''
-    out_reset_drops: ''
-    out_resume: ''
-    overrun: ''
+    out_reset_drops: '0'
+    out_resume: '0'
+    overrun: '0'
     protocol_status: down
     rate_limit_drops: ''
-    runts: ''
+    runts: '0'
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
-    speed: ''
+    speed: 'Auto'
     switch_egress_policy_drops: ''
     switch_ingress_policy_drops: ''
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
-    underruns: ''
+    underruns: '0'
     vlan: ''
 -   abort: '0'
-    address: ''
+    address: 'f0f7.5543.a528'
     bandwidth: 10000 Mbps
+    bonded_port: 'Port-channel1'
     broadcasts: '16'
     collisions: '0'
     control_interface_config_status: active
@@ -1295,7 +1102,7 @@ parsed_sample:
     deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Full'
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
     frame: '0'
@@ -1312,14 +1119,15 @@ parsed_sample:
     interface: TenGigabitEthernet0/6
     interface_name: ''
     interface_resets: '0'
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: '0'
     late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: '0'
     out_bytes: '491562768018165'
+    out_decode_drops: ''
     out_errors: '0'
     out_packets: '540331320890'
     out_pause: ''
@@ -1333,23 +1141,26 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
-    speed: ''
+    speed: '10000 Mbps'
     switch_egress_policy_drops: '0'
     switch_ingress_policy_drops: '0'
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
     underruns: '0'
     vlan: ''
 -   abort: '0'
-    address: ''
+    address: 'f0f7.5543.a529'
     bandwidth: 10000 Mbps
+    bonded_port: 'Port-channel1'
     broadcasts: '2097'
     collisions: '0'
     control_interface_config_status: active
@@ -1359,7 +1170,7 @@ parsed_sample:
     deffered: '0'
     delay: 10 usec
     description: ''
-    duplex: ''
+    duplex: 'Full'
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
     frame: '0'
@@ -1376,14 +1187,15 @@ parsed_sample:
     interface: TenGigabitEthernet0/7
     interface_name: ''
     interface_resets: '0'
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: '0'
     late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: '0'
     out_bytes: '13846109908639'
+    out_decode_drops: ''
     out_errors: '0'
     out_packets: '26351891151'
     out_pause: ''
@@ -1397,23 +1209,26 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
-    speed: ''
+    speed: '10000 Mbps'
     switch_egress_policy_drops: '0'
     switch_ingress_policy_drops: '0'
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
     underruns: '0'
     vlan: ''
 -   abort: '0'
-    address: ''
+    address: 'f0f7.5543.a52a'
     bandwidth: 1000 Mbps
+    bonded_port: 'Port-channel2'
     broadcasts: '245856'
     collisions: '0'
     control_interface_config_status: active
@@ -1423,7 +1238,7 @@ parsed_sample:
     deffered: '0'
     delay: 1000 usec
     description: ''
-    duplex: Full-duplex
+    duplex: Full
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
     frame: '0'
@@ -1440,14 +1255,15 @@ parsed_sample:
     interface: TenGigabitEthernet0/8
     interface_name: ''
     interface_resets: '0'
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: '0'
     late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: '0'
     out_bytes: '16640841970890'
+    out_decode_drops: ''
     out_errors: '0'
     out_packets: '20810869221'
     out_pause: ''
@@ -1461,6 +1277,7 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
@@ -1470,14 +1287,16 @@ parsed_sample:
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
     underruns: '0'
     vlan: ''
 -   abort: '0'
-    address: ''
+    address: 'f0f7.5543.a52b'
     bandwidth: 1000 Mbps
+    bonded_port: 'Port-channel2'
     broadcasts: '336212'
     collisions: '0'
     control_interface_config_status: active
@@ -1487,7 +1306,7 @@ parsed_sample:
     deffered: '0'
     delay: 1000 usec
     description: ''
-    duplex: Full-duplex
+    duplex: Full
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
     frame: '0'
@@ -1504,14 +1323,15 @@ parsed_sample:
     interface: TenGigabitEthernet0/9
     interface_name: ''
     interface_resets: '0'
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: '0'
     late_collisions: '0'
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: '0'
     out_bytes: '125662363017538'
+    out_decode_drops: ''
     out_errors: '0'
     out_packets: '415140444956'
     out_pause: ''
@@ -1525,6 +1345,7 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
@@ -1534,24 +1355,26 @@ parsed_sample:
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
     underruns: '0'
     vlan: ''
 -   abort: ''
-    address: ''
+    address: 'f0f7.5543.a528'
     bandwidth: 20000 Mbps
+    bonded_port: ''
     broadcasts: ''
     collisions: ''
-    control_interface_config_status: ''
-    control_interface_number: ''
-    control_interface_state: ''
+    control_interface_config_status: 'active'
+    control_interface_number: '23'
+    control_interface_state: 'active'
     crc: ''
     deffered: ''
     delay: 10 usec
     description: ext
-    duplex: ''
+    duplex: 'Full'
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
     frame: ''
@@ -1568,14 +1391,15 @@ parsed_sample:
     interface: Port-channel1
     interface_name: ''
     interface_resets: ''
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: ''
     late_collisions: ''
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: ''
     out_bytes: ''
+    out_decode_drops: ''
     out_errors: ''
     out_packets: ''
     out_pause: ''
@@ -1589,15 +1413,17 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
-    speed: ''
+    speed: '10000 Mbps'
     switch_egress_policy_drops: ''
     switch_ingress_policy_drops: ''
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
@@ -1606,6 +1432,7 @@ parsed_sample:
 -   abort: ''
     address: ''
     bandwidth: 20000 Mbps
+    bonded_port: ''
     broadcasts: ''
     collisions: ''
     control_interface_config_status: ''
@@ -1640,6 +1467,7 @@ parsed_sample:
     net_mask: ''
     no_buffer: ''
     out_bytes: ''
+    out_decode_drops: ''
     out_errors: ''
     out_packets: ''
     out_pause: ''
@@ -1653,6 +1481,7 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
@@ -1662,24 +1491,26 @@ parsed_sample:
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
     underruns: ''
     vlan: '355'
 -   abort: ''
-    address: ''
+    address: 'f0f7.5543.a52a'
     bandwidth: 2000 Mbps
+    bonded_port: ''
     broadcasts: ''
     collisions: ''
-    control_interface_config_status: ''
-    control_interface_number: ''
-    control_interface_state: ''
+    control_interface_config_status: 'active'
+    control_interface_number: '24'
+    control_interface_state: 'active'
     crc: ''
     deffered: ''
     delay: 1000 usec
     description: techlan
-    duplex: Full-duplex
+    duplex: Full
     flowcontrol_in: unsupported
     flowcontrol_out: 'off'
     frame: ''
@@ -1696,14 +1527,15 @@ parsed_sample:
     interface: Port-channel2
     interface_name: ''
     interface_resets: ''
-    ip_address: ''
+    ip_address: 'unassigned'
     l2_decode_drops: ''
     late_collisions: ''
     link_status: up
-    mtu: ''
+    mtu: 'not set'
     net_mask: ''
     no_buffer: ''
     out_bytes: ''
+    out_decode_drops: ''
     out_errors: ''
     out_packets: ''
     out_pause: ''
@@ -1717,6 +1549,7 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
@@ -1726,6 +1559,7 @@ parsed_sample:
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []
@@ -1734,6 +1568,7 @@ parsed_sample:
 -   abort: ''
     address: ''
     bandwidth: 2000 Mbps
+    bonded_port: ''
     broadcasts: ''
     collisions: ''
     control_interface_config_status: ''
@@ -1768,6 +1603,7 @@ parsed_sample:
     net_mask: ''
     no_buffer: ''
     out_bytes: ''
+    out_decode_drops: ''
     out_errors: ''
     out_packets: ''
     out_pause: ''
@@ -1781,6 +1617,7 @@ parsed_sample:
     rxring_blocks_free_curr: []
     rxring_blocks_free_low: []
     rxring_bytes: []
+    rxring_interface: []
     rxring_number: []
     rxring_overrun: []
     rxring_packets: []
@@ -1790,6 +1627,7 @@ parsed_sample:
     txring_blocks_free_curr: []
     txring_blocks_free_low: []
     txring_bytes: []
+    txring_interface: []
     txring_number: []
     txring_packets: []
     txring_underrun: []


### PR DESCRIPTION
Breaking Changes:
  * Change `DUPLEX` to remove reference to duplex

Additional Capture Groups:
  * `BONDED_PORT`: Identifies port-channel the interface is associated to
  * `OUT_DECODE_DROPS`: Identifies an additional drop counter
  * `RXRING_INTERFACE`: Identifies interfaces used by RX Rings
  * `TXRING_INTERFACE`: Identifies interfaces used by TX Rings

Enhancements:
  * Change spaces to use `\s+` to allow for more than single space
  * Change record to happen required interface name to remove unnecessary dependency on non-required line.
  * Add `\` to escape dot in `ADDRESS` instead of it being anything
  * Add Error statements in each state to ensure data is parsed properly
    - Capture data for interfaces that are shutdown
     - Update capture groups to account for additional data:
        * `DUPLEX`
        * `SPEED`
        * `MTU`
        * `IP_ADDRESS`
        * `NET_MASK`
      - Updated regex to account for each line in raw file

Tests:
  * Update parsed file to account for changes to template
