### PR TITLE
cisco_nxos_show_version extension for pulling PLATFORM from N9K

### DIFF
--- a/templates/cisco_nxos_show_version.template
+++ b/templates/cisco_nxos_show_version.template
@@ -9,5 +9,6 @@ Start
   ^\s+(NXOS|kickstart)\s+image\s+file\s+is:\s+${BOOT_IMAGE}\s*$$
   ^\s+cisco\s+${PLATFORM}\s+[cC]hassis
   ^\s+cisco\s+Nexus\d+\s+${PLATFORM}
+  ^\s+cisco\s+.+-${PLATFORM}\s*
   ^Kernel\s+uptime\s+is\s+${UPTIME}
   ^\s+Reason:\s${LAST_REBOOT_REASON} -> Record

--- a/tests/cisco_nxos/show_version/cisco_nxos_show_version1.parsed
+++ b/tests/cisco_nxos/show_version/cisco_nxos_show_version1.parsed
@@ -1,0 +1,8 @@
+---
+
+parsed_sample:
+- BOOT_IMAGE: /bootflash/aci-n9000-dk9.14.0.1h.bin
+  LAST_REBOOT_REASON: unknown
+  OS: 14.0(1h) [build 14.0(1h)]
+  PLATFORM: C9396PX
+  UPTIME: 11 day(s), 01 hour(s), 57 minute(s), 02 second(s)

--- a/tests/cisco_nxos/show_version/cisco_nxos_show_version1.parsed
+++ b/tests/cisco_nxos/show_version/cisco_nxos_show_version1.parsed
@@ -1,8 +1,8 @@
 ---
 
 parsed_sample:
-- BOOT_IMAGE: /bootflash/aci-n9000-dk9.14.0.1h.bin
-  LAST_REBOOT_REASON: unknown
-  OS: 14.0(1h) [build 14.0(1h)]
-  PLATFORM: C9396PX
-  UPTIME: 11 day(s), 01 hour(s), 57 minute(s), 02 second(s)
+- boot_image: /bootflash/aci-n9000-dk9.14.0.1h.bin
+  last_reboot_reason: unknown
+  os: 14.0(1h) [build 14.0(1h)]
+  platform: C9396PX
+  uptime: 11 day(s), 01 hour(s), 57 minute(s), 02 second(s)

--- a/tests/cisco_nxos/show_version/cisco_nxos_show_version1.raw
+++ b/tests/cisco_nxos/show_version/cisco_nxos_show_version1.raw
@@ -1,0 +1,43 @@
+Cisco Nexus Operating System (NX-OS) Software
+TAC support: http://www.cisco.com/tac
+Documents: http://www.cisco.com/en/US/products/ps9372/tsd_products_support_series_home.html
+Copyright (c) 2002-2014, Cisco Systems, Inc. All rights reserved.
+The copyrights to certain works contained in this software are
+owned by other third parties and used and distributed under
+license. Certain components of this software are licensed under
+the GNU General Public License (GPL) version 2.0 or the GNU
+Lesser General Public License (LGPL) Version 2.1. A copy of each
+such license is available at
+http://www.opensource.org/licenses/gpl-2.0.php and
+http://www.opensource.org/licenses/lgpl-2.1.php
+
+Software
+  BIOS:      version 07.64
+  kickstart: version 14.0(1h) [build 14.0(1h)]
+  system:    version 14.0(1h) [build 14.0(1h)]
+  PE:        version 4.0(1h)
+  BIOS compile time:       05/16/2018
+  kickstart image file is: /bootflash/aci-n9000-dk9.14.0.1h.bin
+  kickstart compile time:  10/24/2018 03:13:58 [10/24/2018 03:13:58]
+  system image file is:    /bootflash/auto-s
+  system compile time:     10/24/2018 03:13:58 [10/24/2018 03:13:58]
+
+
+Hardware
+  cisco N9K-C9396PX ("supervisor")
+
+   Intel(R) Core(TM) i3- CPU @ 2.50GHz with 16267264 kB of memory.
+  Processor Board ID SAL1909A8CT
+
+  Device name: Leaf-101
+  bootflash:    62522368 kB
+
+Kernel uptime is 11 day(s), 01 hour(s), 57 minute(s), 02 second(s)
+
+Last reset at 20000 usecs after Mon Mar 25 11:44:47 2019 EDT
+  Reason: unknown
+  System version: 14.0(1h)
+  Service: module reloaded
+
+plugin
+  Core Plugin, Ethernet Plugin


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Additional Testing

##### COMPONENT
<!--- Name of the template, os and command  -->
Template: cisco_nxos_show_version.template
OS: Cisco NX-OS
Command: show version

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Extending the cisco_nxos show version template to pull Platform value from slightly different output.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
