### PR TITLE
Add files via upload

### DIFF
--- a/templates/cisco_xr_show_ip_interface_brief.template
+++ b/templates/cisco_xr_show_ip_interface_brief.template
@@ -1,0 +1,8 @@
+Value INTERFACE (.+?)
+Value IP_ADDRESS (\S+)
+Value INTF_STATE (Up|Down|Shutdown)
+Value PROTO_STATE (Up|Down)
+Value VRF_NAME (\S+)
+
+Start
+  ^${INTERFACE}\s+${IP_ADDRESS}\s+${INTF_STATE}\s+${PROTO_STATE}\s+${VRF_NAME} -> Record

--- a/templates/index
+++ b/templates/index
@@ -252,6 +252,7 @@ cisco_xr_show_cdp_neighbors_detail.template, .*, cisco_xr, sh[[ow]] c[[dp]] neig
 cisco_xr_show_cef_drops_location.template, .*, cisco_xr, sh[[ow]] cef drops loc[[ation]]
 cisco_xr_show_redundancy_summary.template, .*, cisco_xr, sh[[ow]] redun[[dancy]] summ[[ary]]
 cisco_xr_show_interface_brief.template, .*, cisco_xr, sh[[ow]] int[[erface]] br[[ief]]
+cisco_xr_show_ip_interface_brief.template, .*, cisco_xr, sh[[ow]] ip int[[erface]] br[[ief]]
 cisco_xr_admin_show_platform.template, .*, cisco_xr, adm[[in]] sh[[ow]] pla[[tform]]
 cisco_xr_show_ip_bgp_summary.template, .*, cisco_xr, sh[[ow]] ip b[[gp]] s[[ummary]]
 cisco_xr_show_isis_neighbors.template, .*, cisco_xr, sh[[ow]] isis ne[[ighbors]]


### PR DESCRIPTION
ISSUE TYPE

 - New Template Pull Request

COMPONENT

cisco_xr_show_ip_interface_brief.template

SUMMARY

Implementing "show ip interface brief" command for Cisco IOS XR devices.
The command allows to view all interfaces with their IP addresses, state and the VRF it belongs to.
