### PR TITLE
`cisco_nxos_show_interface_status`: Fixes issue #333

### DIFF
--- a/templates/cisco_nxos_show_interface_status.template
+++ b/templates/cisco_nxos_show_interface_status.template
@@ -1,7 +1,7 @@
 Value PORT (\S+)
 Value NAME (.*?)
 Value STATUS (\S+)
-Value VLAN (\d+|routed|trunk)
+Value VLAN (\d+|routed|trunk|--)
 Value DUPLEX (\S+)
 Value SPEED (\d+|auto)
 Value TYPE (.+?)

--- a/tests/cisco_nxos/show_interface_status/cisco_nxos_show_interface_status.parsed
+++ b/tests/cisco_nxos/show_interface_status/cisco_nxos_show_interface_status.parsed
@@ -576,3 +576,11 @@ parsed_sample:
       duplex: "auto"
       speed: "auto"
       type: "--"
+
+    - port: "nve1"
+      name: "--"
+      status: "connected"
+      vlan: "--"
+      duplex: "auto"
+      speed: "auto"
+      type: "--"

--- a/tests/cisco_nxos/show_interface_status/cisco_nxos_show_interface_status.raw
+++ b/tests/cisco_nxos/show_interface_status/cisco_nxos_show_interface_status.raw
@@ -73,4 +73,5 @@ Vlan20        --                 down      routed    auto    auto    --
 Vlan66        --                 down      routed    auto    auto    --
 Vlan77        --                 down      routed    auto    auto    --
 Vlan146       my vlan 146        down      routed    auto    auto    --
+nve1          --                 connected --        auto    auto    --
 


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT
cisco_nxos_show_interface_status
##### SUMMARY
Template was giving an error on the line for the nve1 interface because the VLAN value is "--". Added "--" to the regular expression for `VLAN `

BEFORE
```
$ textfsm.py templates/cisco_nxos_show_interface_status.template tests/cisco_nxos/show_interface_status/cisco_nxos_show_interface_status.raw
FSM Template:
Value PORT (\S+)
Value NAME (.*?)
Value STATUS (\S+)
Value VLAN (\d+|routed|trunk)
Value DUPLEX (\S+)
Value SPEED (\d+|auto)
Value TYPE (.+?)

Start
  ^[Pp]ort\s+[Nn]ame\s+[Ss]tatus\s+[Vv]lan\s+[Dd]uplex\s+[Ss]peed\s+[Tt]ype\s*$$ -> INTFS
  ^-+\s*$$
  ^$$
  ^.*$$ -> Error

INTFS
  ^${PORT}\s+${NAME}\s+${STATUS}\s+${VLAN}\s+${DUPLEX}\s+${SPEED}\s+${TYPE}\s*$$ -> Record
  ^-+\s*$$
  ^$$
  ^.*$$ -> Error

State Error raised. Rule Line: 19. Input Line: nve1          --                 connected --        auto    auto    --

```
AFTER:
```
$ textfsm.py templates/cisco_nxos_show_interface_status.template tests/cisco_nxos/show_interface_status/cisco_nxos_show_interface_status.raw
FSM Template:
Value PORT (\S+)
Value NAME (.*?)
Value STATUS (\S+)
Value VLAN (\d+|routed|trunk|--)
Value DUPLEX (\S+)
Value SPEED (\d+|auto)
Value TYPE (.+?)

Start
  ^[Pp]ort\s+[Nn]ame\s+[Ss]tatus\s+[Vv]lan\s+[Dd]uplex\s+[Ss]peed\s+[Tt]ype\s*$$ -> INTFS
  ^-+\s*$$
  ^$$
  ^.*$$ -> Error

INTFS
  ^${PORT}\s+${NAME}\s+${STATUS}\s+${VLAN}\s+${DUPLEX}\s+${SPEED}\s+${TYPE}\s*$$ -> Record
  ^-+\s*$$
  ^$$
  ^.*$$ -> Error


FSM Table:
['PORT', 'NAME', 'STATUS', 'VLAN', 'DUPLEX', 'SPEED', 'TYPE']
['mgmt0', '--', 'connected', 'routed', 'full', '100', '--']
['Eth1/1', 'managed by puppet', 'disabled', 'routed', 'auto', 'auto', 'SFP-H10GB-CU2M']
['Eth1/2', '--', 'disabled', '1', 'auto', 'auto', 'SFP-H10GB-CU2M']
['Eth1/3', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/4', '--', 'xcvrAbsen', 'trunk', 'auto', 'auto', '--']
['Eth1/5', '--', 'xcvrAbsen', 'trunk', 'auto', 'auto', '--']
['Eth1/6', '--', 'xcvrAbsen', 'trunk', 'auto', 'auto', '--']
['Eth1/7', '--', 'xcvrAbsen', 'trunk', 'auto', 'auto', '--']
['Eth1/8', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/9', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/10', 'managed by puppet', 'xcvrAbsen', 'routed', 'auto', 'auto', '--']
['Eth1/11', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/12', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/13', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/14', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/15', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/16', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/17', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/18', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/19', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/20', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/21', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/22', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/23', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/24', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/25', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/26', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/27', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/28', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/29', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/30', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/31', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/32', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/33', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/34', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/35', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/36', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/37', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/38', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/39', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/40', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/41', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/42', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/43', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/44', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/45', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/46', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/47', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth1/48', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth2/1', '--', 'notconnec', 'routed', 'auto', 'auto', 'QSFP-40G-SR-BD']
['Eth2/2', '--', 'notconnec', 'routed', 'auto', 'auto', 'QSFP-40G-SR-BD']
['Eth2/3', '--', 'notconnec', 'routed', 'auto', 'auto', 'QSFP-40G-SR-BD']
['Eth2/4', '--', 'notconnec', 'routed', 'auto', 'auto', 'QSFP-40G-SR-BD']
['Eth2/5', '--', 'xcvrAbsen', 'trunk', 'auto', 'auto', '--']
['Eth2/6', '--', 'xcvrAbsen', 'trunk', 'auto', 'auto', '--']
['Eth2/7', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth2/8', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth2/9', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth2/10', '--', 'xcvrAbsen', '1', 'auto', 'auto', '--']
['Eth2/11', '--', 'disabled', '1', 'auto', 'auto', 'QSFP-40G-SR-BD']
['Eth2/12', '--', 'disabled', '1', 'auto', 'auto', 'QSFP-40G-SR-BD']
['Po10', '--', 'noOperMem', '1', 'auto', 'auto', '--']
['Po11', '--', 'noOperMem', '1', 'auto', 'auto', '--']
['Po12', '--', 'noOperMem', '1', 'auto', 'auto', '--']
['Lo10', '--', 'connected', 'routed', 'auto', 'auto', '--']
['Vlan1', '--', 'down', 'routed', 'auto', 'auto', '--']
['Vlan5', '--', 'down', 'routed', 'auto', 'auto', '--']
['Vlan10', '--', 'down', 'routed', 'auto', 'auto', '--']
['Vlan20', '--', 'down', 'routed', 'auto', 'auto', '--']
['Vlan66', '--', 'down', 'routed', 'auto', 'auto', '--']
['Vlan77', '--', 'down', 'routed', 'auto', 'auto', '--']
['Vlan146', 'my vlan 146', 'down', 'routed', 'auto', 'auto', '--']
['nve1', '--', 'connected', '--', 'auto', 'auto', '--']
```