### PR TITLE
Update cisco_ios_show_interfaces_description.template

### DIFF
--- a/templates/cisco_ios_show_interfaces_description.template
+++ b/templates/cisco_ios_show_interfaces_description.template
@@ -6,9 +6,9 @@ Value DESCRIP (\S.*?)
 Start
   ^Interface\s+Status\s+Protocol\s+Description\s*$$ -> Begin
   ^\s*$$
-  ^. -> Error
+
 
 Begin
   ^${PORT}\s+${STATUS}\s+${PROTOCOL}(?:\s+${DESCRIP})?\s*$$ -> Record
   ^\s*$$
-  ^. -> Error
+


### PR DESCRIPTION
the above template gives me an exception with ios 15.7 2911 router. I saw that this was due to the first two lines that appear when you do a show int desc: When I removed them, the parsing worked.

Load for five secs: 17%/12%; one minute: 22%; five minutes: 21%
Time source is NTP, 10:59:42.831 EEST Wed Aug 7 2019

So I modified the template and it works now

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT
<!--- cisco_ios_show_interfaces_description.template  -->

##### SUMMARY
<!--- I deleted the "^. -> Error" line because it gave an exception -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
textfsm.TextFSMError: State Error raised. Rule Line: 9. Input Line: Load for five secs: 17%/12%; one minute: 22%; five minutes: 21%

after removing the ^.-> works ok
[['Em0/0', 'admin down', 'down', '']
['Gi0/0', 'up', 'up', '']
['Gi0/0.1', 'up', 'up', 'To Data Vlan']]
```
