### PR TITLE
Update cisco_nxos_show_interface_status.template

### DIFF
--- a/templates/cisco_nxos_show_interface_status.template
+++ b/templates/cisco_nxos_show_interface_status.template
@@ -14,6 +14,7 @@ Start
 
 INTFS
   ^${PORT}\s+${NAME}\s+${STATUS}\s+${VLAN}\s+${DUPLEX}\s+${SPEED}\s+${TYPE}\s*$$ -> Record
+  ^[Pp]ort\s+[Nn]ame\s+[Ss]tatus\s+[Vv]lan\s+[Dd]uplex\s+[Ss]peed\s+[Tt]ype\s*$$
   ^-+\s*$$
   ^$$
   ^.*$$ -> Error

--- a/tests/cisco_nxos/show_interface_status/cisco_nxos_show_interface_status2.parsed
+++ b/tests/cisco_nxos/show_interface_status/cisco_nxos_show_interface_status2.parsed
@@ -1,0 +1,442 @@
+---
+parsed_sample:
+
+- duplex: auto
+  name: --
+  port: mgmt0
+  speed: auto
+  status: notconnec
+  type: --
+  vlan: routed
+
+- duplex: full
+  name: --
+  port: Eth1/1
+  speed: '1000'
+  status: connected
+  type: 1000base-T
+  vlan: trunk
+
+- duplex: auto
+  name: --
+  port: Eth1/2
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/3
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/4
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/5
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/6
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/7
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/8
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/9
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/10
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/11
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/12
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/13
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/14
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/15
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/16
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/17
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/18
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/19
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/20
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/21
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/22
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/23
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/24
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/25
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/26
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/27
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/28
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/29
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/30
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/31
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/32
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/33
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/34
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/35
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/36
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/37
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/38
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/39
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/40
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/41
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/42
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/43
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/44
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/45
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/46
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/47
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/48
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/49
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/50
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/51
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: --
+  port: Eth1/52
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: '1'
+
+- duplex: auto
+  name: VPC-peer-link !kob
+  port: Eth1/53
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: trunk
+
+- duplex: auto
+  name: VPC-peer-link !kob
+  port: Eth1/54
+  speed: auto
+  status: xcvrAbsen
+  type: --
+  vlan: trunk

--- a/tests/cisco_nxos/show_interface_status/cisco_nxos_show_interface_status2.raw
+++ b/tests/cisco_nxos/show_interface_status/cisco_nxos_show_interface_status2.raw
@@ -1,0 +1,62 @@
+--------------------------------------------------------------------------------
+Port          Name               Status    Vlan      Duplex  Speed   Type
+--------------------------------------------------------------------------------
+mgmt0         --                 notconnec routed    auto    auto    --         
+
+--------------------------------------------------------------------------------
+Port          Name               Status    Vlan      Duplex  Speed   Type
+--------------------------------------------------------------------------------
+Eth1/1        --                 connected trunk     full    1000    1000base-T 
+Eth1/2        --                 xcvrAbsen 1         auto    auto    --         
+Eth1/3        --                 xcvrAbsen 1         auto    auto    --         
+Eth1/4        --                 xcvrAbsen 1         auto    auto    --         
+Eth1/5        --                 xcvrAbsen 1         auto    auto    --         
+Eth1/6        --                 xcvrAbsen 1         auto    auto    --         
+Eth1/7        --                 xcvrAbsen 1         auto    auto    --         
+Eth1/8        --                 xcvrAbsen 1         auto    auto    --         
+Eth1/9        --                 xcvrAbsen 1         auto    auto    --         
+Eth1/10       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/11       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/12       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/13       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/14       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/15       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/16       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/17       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/18       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/19       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/20       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/21       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/22       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/23       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/24       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/25       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/26       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/27       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/28       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/29       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/30       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/31       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/32       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/33       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/34       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/35       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/36       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/37       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/38       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/39       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/40       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/41       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/42       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/43       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/44       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/45       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/46       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/47       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/48       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/49       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/50       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/51       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/52       --                 xcvrAbsen 1         auto    auto    --         
+Eth1/53       VPC-peer-link !kob xcvrAbsen trunk     auto    auto    --         
+Eth1/54       VPC-peer-link !kob xcvrAbsen trunk     auto    auto    --         


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
cisco_nxos_show_interface_status.template

##### SUMMARY
In NXOS 7.0.3.I7.5a there is a separate section with column names for the mgmt0 interface. This caused a "textfsm.TextFSMError" when the column name section appeared for the second time. This update fixes the issue.

```

```
