### PR TITLE
Support for locating templates when installing local directory on Windows - Fixes #455

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,8 @@
+## [1.2.0]
+### Fixed for any bug fixes
+- [#455] Template files were inaccessable when installing from local directory; now works when using `pip -e`
+
+### Added for new features
+### Changed for changes in existing functionality
+### Deprecated for soon-to-be removed features
+### Removed for now removed features

--- a/lib/ntc_templates/parse.py
+++ b/lib/ntc_templates/parse.py
@@ -1,5 +1,6 @@
 """ntc_templates.parse."""
-import pkg_resources
+import os
+
 try:
     from textfsm import clitable
 except ImportError:
@@ -7,7 +8,13 @@ except ImportError:
 
 
 def _get_template_dir():
-    return pkg_resources.resource_filename("ntc_templates", "templates")
+    package_dir = os.path.dirname(__file__)
+    template_dir = os.path.join(package_dir, "templates")
+    if not os.path.isdir(template_dir):
+        project_dir = os.path.dirname(os.path.dirname(os.path.dirname(template_dir)))
+        template_dir = os.path.join(project_dir, "templates")
+
+    return template_dir
 
 
 def _clitable_to_dict(cli_table):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request (Fixes #455)

##### COMPONENT
<!--- Name of the template, os and command  -->
parse.py - _get_template_dir

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Cloning and installing the project from local directory on Windows fails to properly install template directory (symlinks do not work on Windows).

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
