### PR TITLE
added "show interface switchport" for both IOS and NX-OS

### DIFF
--- a/templates/cisco_ios_show_interface_switchport.template
+++ b/templates/cisco_ios_show_interface_switchport.template
@@ -1,0 +1,20 @@
+Value Required INTERFACE (\S+)
+Value SWITCHPORT (\S+)
+Value ADMIN_MODE (.+)
+Value OPER_MODE (.+)
+Value DTP (\S+)
+Value ACCESS_VLAN (\S+)
+Value NATIVE_VLAN (\S+)
+Value VOICE_VLAN (\S+)
+Value TRUNKING_VLANS (\S+)
+
+Start
+  ^Name: ${INTERFACE}
+  ^Switchport: ${SWITCHPORT}
+  ^Administrative Mode: ${ADMIN_MODE}
+  ^Operational Mode: ${OPER_MODE}
+  ^Negotiation of Trunking: ${DTP}
+  ^Access Mode VLAN: ${ACCESS_VLAN}
+  ^Trunking Native Mode VLAN: ${NATIVE_VLAN}
+  ^Voice VLAN: ${VOICE_VLAN}
+  ^Trunking VLANs Enabled: ${TRUNKING_VLANS} -> Record

--- a/templates/cisco_nxos_show_interface_switchport.template
+++ b/templates/cisco_nxos_show_interface_switchport.template
@@ -1,0 +1,14 @@
+Value Required INTERFACE (\S+)
+Value SWITCHPORT (\S+)
+Value MODE (\S+)
+Value ACCESS_VLAN (\S+)
+Value NATIVE_VLAN (\S+)
+Value TRUNKING_VLANS (\S+)
+
+Start
+  ^Name: ${INTERFACE}
+  ^\s*Switchport: ${SWITCHPORT}
+  ^\s*Operational Mode: ${MODE}
+  ^\s*Access Mode VLAN: ${ACCESS_VLAN}
+  ^\s*Trunking Native Mode VLAN: ${NATIVE_VLAN}
+  ^\s*Trunking VLANs Allowed: ${TRUNKING_VLANS} -> Record

--- a/templates/index
+++ b/templates/index
@@ -91,7 +91,7 @@ brocade_netiron_show_span.template, .*, brocade_netiron, sh[[ow]] sp[[anning-tre
 brocade_netiron_show_topo.template, .*, brocade_netiron, sh[[ow]] to[[pology-group]]
 
 checkpoint_gaia_show_interfaces_all.template, .*, checkpoint_gaia, show interfaces all
-checkpoint_gaia_show_ntp_servers.template, .*, checkpoint_gaia, show ntp servers 
+checkpoint_gaia_show_ntp_servers.template, .*, checkpoint_gaia, show ntp servers
 checkpoint_gaia_show_version_all.template, .*, checkpoint_gaia, show version all
 checkpoint_gaia_show_domainname.template, .*, checkpoint_gaia, show domainname
 checkpoint_gaia_show_ipv6_route.template, .*, checkpoint_gaia, show ipv6 route
@@ -137,6 +137,7 @@ cisco_ios_show_environment_power_all.template, .*, cisco_ios, sh[[ow]] envi[[ron
 cisco_ios_show_interface_transceiver.template, .*, cisco_ios, sh[[ow]] int[[erface]] trans[[ceiver]]
 cisco_ios_show_lldp_neighbors_detail.template, .*, cisco_ios, sh[[ow]] lld[[p]] neig[[hbors]] det[[ail]]
 cisco_ios_show_cdp_neighbors_detail.template, .*, cisco_ios, sh[[ow]] c[[dp]] neig[[hbors]] det[[ail]]
+cisco_ios_show_interface_switchport.template, .*, cisco_ios, sh[[ow]] int[[erface]] sw[[itchport]]
 cisco_ios_show_ipv6_interface_brief.template, .*, cisco_ios, sh[[ow]] ipv[[6]] i[[nterface]] b[[rief]]
 cisco_ios_show_ip_eigrp_neighbors.template, .*, cisco_ios, sh[[ow]] ip ei[[grp]] nei[[ghbors]]
 cisco_ios_show_ip_interface_brief.template, .*, cisco_ios, sh[[ow]] ip int[[erface]] br[[ief]]
@@ -191,6 +192,7 @@ cisco_nxos_show_environment_temperature.template, .*, cisco_nxos, sh[[ow]] env[[
 cisco_nxos_show_ip_dhcp_relay_address.template, .*, cisco_nxos, sh[[ow]] ip dh[[cp]] r[[elay]] a[[ddress]]
 cisco_nxos_show_lldp_neighbors_detail.template, .*, cisco_nxos, sh[[ow]] ll[[dp]] nei[[ghbors]] d[[etail]]
 cisco_nxos_show_cdp_neighbors_detail.template, .*, cisco_nxos, sh[[ow]] c[[dp]] neig[[hbors]] det[[ail]]
+cisco_nxos_show_interface_switchport.template, .*, cisco_nxos, sh[[ow]] int[[erface]] sw[[itchport]]
 cisco_nxos_show_ip_ospf_neighbor_vrf.template, .*, cisco_nxos, sh[[ow]] ip ospf nei[[ghbor]] vrf (\S+)
 cisco_nxos_show_ipv6_interface_brief.template, .*, cisco_nxos, sh[[ow]] ipv[[6]] interf[[ace]] b[[rief]]
 cisco_nxos_show_port-channel_summary.template, .*, cisco_nxos, sh[[ow]] po[[rt-channel]] sum[[mary]]

--- a/tests/cisco_ios/show_interface_switchport/cisco_ios_show_interface_switchport.parsed
+++ b/tests/cisco_ios/show_interface_switchport/cisco_ios_show_interface_switchport.parsed
@@ -1,0 +1,32 @@
+---
+parsed_sample:
+
+    - interface: "Et0/1"
+      switchport: "Enabled"
+      admin_mode: "static access"
+      oper_mode: "static access"
+      dtp: "Off"
+      access_vlan: "30"
+      native_vlan: "1"
+      voice_vlan: "31"
+      trunking_vlans: "ALL"
+
+    - interface: "Et0/2"
+      switchport: "Enabled"
+      admin_mode: "trunk"
+      oper_mode: "trunk"
+      dtp: "On"
+      access_vlan: "1"
+      native_vlan: "7"
+      voice_vlan: "none"
+      trunking_vlans: "7,43,56,78,90,99-102"
+
+    - interface: "Et0/3"
+      switchport: "Enabled"
+      admin_mode: "dynamic auto"
+      oper_mode: "down"
+      dtp: "On"
+      access_vlan: "1"
+      native_vlan: "1"
+      voice_vlan: "none"
+      trunking_vlans: "ALL"

--- a/tests/cisco_ios/show_interface_switchport/cisco_ios_show_interface_switchport.raw
+++ b/tests/cisco_ios/show_interface_switchport/cisco_ios_show_interface_switchport.raw
@@ -1,0 +1,82 @@
+Name: Et0/1
+Switchport: Enabled
+Administrative Mode: static access
+Operational Mode: static access
+Administrative Trunking Encapsulation: negotiate
+Operational Trunking Encapsulation: native
+Negotiation of Trunking: Off
+Access Mode VLAN: 30 (VLAN0030)
+Trunking Native Mode VLAN: 1 (default)
+Administrative Native VLAN tagging: enabled
+Voice VLAN: 31 (VLAN0031)
+Administrative private-vlan host-association: none
+Administrative private-vlan mapping: none
+Administrative private-vlan trunk native VLAN: none
+Administrative private-vlan trunk Native VLAN tagging: enabled
+Administrative private-vlan trunk encapsulation: dot1q
+Administrative private-vlan trunk normal VLANs: none
+Administrative private-vlan trunk associations: none
+Administrative private-vlan trunk mappings: none
+Operational private-vlan: none
+Trunking VLANs Enabled: ALL
+Pruning VLANs Enabled: 2-1001
+Capture Mode Disabled
+Capture VLANs Allowed: ALL
+
+Protected: false
+Appliance trust: none
+
+Name: Et0/2
+Switchport: Enabled
+Administrative Mode: trunk
+Operational Mode: trunk
+Administrative Trunking Encapsulation: dot1q
+Operational Trunking Encapsulation: dot1q
+Negotiation of Trunking: On
+Access Mode VLAN: 1 (default)
+Trunking Native Mode VLAN: 7 (Inactive)
+Administrative Native VLAN tagging: enabled
+Voice VLAN: none
+Administrative private-vlan host-association: none
+Administrative private-vlan mapping: none
+Administrative private-vlan trunk native VLAN: none
+Administrative private-vlan trunk Native VLAN tagging: enabled
+Administrative private-vlan trunk encapsulation: dot1q
+Administrative private-vlan trunk normal VLANs: none
+Administrative private-vlan trunk associations: none
+Administrative private-vlan trunk mappings: none
+Operational private-vlan: none
+Trunking VLANs Enabled: 7,43,56,78,90,99-102
+Pruning VLANs Enabled: 2-1001
+Capture Mode Disabled
+Capture VLANs Allowed: ALL
+
+Protected: false
+Appliance trust: none
+
+Name: Et0/3
+Switchport: Enabled
+Administrative Mode: dynamic auto
+Operational Mode: down
+Administrative Trunking Encapsulation: negotiate
+Negotiation of Trunking: On
+Access Mode VLAN: 1 (default)
+Trunking Native Mode VLAN: 1 (default)
+Administrative Native VLAN tagging: enabled
+Voice VLAN: none
+Administrative private-vlan host-association: none
+Administrative private-vlan mapping: none
+Administrative private-vlan trunk native VLAN: none
+Administrative private-vlan trunk Native VLAN tagging: enabled
+Administrative private-vlan trunk encapsulation: dot1q
+Administrative private-vlan trunk normal VLANs: none
+Administrative private-vlan trunk associations: none
+Administrative private-vlan trunk mappings: none
+Operational private-vlan: none
+Trunking VLANs Enabled: ALL
+Pruning VLANs Enabled: 2-1001
+Capture Mode Disabled
+Capture VLANs Allowed: ALL
+
+Protected: false
+Appliance trust: none

--- a/tests/cisco_nxos/show_interface_switchport/cisco_nxos_show_interface_switchport.parsed
+++ b/tests/cisco_nxos/show_interface_switchport/cisco_nxos_show_interface_switchport.parsed
@@ -1,0 +1,23 @@
+---
+parsed_sample:
+
+    - interface: "Ethernet1/1"
+      switchport: "Enabled"
+      mode: "access"
+      access_vlan: "1"
+      native_vlan: "1"
+      trunking_vlans: "1-4094"
+
+    - interface: "Ethernet1/2"
+      switchport: "Enabled"
+      mode: "trunk"
+      access_vlan: "1"
+      native_vlan: "1"
+      trunking_vlans: "30,40-50,67,270,220"
+
+    - interface: "Ethernet1/3"
+      switchport: "Enabled"
+      mode: "access"
+      access_vlan: "20"
+      native_vlan: "1"
+      trunking_vlans: "1-4094"

--- a/tests/cisco_nxos/show_interface_switchport/cisco_nxos_show_interface_switchport.raw
+++ b/tests/cisco_nxos/show_interface_switchport/cisco_nxos_show_interface_switchport.raw
@@ -1,0 +1,49 @@
+Name: Ethernet1/1
+  Switchport: Enabled
+  Switchport Monitor: Not enabled
+  Operational Mode: access
+  Access Mode VLAN: 1 (default)
+  Trunking Native Mode VLAN: 1 (default)
+  Trunking VLANs Allowed: 1-4094
+  Administrative private-vlan primary host-association: none
+  Administrative private-vlan secondary host-association: none
+  Administrative private-vlan primary mapping: none
+  Administrative private-vlan secondary mapping: none
+  Administrative private-vlan trunk native VLAN: none
+  Administrative private-vlan trunk encapsulation: dot1q
+  Administrative private-vlan trunk normal VLANs: none
+  Administrative private-vlan trunk private VLANs: none
+  Operational private-vlan: none
+Name: Ethernet1/2
+  Switchport: Enabled
+  Switchport Monitor: Not enabled
+  Operational Mode: trunk
+  Access Mode VLAN: 1 (default)
+  Trunking Native Mode VLAN: 1 (default)
+  Trunking VLANs Allowed: 30,40-50,67,270,220
+  Pruning VLANs Enabled: 2-1001
+  Administrative private-vlan primary host-association: none
+  Administrative private-vlan secondary host-association: none
+  Administrative private-vlan primary mapping: none
+  Administrative private-vlan secondary mapping: none
+  Administrative private-vlan trunk native VLAN: none
+  Administrative private-vlan trunk encapsulation: dot1q
+  Administrative private-vlan trunk normal VLANs: none
+  Administrative private-vlan trunk private VLANs: none
+  Operational private-vlan: none
+Name: Ethernet1/3
+  Switchport: Enabled
+  Switchport Monitor: Not enabled
+  Operational Mode: access
+  Access Mode VLAN: 20 (VLAN_20)
+  Trunking Native Mode VLAN: 1 (default)
+  Trunking VLANs Allowed: 1-4094
+  Administrative private-vlan primary host-association: none
+  Administrative private-vlan secondary host-association: none
+  Administrative private-vlan primary mapping: none
+  Administrative private-vlan secondary mapping: none
+  Administrative private-vlan trunk native VLAN: none
+  Administrative private-vlan trunk encapsulation: dot1q
+  Administrative private-vlan trunk normal VLANs: none
+  Administrative private-vlan trunk private VLANs: none
+  Operational private-vlan: none


### PR DESCRIPTION
##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
- cisco_ios_show_interface_switchport.template
- cisco_nxos_show_interface_switchport.template

##### SUMMARY
Added "show interface switchport" so users can get which VLAN is used in which interface with a single show.
