### PR TITLE
Arista EOS show vrf to create a simple table of VRF names and RDs

### DIFF
--- a/templates/arista_eos_show_vrf.template
+++ b/templates/arista_eos_show_vrf.template
@@ -1,0 +1,8 @@
+Value VRF (\S+)
+Value RD (<not set>|\S+)
+
+Start
+  ^\s+Vrf\s+RD\s+Protocols\s+State\s+Interfaces -> Start_record
+
+Start_record
+  ^\s+${VRF}\s+${RD} -> Record

--- a/templates/index
+++ b/templates/index
@@ -50,6 +50,7 @@ arista_eos_show_clock.template, .*, arista_eos, sh[[ow]] clo[[ck]]
 arista_eos_dir_flash.template, .*, arista_eos, dir fl[[ash:]]
 arista_eos_show_mlag.template, .*, arista_eos, sh[[ow]] ml[[ag]]
 arista_eos_show_vlan.template, .*, arista_eos, sh[[ow]] vl[[an]]
+arista_eos_show_vrf.template, .*, arista_eos, sh[[ow]] vrf
 
 aruba_os_show_ipv6_interface_brief.template, .*, aruba_os, sh[[ow]] ipv6 in[[terface]] b[[rief]]
 aruba_os_show_ip_interface_brief.template, .*, aruba_os, sh[[ow]] ip in[[terface]] b[[rief]]

--- a/tests/arista_eos/show_vrf/arista_eos_show_vrf.parsed
+++ b/tests/arista_eos/show_vrf/arista_eos_show_vrf.parsed
@@ -1,0 +1,16 @@
+---
+parsed_sample:
+- vrf: blue
+  rd: 10.125.253.15:1  
+
+- vrf: green
+  rd: <not set>
+
+- vrf: yellow
+  rd: 10.125.253.15:4
+
+- vrf: red
+  rd: 10.125.253.15:6
+
+- vrf: black
+  rd: 999:999

--- a/tests/arista_eos/show_vrf/arista_eos_show_vrf.raw
+++ b/tests/arista_eos/show_vrf/arista_eos_show_vrf.raw
@@ -1,0 +1,6 @@
+   Vrf              RD                     Protocols       State             Interfaces                    
+   blue             10.125.253.15:1        ipv4,ipv6       v4:routing,       Vlan1006, Vlan2230, Vlan2231, 
+   green            <not set>              ipv4,ipv6       v4:routing,       Vlan1015                      
+   yellow           10.125.253.15:4        ipv4,ipv6       v4:routing,       Vlan1009                      
+   red              10.125.253.15:6        ipv4,ipv6       v4:routing,       Vlan1011                        
+   black            999:999                ipv4,ipv6       v4:no routing,    Management1                                   


### PR DESCRIPTION
##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
- arista_eos_show_vrf.template
- arista_eos
- show vrf

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
A template for Arista EOS command "show vrf" which creates a table of the VRF names and Route Distinguishers (RD)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
