### PR TITLE
Add 'List' before Serial to cisco_asa_show_version.template.

### DIFF
--- a/templates/cisco_asa_show_version.template
+++ b/templates/cisco_asa_show_version.template
@@ -13,7 +13,7 @@ Value MAX_INTF (\d+)
 Value MAX_VLANS (\d+)
 Value FAILOVER (\S+)
 Value CLUSTER (\S+)
-Value SERIAL (\S+)
+Value List SERIAL (\S+)
 Value LAST_MOD (.+)
 
 Start

--- a/tests/cisco_asa/show_version/cisco_asa_show_version.parsed
+++ b/tests/cisco_asa/show_version/cisco_asa_show_version.parsed
@@ -24,5 +24,5 @@ parsed_sample:
   max_vlans: '50'
   failover: 'Active/Standby'
   cluster: 'Disabled'
-  serial: '9AT1L9EX0DF'
+  serial: ['9AT1L9EX0DF']
   last_mod: 'ntc at 18:56:48.410 UTC Wed Apr 5 2017'

--- a/tests/cisco_asa/show_version/cisco_asa_show_version.raw
+++ b/tests/cisco_asa/show_version/cisco_asa_show_version.raw
@@ -1,57 +1,61 @@
-Cisco Adaptive Security Appliance Software Version 9.5(2)204
-Device Manager Version 7.5(2)
 
-Compiled on Mon 15-Feb-16 19:00 PST by builders
-System image file is "boot:/asa952-204-smp-k8.bin"
+Cisco Adaptive Security Appliance Software Version 9.9(2)32 
+Firepower Extensible Operating System Version 2.3(1.121)
+Device Manager Version 7.9(1)151
+
+Compiled on Mon 05-Nov-18 13:32 PST by builders
+System image file is "disk0:/asa992-32-lfbff-k8.SPA"
 Config file at boot was "startup-config"
 
-asa1 up 41 days 19 hours
+LHRUB-ASA5516-01 up 51 days 9 hours
+failover cluster up 83 days 15 hours
 
-Hardware:   ASAv, 2048 MB RAM, CPU Pentium II 1800 MHz,
-Model Id:   ASAv10
-Internal ATA Compact Flash, 8192MB
-Slot 1: ATA Compact Flash, 8192MB
-BIOS Flash Firmware Hub @ 0x0, 0KB
+Hardware:   ASA5516, 8192 MB RAM, CPU Atom C2000 series 2416 MHz, 1 CPU (8 cores)
+Internal ATA Compact Flash, 8000MB
+BIOS Flash M25P64 @ 0xfed01000, 16384KB
 
+Encryption hardware device : Cisco ASA Crypto on-board accelerator (revision 0x1)
+                             Number of accelerators: 1
 
- 0: Ext: Management0/0       : address is 5000.000a.0000, irq 11
- 1: Ext: GigabitEthernet0/0  : address is 5000.000a.0001, irq 11
- 2: Ext: GigabitEthernet0/1  : address is 5000.000a.0002, irq 10
- 3: Ext: GigabitEthernet0/2  : address is 5000.000a.0003, irq 10
- 4: Ext: GigabitEthernet0/3  : address is 5000.000a.0004, irq 11
- 5: Ext: GigabitEthernet0/4  : address is 5000.000a.0005, irq 11
- 6: Ext: GigabitEthernet0/5  : address is 5000.000a.0006, irq 10
- 7: Ext: GigabitEthernet0/6  : address is 5000.000a.0007, irq 10
-
-License mode: Smart Licensing
-ASAv Platform License State: Unlicensed
-No active entitlement: no feature tier and no throughput level configured
-*Memory resource allocation is more than the permitted limit.
+ 1: Ext: GigabitEthernet1/1  : address is 7872.5dce.e58c, irq 255
+ 2: Ext: GigabitEthernet1/2  : address is 7872.5dce.e58d, irq 255
+ 3: Ext: GigabitEthernet1/3  : address is 7872.5dce.e58e, irq 255
+ 4: Ext: GigabitEthernet1/4  : address is 7872.5dce.e58f, irq 255
+ 5: Ext: GigabitEthernet1/5  : address is 7872.5dce.e590, irq 255
+ 6: Ext: GigabitEthernet1/6  : address is 7872.5dce.e591, irq 255
+ 7: Ext: GigabitEthernet1/7  : address is 7872.5dce.e592, irq 255
+ 8: Ext: GigabitEthernet1/8  : address is 7872.5dce.e593, irq 255
+ 9: Int: Internal-Data1/1    : address is 7872.5dce.e58b, irq 255
+10: Int: Internal-Data1/2    : address is 0000.0001.0002, irq 0
+11: Int: Internal-Control1/1 : address is 0000.0001.0001, irq 0
+12: Int: Internal-Data1/3    : address is 0000.0001.0003, irq 0
+13: Ext: Management1/1       : address is 7872.5dce.e58b, irq 0
+14: Int: Internal-Data1/4    : address is 0000.0100.0001, irq 0
 
 Licensed features for this platform:
-Maximum Physical Interfaces       : 10
-Maximum VLANs                     : 50
-Inside Hosts                      : Unlimited
-Failover                          : Active/Standby
-Encryption-DES                    : Enabled
-Encryption-3DES-AES               : Enabled
-Security Contexts                 : 0
-Carrier                           : Disabled
-AnyConnect Premium Peers          : 2
-AnyConnect Essentials             : Disabled
-Other VPN Peers                   : 250
-Total VPN Peers                   : 250
-AnyConnect for Mobile             : Disabled
-AnyConnect for Cisco VPN Phone    : Disabled
-Advanced Endpoint Assessment      : Disabled
-Shared License                    : Disabled
-Total UC Proxy Sessions           : 2
-Botnet Traffic Filter             : Enabled
-Cluster                           : Disabled
+Maximum Physical Interfaces       : Unlimited      perpetual
+Maximum VLANs                     : 150            perpetual
+Inside Hosts                      : Unlimited      perpetual
+Failover                          : Active/Active  perpetual
+Encryption-DES                    : Enabled        perpetual
+Encryption-3DES-AES               : Enabled        perpetual
+Security Contexts                 : 2              perpetual
+Carrier                           : Disabled       perpetual
+AnyConnect Premium Peers          : 4              perpetual
+AnyConnect Essentials             : Disabled       perpetual
+Other VPN Peers                   : 300            perpetual
+Total VPN Peers                   : 300            perpetual
+AnyConnect for Mobile             : Disabled       perpetual
+AnyConnect for Cisco VPN Phone    : Disabled       perpetual
+Advanced Endpoint Assessment      : Disabled       perpetual
+Shared License                    : Disabled       perpetual
+Total TLS Proxy Sessions          : 1000           perpetual
+Botnet Traffic Filter             : Disabled       perpetual
+Cluster                           : Enabled        perpetual
+Cluster Members                   : 2              perpetual
+VPN Load Balancing                : Enabled        perpetual
 
-Serial Number: 9AT1L9EX0DF
+Serial Number: JAD222605K8
 
-Image type          : Release
-Key version         : A
-
-Configuration last modified by ntc at 18:56:48.410 UTC Wed Apr 5 2017
+Image type                : Release
+Key Version               : A


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
##### COMPONENT
<!--- Name of the template, os and command  -->
b/templates/cisco_asa_show_version.template cisco_asa, show version

##### SUMMARY
Hello everyone, do you guys think it would be ok to change cisco_asa_show_version.template:
from: Value SERIAL (\S+) to Value List SERIAL (\S+) this would be in par with cisco_ios_show_version.template, I have a script that parses this to json and another frontend (datatables.net) that reads this json. The issue is when I use the datatables search api to search for a serial number which is not an array in json, it fails to find it, I can change it to look in array but then I can’t search for ASA’s serial numbers, so by making them both the same (array/list) it lets me search for any SN, be it IOS or ASA.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Before: 
note `serial` is a string:
[{'version': 'XXXX', 'device_mgr_version': '7.9(1)151', 'image': 'disk0:/xxx-lfbff-k8.SPA', 'hostname': 'XXX-ASA5516-01', 'uptime': '51 days 8 hours', 'hardware': 'ASA5516, 8192 MB RAM, CPU Atom C2000 series 2416 MHz', 'model': '', 'flash': '8000MB', 'interfaces': ['GigabitEthernet1/1', 'GigabitEthernet1/2', 'GigabitEthernet1/3', 'GigabitEthernet1/4', 'GigabitEthernet1/5', 'GigabitEthernet1/6', 'GigabitEthernet1/7', 'GigabitEthernet1/8', 'Internal-Data1/1'], 'license_mode': '', 'license_state': '', 'max_intf': '', 'max_vlans': '150', 'failover': 'Active/Active', 'cluster': 'Enabled', 'serial': 'JAD22XXXX', 'last_mod': 'xxx at 17:20:37.576 CDT Thu Aug 8 2019'}]

After: note `serial` is a list:

[{'version': 'XXXX', 'device_mgr_version': '7.9(1)151', 'image': 'disk0:/xxx-lfbff-k8.SPA', 'hostname': 'XXX-ASA5516-01', 'uptime': '51 days 8 hours', 'hardware': 'ASA5516, 8192 MB RAM, CPU Atom C2000 series 2416 MHz', 'model': '', 'flash': '8000MB', 'interfaces': ['GigabitEthernet1/1', 'GigabitEthernet1/2', 'GigabitEthernet1/3', 'GigabitEthernet1/4', 'GigabitEthernet1/5', 'GigabitEthernet1/6', 'GigabitEthernet1/7', 'GigabitEthernet1/8', 'Internal-Data1/1'], 'license_mode': '', 'license_state': '', 'max_intf': '', 'max_vlans': '150', 'failover': 'Active/Active', 'cluster': 'Enabled', 'serial': ['JAD22XXXX'], 'last_mod': 'xxx at 17:20:37.576 CDT Thu Aug 8 2019'}]

```
