### PR TITLE
Corrected Local IP and Local AS number line

### DIFF
--- a/templates/arista_eos_show_ip_bgp_summary.template
+++ b/templates/arista_eos_show_ip_bgp_summary.template
@@ -12,7 +12,7 @@ Value STATE_PFXRCD (\d+)
 Value STATE_PFXACC (\d+)
 
 Start
-  ^.*\s+${ROUTER_ID}.*\s+${LOCAL_AS} -> Continue
+  ^\w+\s\w+\s${ROUTER_ID}.*\s+${LOCAL_AS} -> Continue
   ^\s+${BGP_NEIGH}\s+\d+\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE}\s+${STATE_PFXRCD}\s+${STATE_PFXACC} -> Record
   ^\s+${BGP_NEIGH}\s+\d+\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE}\s+ -> Record
   ^${BGP_NEIGH}\s+\d+\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE_PFXRCD} -> Record


### PR DESCRIPTION
Corrected the local IP and local AS Number line to fetch correct value

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT
<!--- Name of the template, os and command  -->

Local IP and Local AS line was not fetching the correct IP address and AS Number
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Changed the first line of the rule with the correct regular expression
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
