### PR TITLE
Add template cisco_nxos_show_ip_interface_brief

### DIFF
--- a/templates/cisco_nxos_show_ip_interface_brief.template
+++ b/templates/cisco_nxos_show_ip_interface_brief.template
@@ -1,0 +1,9 @@
+Value Required INTF (\S+)
+Value Required IPADDR ([a-zA-Z0-9./]+)
+Value STATUS (\S+-\S+)
+Value LINK (\S+-\S+)
+Value PROTO (\S+-\S+)
+
+Start
+  ^${INTF}\s+${IPADDR}\s+${STATUS}/${LINK}/${PROTO} -> Record
+

--- a/templates/cisco_nxos_show_ip_interface_brief.template
+++ b/templates/cisco_nxos_show_ip_interface_brief.template
@@ -6,4 +6,3 @@ Value PROTO (\S+-\S+)
 
 Start
   ^${INTF}\s+${IPADDR}\s+${STATUS}/${LINK}/${PROTO} -> Record
-

--- a/templates/index
+++ b/templates/index
@@ -201,6 +201,7 @@ cisco_nxos_show_lldp_neighbors_detail.template, .*, cisco_nxos, sh[[ow]] ll[[dp]
 cisco_nxos_show_cdp_neighbors_detail.template, .*, cisco_nxos, sh[[ow]] c[[dp]] neig[[hbors]] det[[ail]]
 cisco_nxos_show_ip_ospf_neighbor_vrf.template, .*, cisco_nxos, sh[[ow]] ip ospf nei[[ghbor]] vrf (\S+)
 cisco_nxos_show_ipv6_interface_brief.template, .*, cisco_nxos, sh[[ow]] ipv[[6]] interf[[ace]] b[[rief]]
+cisco_nxos_show_ip_interface_brief.template, .*, cisco_nxos, sh[[ow]] ip int[[erface]] b[[rief]]
 cisco_nxos_show_port-channel_summary.template, .*, cisco_nxos, sh[[ow]] po[[rt-channel]] sum[[mary]]
 cisco_nxos_show_cts_interface_brief.template, .*, cisco_nxos, sh[[ow]] cts inte[[rface]] br[[ief]]
 cisco_nxos_show_cts_interface_all.template, .*, cisco_nxos, sh[[ow]] ct[[s]] inter[[face]] al[[l]]

--- a/tests/cisco_nxos/show_ip_interface_brief/cisco_nxos_show_ip_interface_brief.parsed
+++ b/tests/cisco_nxos/show_ip_interface_brief/cisco_nxos_show_ip_interface_brief.parsed
@@ -1,0 +1,37 @@
+---
+parsed_sample:
+- intf: Eth1/1
+  ipaddr: 10.1.1.11
+  link: link-down
+  proto: admin-up
+  status: protocol-down
+- intf: Eth1/2
+  ipaddr: 10.1.1.12
+  link: link-up
+  proto: admin-up
+  status: protocol-up
+- intf: Eth1/3
+  ipaddr: 10.1.1.13
+  link: link-up
+  proto: admin-up
+  status: protocol-up
+- intf: Eth1/4
+  ipaddr: 10.1.1.14
+  link: link-up
+  proto: admin-up
+  status: protocol-up
+- intf: Eth1/5
+  ipaddr: 10.1.1.15
+  link: link-up
+  proto: admin-up
+  status: protocol-up
+- intf: Eth1/6
+  ipaddr: 10.1.1.16
+  link: link-down
+  proto: admin-up
+  status: protocol-down
+- intf: Eth1/7
+  ipaddr: 10.1.1.17
+  link: link-down
+  proto: admin-up
+  status: protocol-down

--- a/tests/cisco_nxos/show_ip_interface_brief/cisco_nxos_show_ip_interface_brief.raw
+++ b/tests/cisco_nxos/show_ip_interface_brief/cisco_nxos_show_ip_interface_brief.raw
@@ -1,0 +1,9 @@
+IP Interface Status for VRF "default"(1)
+Interface            IP Address      Interface Status
+Eth1/1               10.1.1.11       protocol-down/link-down/admin-up   
+Eth1/2               10.1.1.12       protocol-up/link-up/admin-up       
+Eth1/3               10.1.1.13       protocol-up/link-up/admin-up       
+Eth1/4               10.1.1.14       protocol-up/link-up/admin-up       
+Eth1/5               10.1.1.15       protocol-up/link-up/admin-up       
+Eth1/6               10.1.1.16       protocol-down/link-down/admin-up   
+Eth1/7               10.1.1.17       protocol-down/link-down/admin-up  


### PR DESCRIPTION
##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
cisco_nxos_show_ip_interface_brief

##### SUMMARY
Adds in support for the command "show ip interface brief" on Cisco NX-OS.
This command is supported in IOS, and the IPv6 version of this command is supported in NX-OS.
Tested on Cisco Nexus 7k and 9k physical hardware.