### PR TITLE
Add show_boot template for cisco_ios

### DIFF
--- a/templates/cisco_ios_show_boot.template
+++ b/templates/cisco_ios_show_boot.template
@@ -1,0 +1,32 @@
+Value BOOT_PATH (\S+)
+Value CONFIG_FILE (\S+)
+Value PRIV_CONFIG_FILE (\S+)
+Value ENABLE_BREAK (yes|no)
+Value MANUAL_BOOT (yes|no)
+Value ALLOW_DEV_KEY (yes|no)
+Value HELPER_PATH_LIST (\S+)
+Value AUTO_UPGRADE (yes|no)
+Value AUTO_UPGRADE_PATH (\S+)
+Value BUFFER_SIZE (\d+)
+Value TIMEOUT_CONFIG_DOWNLOAD (\d+)
+Value CONFIG_DOWNLOAD_DHCP (enabled|disabled)
+Value CONFIG_DOWNLOAD_DHCP_NEXT_BOOT (enabled|disabled)
+
+Start
+  ^BOOT\s+path-list\s+:\s+${BOOT_PATH}
+  ^Config\s+file\s+:\s+${CONFIG_FILE}
+  ^Private\s+Config\s+file\s+:\s+${PRIV_CONFIG_FILE}
+  ^Enable\s+Break\s+:\s+${ENABLE_BREAK}
+  ^Manual\s+Boot\s+:\s+${MANUAL_BOOT}
+  ^Allow\s+Dev\s+Key\s+:\s+${ALLOW_DEV_KEY}
+  ^HELPER\s+path-list\s+:.*
+  ^Auto\s+upgrade\s+:\s+${AUTO_UPGRADE}
+  ^Auto\s+upgrade\s+path\s+:.*
+  ^NVRAM/Config\s+file
+  ^\s+buffer\s+size:\s+${BUFFER_SIZE}
+  ^Timeout\s+for\s+Config
+  ^\s+Download:\s+${TIMEOUT_CONFIG_DOWNLOAD}
+  ^Config\s+Download
+  ^\s+via\s+DHCP:\s+${CONFIG_DOWNLOAD_DHCP}
+  ^\s*$$
+  ^. -> Error

--- a/templates/index
+++ b/templates/index
@@ -146,6 +146,7 @@ cisco_ios_show_ip_arp.template, .*, cisco_ios, sh[[ow]] i[[p]] a[[rp]]
 cisco_ios_show_ip_bgp.template, .*, cisco_ios, sh[[ow]] i[[p]] bgp
 cisco_ios_show_clock.template, .*, cisco_ios, sh[[ow]] clo[[ck]]
 cisco_ios_show_vlan.template, .*, cisco_ios, sh[[ow]] vlan
+cisco_ios_show_boot.template, .*, cisco_ios, sh[[ow]] boot
 cisco_ios_show_vrf.template, .*, cisco_ios, sh[[ow]] vrf
 cisco_ios_dir.template,  .*, cisco_ios, dir
 

--- a/tests/cisco_ios/show_boot/cisco_ios_show_boot.parsed
+++ b/tests/cisco_ios/show_boot/cisco_ios_show_boot.parsed
@@ -1,0 +1,16 @@
+---
+parsed_sample:
+
+-   allow_dev_key: 'yes'
+    auto_upgrade: 'yes'
+    auto_upgrade_path: ''
+    boot_path: flash:c3750e-ipbasek9-mz.150-2.SE11.bin
+    buffer_size: '524288'
+    config_download_dhcp: disabled
+    config_download_dhcp_next_boot: ''
+    config_file: flash:/config.text
+    enable_break: 'yes'
+    helper_path_list: ''
+    manual_boot: 'no'
+    priv_config_file: flash:/private-config.text
+    timeout_config_download: '0'

--- a/tests/cisco_ios/show_boot/cisco_ios_show_boot.raw
+++ b/tests/cisco_ios/show_boot/cisco_ios_show_boot.raw
@@ -1,0 +1,15 @@
+BOOT path-list      : flash:c3750e-ipbasek9-mz.150-2.SE11.bin
+Config file         : flash:/config.text
+Private Config file : flash:/private-config.text
+Enable Break        : yes
+Manual Boot         : no
+Allow Dev Key         : yes
+HELPER path-list    : 
+Auto upgrade        : yes
+Auto upgrade path   :
+NVRAM/Config file
+      buffer size:   524288
+Timeout for Config
+          Download:    0 seconds
+Config Download
+       via DHCP:       disabled (next boot: disabled


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
This is to parse the `show boot` command from cisco IOS switch
cisco_ios_show_boot
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This collects most of the data from the `show boot` output of a switch
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
