### PR TITLE
Capture "Peer address is" for Serial Interfaces

### DIFF
--- a/templates/cisco_ios_show_ip_interface.template
+++ b/templates/cisco_ios_show_ip_interface.template
@@ -40,6 +40,7 @@ Start
   ^\s+Split
   ^\s+ICMP
   ^\s+IP\s+(?:fast|Flow|CEF|Null|multicast|route|output|access)
+  ^\s+Downstream
   ^\s+Associated
   ^\s+Topology
   ^\s+Router

--- a/templates/cisco_ios_show_ip_interface.template
+++ b/templates/cisco_ios_show_ip_interface.template
@@ -28,6 +28,7 @@ Start
   ^\s+Multicast
   ^\s+2[2-5]\d\.
   ^\s+Address\s+determined
+  ^\s+Peer
   ^\s+Directed
   ^\s+MTU
   ^\s+Helper


### PR DESCRIPTION
Prevent Error condition on parsing Serial interfaces

Serial0/0/0:0 is up, line protocol is up
  Internet address is 172.1.1.110/30
  Broadcast address is 255.255.255.255
  Address determined by non-volatile memory
  Peer address is 172.1.1.109

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request
 - Bugfix Pull Request
 - Additional Testing
 - Docs Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
