### PR TITLE
Cisco IOS - Show ip mroute - Up-time Counters Fix

### DIFF
--- a/templates/cisco_ios_show_ip_mroute.template
+++ b/templates/cisco_ios_show_ip_mroute.template
@@ -1,6 +1,6 @@
 Value MULTICAST_SOURCE_IP (\*|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
 Value MULTICAST_GROUP_IP (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
-Value UP_TIME (\d{2}:\d{2}:\d{2})
+Value UP_TIME (\S+)
 Value EXPIRATION_TIME (\d{2}:\d{2}:\d{2}|stopped)
 Value RENDEZVOUS_POINT (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
 Value FLAGS (\w*)
@@ -9,7 +9,7 @@ Value REVERSE_PATH_FORWARDING_NEIGHBOUR_IP (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
 Value REGISTERING (Registering)
 Value List OUTGOING_INTERFACE (\S+)
 Value List FORWARD_MODE (Forward\/Sparse|Forward\/Dense)
-Value List OUTGOING_MULTICAST_UP_TIME (\d{2}:\d{2}:\d{2})
+Value List OUTGOING_MULTICAST_UP_TIME (\S+)
 Value List OUTGOING_MULTICAST_EXPIRATION_TIME (\d{2}:\d{2}:\d{2}|stopped)
 
 Start


### PR DESCRIPTION
This template was failing for me and it was because the up-time counters change format after 24 hours (Nice one Cisco). Creating a (\S+) solved it for me, but someone might want to get more specific.. 

Example: 
Pre 24 Hours  = 04:03:45
Post 24 Hours = 3d:14h

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_ip_mroute.template, cisco ios, show ip mroute

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
All test data shows pre-24 hour uptime, uptime format changes after 24 hours, causing template to fail.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
