### PR TITLE
Fix spacing before VLAN number

### DIFF
--- a/templates/cisco_ios_show_mac-address-table.template
+++ b/templates/cisco_ios_show_mac-address-table.template
@@ -19,4 +19,4 @@ TYPE3
   ^\s+${VLAN}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+${DESTINATION_PORT} -> Record
 
 TYPE4
-  ^\s+${VLAN}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+${DESTINATION_PORT} -> Record
+  ^(?:\s+)?${VLAN}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+${DESTINATION_PORT} -> Record


### PR DESCRIPTION
[TYPE4] Ignore spacing before VLAN number that's in 4 digit 
(If VLAN number is 4 digit, it has no space)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
Template name: cisco_ios_show_mac-address-table.template
OS: Cisco IOS
Command: show mac address-table

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Ignore spacing before VLAN number that's in 4 digit 
(If VLAN number is 4 digit, it has no space)

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```