### PR TITLE
Updated cisco_xr_show_version.template

### DIFF
--- a/templates/cisco_xr_show_version.template
+++ b/templates/cisco_xr_show_version.template
@@ -1,28 +1,19 @@
-Value VERSION (\S+)
+Value VERSION (\S[^\[]+)
 Value UPTIME (.+)
 Value LOCATION (\S+)
-Value HARDWARE (\S+)
+Value HARDWARE (.+)
 Value BUILD_HOST (\S+)
 
 Start
-  ^.+UTC
-  ^Cisco.+Software.+Version.+
-  ^Copyright\s\(c\).+
+  ^Cisco IOS XR Software, Version ${VERSION} 
   ^Build\s+Information: -> Build_Info
-  ^[Cc]isco\s${HARDWARE}\s.+
-  ^System\suptime\sis\s${UPTIME} -> Record
-  ^\s+$$
-  ^$$
-  ^.* -> Error "Line not found"
+  ^.+uptime is ${UPTIME}
+  ^${HARDWARE}\s\(.*\) processor
   
+#A VARIATION OF THE OUTPUT, EX. NCS PLATFORM
 Build_Info
   ^\s+Built\sBy.+
   ^\s+Built\sOn.+
-  ^\s+Build\sHost\s+:\s+${BUILD_HOST}
-  ^\s+Workspace\s+:\s\S+
-  ^\s+Version\s+:\s${VERSION}
-  ^\s+Location\s+:\s${LOCATION}
-  ^$$ -> Start
-  ^\s+$$
-  ^$$
-  ^.* -> Error "Line not found"
+  ^\s+Buil[dt]\sHost.+:\s+${BUILD_HOST}
+  ^\s+Workspace.+:\s\S+
+  ^\s+Location.+:\s${LOCATION} -> Start

--- a/tests/cisco_xr/show_version/cisco_xr_show_version.parsed
+++ b/tests/cisco_xr/show_version/cisco_xr_show_version.parsed
@@ -6,5 +6,5 @@ parsed_sample:
 - version : '6.1.4' 
   uptime : '4 weeks, 6 days, 1 hour, 42 minutes'
   location : '/opt/cisco/XR/packages/'
-  hardware : 'NCS-5500'
+  hardware : 'cisco NCS-5500'
   build_host : 'iox-lnx-032'

--- a/tests/cisco_xr/show_version/cisco_xr_show_version.parsed
+++ b/tests/cisco_xr/show_version/cisco_xr_show_version.parsed
@@ -3,9 +3,8 @@
 parsed_sample:
 
 
-- hardware : 'NCS-5500'
+- version : '6.1.4' 
   uptime : '4 weeks, 6 days, 1 hour, 42 minutes'
-  version : '6.1.4'
   location : '/opt/cisco/XR/packages/'
+  hardware : 'NCS-5500'
   build_host : 'iox-lnx-032'
-

--- a/tests/cisco_xr/show_version/cisco_xr_show_version_crs.parsed
+++ b/tests/cisco_xr/show_version/cisco_xr_show_version_crs.parsed
@@ -1,0 +1,10 @@
+---
+
+parsed_sample:
+
+
+- version : '4.1.0'
+  uptime : '1 week, 6 days, 4 hours, 22 minutes'
+  location : ''
+  hardware : 'cisco CRS-8/S'
+  build_host : ''

--- a/tests/cisco_xr/show_version/cisco_xr_show_version_crs.raw
+++ b/tests/cisco_xr/show_version/cisco_xr_show_version_crs.raw
@@ -1,0 +1,37 @@
+Cisco IOS XR Software, Version 4.1.0[Default]
+Copyright (c) 2010 by Cisco Systems, Inc.
+
+ 
+ROM: System Bootstrap, Version 2.100(20100129:213223) [CRS-1 ROMMON],  
+
+
+router uptime is 1 week, 6 days, 4 hours, 22 minutes
+System image file is "bootflash:disk0/hfr-os-mbi-4.1.0/mbihfr-rp.vm"
+
+
+cisco CRS-8/S (7457) processor with 4194304K bytes of memory.
+7457 processor at 1197Mhz, Revision 1.2
+
+
+2 Management Ethernet
+8 GigabitEthernet
+12 SONET/SDH
+12 Packet over SONET/SDH
+1 WANPHY controller(s)
+1 TenGigE
+1019k bytes of non-volatile configuration memory.
+38079M bytes of hard disk.
+3607592k bytes of disk0: (Sector size 512 bytes).
+3607592k bytes of disk1: (Sector size 512 bytes).
+
+
+Boot device on node 0/1/SP is bootflash:
+Package active on node 0/1/SP:
+hfr-doc, V 4.1.0[Default], Cisco Systems, at disk0:hfr-doc-4.1.0
+    Built on Thu May  6 17:28:51 DST 2010
+    By sjc-lds-364 in /auto/ioxbuild6/production/4.1.0.DT_IMAGE/hfr/workspace for pie
+
+
+iosxr-infra, V 4.1.0[Default], Cisco Systems, at disk0:iosxr-infra-4.1.0
+    Built on Thu May  6 15:09:12 DST 2010
+    By sjc-lds-364 in /auto/ioxbuild6/production/4.1.0.DT_IMAGE/hfr/workspace for pie


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request
    - Updated the cisco_xr_show_version.template 
 - Additional Testing
    - Added a CRS version RAW and parsed files

##### COMPONENT
cisco_xr_show_version.template

##### SUMMARY
I updated the cisco_xr_show_version.template to incorporate the CRS output of the show version command, in addition to the NCS version that it already parses. See RAW and parsed files for the before and after outputs.