### PR TITLE
Bugfix: asa_dir template to account for change in raw output

### DIFF
--- a/templates/cisco_asa_dir.template
+++ b/templates/cisco_asa_dir.template
@@ -4,6 +4,7 @@ Value PERMISSIONS (\S+)
 Value SIZE (\d+)
 Value Fillup TOTAL_SIZE (\d+)
 Value Fillup TOTAL_FREE (\d+)
+Value Fillup TOTAL_PERCENT_FREE (\d+)
 Value DATE_TIME ((<no date>)|(\S+\s\w+\s\d+\s\d+))
 Value NAME (\S+)
 
@@ -14,6 +15,10 @@ DIR
   ^Directory of\s+${FILE_SYSTEM} -> DIR
   ^((\s+)*${ID})\s+${PERMISSIONS}\s+${SIZE}\s+${DATE_TIME}\s+${NAME} -> Record
   ^${TOTAL_SIZE}\s+\S+\s+\S+\s\(${TOTAL_FREE} bytes free\)
+  # Accounts for X files total size: X bytes
+  ^\d+\s+\S+\s+\S+\s+\d+\s+\S+
+  ^${TOTAL_SIZE} bytes total \(${TOTAL_FREE} bytes free/${TOTAL_PERCENT_FREE}\% free\)
+  ^.*$$
 
 #
 EOF

--- a/tests/cisco_asa/dir/cisco_asa_dir.parsed
+++ b/tests/cisco_asa/dir/cisco_asa_dir.parsed
@@ -1,164 +1,165 @@
 ---
 parsed_sample:
 
-- file_system: 'disk0:/'
-  id: '120'
-  permissions: '-rwx'
-  size: '74369568'
-  date_time: '19:39:56 Nov 03 2015'
-  name: 'asa951-lfbff-k8.spa'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '121'
-  permissions: '-rwx'
-  size: '25025404'
-  date_time: '19:40:46 Nov 03 2015'
-  name: 'asdm-751.bin'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '122'
-  permissions: '-rwx'
-  size: '89'
-  date_time: '11:48:07 May 04 2016'
-  name: '.boot_string'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '11'
-  permissions: 'drwx'
-  size: '4096'
-  date_time: '19:43:48 Nov 03 2015'
-  name: 'log'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '23'
-  permissions: 'drwx'
-  size: '4096'
-  date_time: '19:44:38 Nov 03 2015'
-  name: 'crypto_archive'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '24'
-  permissions: 'drwx'
-  size: '4096'
-  date_time: '19:44:40 Nov 03 2015'
-  name: 'coredumpinfo'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '123'
-  permissions: 'drwx'
-  size: '4096'
-  date_time: '08:33:16 May 31 2016'
-  name: 'LOCAL-CA-SERVER'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '124'
-  permissions: '-rwx'
-  size: '4096'
-  date_time: '00:00:00 Jan 01 1980'
-  name: 'FSCK0000.REC'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '125'
-  permissions: '-rwx'
-  size: '28672'
-  date_time: '00:00:00 Jan 01 1980'
-  name: 'FSCK0001.REC'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '126'
-  permissions: '-rwx'
-  size: '4096'
-  date_time: '00:00:00 Jan 01 1980'
-  name: 'FSCK0002.REC'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '127'
-  permissions: '-rwx'
-  size: '28672'
-  date_time: '00:00:00 Jan 01 1980'
-  name: 'FSCK0003.REC'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '128'
-  permissions: '-rwx'
-  size: '4096'
-  date_time: '00:00:00 Jan 01 1980'
-  name: 'FSCK0004.REC'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '129'
-  permissions: '-rwx'
-  size: '19183882'
-  date_time: '05:45:32 Feb 12 2016'
-  name: 'anyconnect-win-4.2.01035-k9.pkg'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '130'
-  permissions: '-rwx'
-  size: '17469933'
-  date_time: '05:45:56 Feb 12 2016'
-  name: 'anyconnect-macosx-i386-4.2.01035-k9.pkg'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '131'
-  permissions: '-rwx'
-  size: '82330784'
-  date_time: '05:56:48 Feb 12 2016'
-  name: 'asa952-2-lfbff-k8.SPA'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '132'
-  permissions: '-rwx'
-  size: '4102'
-  date_time: '07:07:44 Feb 12 2016'
-  name: 'scp_f1'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '133'
-  permissions: '-rwx'
-  size: '4102'
-  date_time: '07:09:04 Feb 12 2016'
-  name: 'scp_f2'
-  total_size: '7859437568'
-  total_free: '4417200128'
-
-- file_system: 'disk0:/'
-  id: '134'
-  permissions: '-rwx'
-  size: '2595'
-  date_time: '07:20:42 Feb 12 2016'
-  name: 'general.xml'
-  total_size: '7859437568'
-  total_free: '4417200128'
+-   date_time: 19:39:56 Nov 03 2015
+    file_system: disk0:/
+    id: '120'
+    name: asa951-lfbff-k8.spa
+    permissions: -rwx
+    size: '74369568'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 19:40:46 Nov 03 2015
+    file_system: disk0:/
+    id: '121'
+    name: asdm-751.bin
+    permissions: -rwx
+    size: '25025404'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 11:48:07 May 04 2016
+    file_system: disk0:/
+    id: '122'
+    name: .boot_string
+    permissions: -rwx
+    size: '89'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 19:43:48 Nov 03 2015
+    file_system: disk0:/
+    id: '11'
+    name: log
+    permissions: drwx
+    size: '4096'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 19:44:38 Nov 03 2015
+    file_system: disk0:/
+    id: '23'
+    name: crypto_archive
+    permissions: drwx
+    size: '4096'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 19:44:40 Nov 03 2015
+    file_system: disk0:/
+    id: '24'
+    name: coredumpinfo
+    permissions: drwx
+    size: '4096'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 08:33:16 May 31 2016
+    file_system: disk0:/
+    id: '123'
+    name: LOCAL-CA-SERVER
+    permissions: drwx
+    size: '4096'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 00:00:00 Jan 01 1980
+    file_system: disk0:/
+    id: '124'
+    name: FSCK0000.REC
+    permissions: -rwx
+    size: '4096'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 00:00:00 Jan 01 1980
+    file_system: disk0:/
+    id: '125'
+    name: FSCK0001.REC
+    permissions: -rwx
+    size: '28672'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 00:00:00 Jan 01 1980
+    file_system: disk0:/
+    id: '126'
+    name: FSCK0002.REC
+    permissions: -rwx
+    size: '4096'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 00:00:00 Jan 01 1980
+    file_system: disk0:/
+    id: '127'
+    name: FSCK0003.REC
+    permissions: -rwx
+    size: '28672'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 00:00:00 Jan 01 1980
+    file_system: disk0:/
+    id: '128'
+    name: FSCK0004.REC
+    permissions: -rwx
+    size: '4096'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 05:45:32 Feb 12 2016
+    file_system: disk0:/
+    id: '129'
+    name: anyconnect-win-4.2.01035-k9.pkg
+    permissions: -rwx
+    size: '19183882'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 05:45:56 Feb 12 2016
+    file_system: disk0:/
+    id: '130'
+    name: anyconnect-macosx-i386-4.2.01035-k9.pkg
+    permissions: -rwx
+    size: '17469933'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 05:56:48 Feb 12 2016
+    file_system: disk0:/
+    id: '131'
+    name: asa952-2-lfbff-k8.SPA
+    permissions: -rwx
+    size: '82330784'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 07:07:44 Feb 12 2016
+    file_system: disk0:/
+    id: '132'
+    name: scp_f1
+    permissions: -rwx
+    size: '4102'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 07:09:04 Feb 12 2016
+    file_system: disk0:/
+    id: '133'
+    name: scp_f2
+    permissions: -rwx
+    size: '4102'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'
+-   date_time: 07:20:42 Feb 12 2016
+    file_system: disk0:/
+    id: '134'
+    name: general.xml
+    permissions: -rwx
+    size: '2595'
+    total_free: '4417200128'
+    total_percent_free: ''
+    total_size: '7859437568'

--- a/tests/cisco_asa/dir/cisco_asa_dir2.parsed
+++ b/tests/cisco_asa/dir/cisco_asa_dir2.parsed
@@ -1,0 +1,93 @@
+---
+parsed_sample:
+
+-   date_time: 06:43:00 Jun 30 2018
+    file_system: disk0:/
+    id: '97'
+    name: asa982-lfbff-k8.SPA
+    permissions: -rwx
+    size: '108563072'
+    total_free: '3847725056'
+    total_percent_free: '52'
+    total_size: '7365472256'
+-   date_time: 06:43:22 Jun 30 2018
+    file_system: disk0:/
+    id: '98'
+    name: asdm-782.bin
+    permissions: -rwx
+    size: '26970456'
+    total_free: '3847725056'
+    total_percent_free: '52'
+    total_size: '7365472256'
+-   date_time: 16:06:56 Jun 04 2019
+    file_system: disk0:/
+    id: '99'
+    name: .boot_string
+    permissions: -rwx
+    size: '63'
+    total_free: '3847725056'
+    total_percent_free: '52'
+    total_size: '7365472256'
+-   date_time: 06:46:42 Jun 30 2018
+    file_system: disk0:/
+    id: '11'
+    name: log
+    permissions: drwx
+    size: '4096'
+    total_free: '3847725056'
+    total_percent_free: '52'
+    total_size: '7365472256'
+-   date_time: 06:47:34 Jun 30 2018
+    file_system: disk0:/
+    id: '22'
+    name: crypto_archive
+    permissions: drwx
+    size: '4096'
+    total_free: '3847725056'
+    total_percent_free: '52'
+    total_size: '7365472256'
+-   date_time: 06:47:36 Jun 30 2018
+    file_system: disk0:/
+    id: '23'
+    name: coredumpinfo
+    permissions: drwx
+    size: '4096'
+    total_free: '3847725056'
+    total_percent_free: '52'
+    total_size: '7365472256'
+-   date_time: 02:58:32 May 17 2019
+    file_system: disk0:/
+    id: '100'
+    name: asa992-32-lfbff-k8.SPA
+    permissions: -rwx
+    size: '111505136'
+    total_free: '3847725056'
+    total_percent_free: '52'
+    total_size: '7365472256'
+-   date_time: 03:00:24 May 17 2019
+    file_system: disk0:/
+    id: '101'
+    name: asdm-791-151.bin
+    permissions: -rwx
+    size: '29197128'
+    total_free: '3847725056'
+    total_percent_free: '52'
+    total_size: '7365472256'
+-   date_time: 03:13:54 May 17 2019
+    file_system: disk0:/
+    id: '105'
+    name: snmp
+    permissions: drwx
+    size: '4096'
+    total_free: '3847725056'
+    total_percent_free: '52'
+    total_size: '7365472256'
+-   date_time: 16:43:50 Jun 04 2019
+    file_system: disk0:/
+    id: '109'
+    name: testfile.spa
+    permissions: -rwx
+    size: '18124800'
+    total_free: '3847725056'
+    total_percent_free: '52'
+    total_size: '7365472256'

--- a/tests/cisco_asa/dir/cisco_asa_dir2.raw
+++ b/tests/cisco_asa/dir/cisco_asa_dir2.raw
@@ -1,0 +1,15 @@
+Directory of disk0:/
+
+97     -rwx  108563072    06:43:00 Jun 30 2018  asa982-lfbff-k8.SPA
+98     -rwx  26970456     06:43:22 Jun 30 2018  asdm-782.bin
+99     -rwx  63           16:06:56 Jun 04 2019  .boot_string
+11     drwx  4096         06:46:42 Jun 30 2018  log
+22     drwx  4096         06:47:34 Jun 30 2018  crypto_archive
+23     drwx  4096         06:47:36 Jun 30 2018  coredumpinfo
+100    -rwx  111505136    02:58:32 May 17 2019  asa992-32-lfbff-k8.SPA
+101    -rwx  29197128     03:00:24 May 17 2019  asdm-791-151.bin
+105    drwx  4096         03:13:54 May 17 2019  snmp
+109    -rwx  18124800     16:43:50 Jun 04 2019  testfile.spa
+
+6 file(s) total size: 294360655 bytes
+7365472256 bytes total (3847725056 bytes free/52% free)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_asa_dir.template

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
User in NTC slack was not getting TOTAL_SIZE/TOTAL_FREE due to changed output from ASA

Changed the following:
- Added new line to capture the changed raw output from ASA dir command
- Added new value (TOTAL_PERCENT_FREE) from new raw output
- Added line to catch, but not capture new line regarding total files and size (don't think it's relevant to add at this time to capture the output)
- Added an error line at the end
