### PR TITLE
show ospf neighbor NEIGHBOR_UPTIME no match when output in 1w2d format

### DIFF
--- a/templates/cisco_xr_show_ospf_neighbor.template
+++ b/templates/cisco_xr_show_ospf_neighbor.template
@@ -4,7 +4,7 @@ Value STATE (\S+\/\s+\-|\S+)
 Value DEAD_TIME (\d+:\d+:\d+)
 Value ADDRESS (\d+.\d+.\d+.\d+)
 Value INTERFACE (\S+)
-Value NEIGHBOR_UPTIME (\d+:\d+:\d+)
+Value NEIGHBOR_UPTIME (\S+)
 
 Start
   ^${NEIGHBOR_ID}\s+${PRIORITY}\s+${STATE}\s+${DEAD_TIME}\s+${ADDRESS}\s+${INTERFACE}

--- a/tests/cisco_xr/show_ospf_neighbor/cisco_xr_show_ospf_neighbor.parsed
+++ b/tests/cisco_xr/show_ospf_neighbor/cisco_xr_show_ospf_neighbor.parsed
@@ -32,4 +32,4 @@ parsed_sample:
   dead_time: "00:00:31"
   address: "10.1.3.1"
   interface: "GigabitEthernet0/0/0/3"
-  neighbor_uptime: "01:04:40"
+  neighbor_uptime: "1w2d"

--- a/tests/cisco_xr/show_ospf_neighbor/cisco_xr_show_ospf_neighbor.raw
+++ b/tests/cisco_xr/show_ospf_neighbor/cisco_xr_show_ospf_neighbor.raw
@@ -13,6 +13,6 @@ Neighbor ID     Pri   State           Dead Time   Address         Interface
 4.4.4.4         1     FULL/DR         00:00:31    10.3.4.4        GigabitEthernet0/0/0/2
     Neighbor is up for 01:04:39
 1.1.1.1         128   FULL/  -        00:00:31    10.1.3.1        GigabitEthernet0/0/0/3
-    Neighbor is up for 01:04:40
+    Neighbor is up for 1w2d
 
 Total neighbor count: 4


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT
cisco_xr_show_ospf_neighbor.template \ cisco_xr \ show ospf neighbor

##### SUMMARY
NEIGHBOR_UPTIME did not match when output was in 1w2d format.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Do what now?
```
