### PR TITLE
Fixes #424: Cisco ASA - show failover error.

### DIFF
--- a/templates/cisco_asa_show_failover.template
+++ b/templates/cisco_asa_show_failover.template
@@ -57,6 +57,7 @@ ThisHost
   ^\s*Other\s+host:.+?-\s+${SERVICE_STATE_MATE}\s*$$ -> OtherHost
   ^\s*Other\s+host:\s+\S+\s*$$ -> OtherHost
   ^\s*slot\s+\d+:\s+empty\s*$$
+  ^\s*ASA\s+FirePOWER
   ^\s*$$
   ^. -> Error
 
@@ -68,6 +69,7 @@ OtherHost
   # Service module has different line
   ^\s*\S+,\s+\S+,\s+\S+\s*$$
   ^\s*slot\s+\d+:\s+empty\s*$$
+  ^\s*ASA\s+FirePOWER
   ^Stateful\s+Failover\s+Logical\s+Update\s+Statistics\s*$$ -> Stats
   ^\s*$$
   ^. -> Error


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
cisco_asa_show_failover

##### SUMMARY
The output of "show failover" command includes additional line in newer ASA versions:

`ASA FirePOWER, 5.4.1-211, Up, (Monitored)`

Which seems to be causing the problem.