### PR TITLE
Made tox.ini work for ntc-templates

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,12 @@
 [tox]
-envlist = py27
-skipsdist=true
+envlist = py37, py27
 
 [testenv]
-setenv =
-    ANSIBLE_REMOTE_TEMP = .tmp
-    ANSIBLE_LIBRARY = .ntc-modules
 
 deps =
     pytest
     PyYAML
-    netmiko
     textfsm
-    ansible==1.9.2
-    terminal
-
-whitelist_externals =
-    git
-    rm
 
 commands=
    py.test
-   rm -rf .ntc-modules
-   git clone https://github.com/networktocode/ntc-ansible.git .ntc-modules
-   {envbindir}/python test-templates.py


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT
tox.ini

##### SUMMARY
The previous tox.ini failed - that is it didn't work.
It was a mishmash of ansible testing, and travis.ci work, and general confusion.
This one works correctly, and validates that the tests run in Python 2.7 and Python 3.7.

It runs the tests successfully in both environments.

It does point out some warnings about possible changes in regex meaning both now and in the future for some of the templates when running under 3.7. This is a good thing.