### PR TITLE
Adding Values for route-map names fetch for nxos_sh_ip_bgp_nei

### DIFF
--- a/templates/cisco_nxos_show_ip_bgp_neighbors.template
+++ b/templates/cisco_nxos_show_ip_bgp_neighbors.template
@@ -48,6 +48,8 @@ Value TOTAL_MESS_COUNT_RCVD (\d+)
 Value TOTAL_BYTES_COUNT_RCVD (\d+)
 Value TOTAL_BYTES_SEND_QUEUE (\d+)
 Value TOTAL_BYTES_RCVD_QUEUE (\d+)
+Value INBOUND_ROUTEMAP (\S+)
+Value OUTBOUND_ROUTEMAP (\S+)
 
 Start
   ^BGP neighbor is ${NEIGHBOR},\s+remote AS\s+${ASN},.*
@@ -86,6 +88,8 @@ AddrFamState
   ^\s+BGP table version ${TABLE_VERSION}, neighbor version ${NEI_TABLE_VERSION}
   ^\s+${ACCEPTED_PATHS} accepted paths consume ${CONSUMED_MEM} bytes of memory
   ^\s+${SENT_PATHS} sent paths
+  ^\s+Inbound route-map configured is\s+${INBOUND_ROUTEMAP}, handle obtained
+  ^\s+Outbound route-map configured is\s+${OUTBOUND_ROUTEMAP}, handle obtained
   ^\s+Last End-of-RIB received [\d:]+ after session start -> AddrFamState
   ^\s+Local host:\s+${LOCALHOST_IP}, Local port:\s+${LOCALHOST_PORT}
   ^\s+Foreign host:\s+${REMOTE_IP}, Foreign port:\s+${REMOTE_PORT} -> Record Start

--- a/templates/cisco_nxos_show_ip_bgp_neighbors.template
+++ b/templates/cisco_nxos_show_ip_bgp_neighbors.template
@@ -88,8 +88,8 @@ AddrFamState
   ^\s+BGP table version ${TABLE_VERSION}, neighbor version ${NEI_TABLE_VERSION}
   ^\s+${ACCEPTED_PATHS} accepted paths consume ${CONSUMED_MEM} bytes of memory
   ^\s+${SENT_PATHS} sent paths
-  ^\s+Inbound route-map configured is\s+${INBOUND_ROUTEMAP}, handle obtained
-  ^\s+Outbound route-map configured is\s+${OUTBOUND_ROUTEMAP}, handle obtained
+  ^\s+Inbound\s+route-map\s+configured\s+is\s+${INBOUND_ROUTEMAP},\s+handle\s+obtained
+  ^\s+Outbound\s+route-map\s+configured\s+is\s+${OUTBOUND_ROUTEMAP},\s+handle\s+obtained
   ^\s+Last End-of-RIB received [\d:]+ after session start -> AddrFamState
   ^\s+Local host:\s+${LOCALHOST_IP}, Local port:\s+${LOCALHOST_PORT}
   ^\s+Foreign host:\s+${REMOTE_IP}, Foreign port:\s+${REMOTE_PORT} -> Record Start

--- a/tests/cisco_nxos/show_ip_bgp_neighbors/cisco_nxos_show_ip_bgp_neighbors.parsed
+++ b/tests/cisco_nxos/show_ip_bgp_neighbors/cisco_nxos_show_ip_bgp_neighbors.parsed
@@ -1,6 +1,8 @@
 ---
 parsed_sample:
 - accepted_paths: '8458'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast  L2VPN EVPN
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast, L2VPN EVPN]
@@ -51,6 +53,8 @@ parsed_sample:
   updates_count_sent: '8514'
   uptime: 1d01h
 - accepted_paths: '8458'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast  L2VPN EVPN
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast, L2VPN EVPN]
@@ -101,6 +105,8 @@ parsed_sample:
   updates_count_sent: '8559'
   uptime: 1w0d
 - accepted_paths: '8458'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast  L2VPN EVPN
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast, L2VPN EVPN]
@@ -151,6 +157,8 @@ parsed_sample:
   updates_count_sent: '8558'
   uptime: 3d21h
 - accepted_paths: '8458'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast  L2VPN EVPN
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast, L2VPN EVPN]
@@ -201,6 +209,8 @@ parsed_sample:
   updates_count_sent: '8566'
   uptime: 3d15h
 - accepted_paths: '0'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast  L2VPN EVPN
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -251,6 +261,8 @@ parsed_sample:
   updates_count_sent: '1'
   uptime: 3d15h
 - accepted_paths: '0'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast  L2VPN EVPN
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -301,6 +313,8 @@ parsed_sample:
   updates_count_sent: '1'
   uptime: 3d15h
 - accepted_paths: '51195'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: ''
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast, IPv4 Unicast, IPv4 Unicast]
@@ -351,6 +365,8 @@ parsed_sample:
   updates_count_sent: '0'
   uptime: 3d16h
 - accepted_paths: '51195'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -401,6 +417,8 @@ parsed_sample:
   updates_count_sent: '937989'
   uptime: 13w2d
 - accepted_paths: '117'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -451,6 +469,8 @@ parsed_sample:
   updates_count_sent: '1534229'
   uptime: 13w2d
 - accepted_paths: '2'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -501,6 +521,8 @@ parsed_sample:
   updates_count_sent: '1534343'
   uptime: 13w2d
 - accepted_paths: '2'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -551,6 +573,8 @@ parsed_sample:
   updates_count_sent: '1533678'
   uptime: 13w2d
 - accepted_paths: '12'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -601,6 +625,8 @@ parsed_sample:
   updates_count_sent: '1533676'
   uptime: 13w2d
 - accepted_paths: '9'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -651,6 +677,8 @@ parsed_sample:
   updates_count_sent: '1533414'
   uptime: 13w2d
 - accepted_paths: '12'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -701,6 +729,8 @@ parsed_sample:
   updates_count_sent: '1533446'
   uptime: 13w2d
 - accepted_paths: '10'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -751,6 +781,8 @@ parsed_sample:
   updates_count_sent: '1534639'
   uptime: 13w2d
 - accepted_paths: '3'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -801,6 +833,8 @@ parsed_sample:
   updates_count_sent: '1532707'
   uptime: 13w2d
 - accepted_paths: '1'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -851,6 +885,8 @@ parsed_sample:
   updates_count_sent: '1532747'
   uptime: 13w2d
 - accepted_paths: '247'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -901,6 +937,8 @@ parsed_sample:
   updates_count_sent: '1532440'
   uptime: 13w2d
 - accepted_paths: '61'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -951,6 +989,8 @@ parsed_sample:
   updates_count_sent: '1531755'
   uptime: 13w2d
 - accepted_paths: '324'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1001,6 +1041,8 @@ parsed_sample:
   updates_count_sent: '1529417'
   uptime: 13w2d
 - accepted_paths: '258'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1051,6 +1093,8 @@ parsed_sample:
   updates_count_sent: '1534379'
   uptime: 13w2d
 - accepted_paths: '265'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1101,6 +1145,8 @@ parsed_sample:
   updates_count_sent: '1532715'
   uptime: 13w2d
 - accepted_paths: '33'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1151,6 +1197,8 @@ parsed_sample:
   updates_count_sent: '1532601'
   uptime: 13w2d
 - accepted_paths: '7'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1201,6 +1249,8 @@ parsed_sample:
   updates_count_sent: '1533067'
   uptime: 13w2d
 - accepted_paths: '6'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: ''
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast, IPv4 Unicast]
@@ -1251,6 +1301,8 @@ parsed_sample:
   updates_count_sent: '0'
   uptime: 13w2d
 - accepted_paths: '54'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1301,6 +1353,8 @@ parsed_sample:
   updates_count_sent: '1531655'
   uptime: 13w2d
 - accepted_paths: '94'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1351,6 +1405,8 @@ parsed_sample:
   updates_count_sent: '1533153'
   uptime: 13w2d
 - accepted_paths: '155'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1401,6 +1457,8 @@ parsed_sample:
   updates_count_sent: '1530946'
   uptime: 13w2d
 - accepted_paths: '358'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1451,6 +1509,8 @@ parsed_sample:
   updates_count_sent: '1530832'
   uptime: 13w2d
 - accepted_paths: '5'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1501,6 +1561,8 @@ parsed_sample:
   updates_count_sent: '1532184'
   uptime: 13w2d
 - accepted_paths: '3'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1551,6 +1613,8 @@ parsed_sample:
   updates_count_sent: '1533949'
   uptime: 13w2d
 - accepted_paths: '5'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1601,6 +1665,8 @@ parsed_sample:
   updates_count_sent: '1531502'
   uptime: 13w2d
 - accepted_paths: '5'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1651,6 +1717,8 @@ parsed_sample:
   updates_count_sent: '1533275'
   uptime: 13w2d
 - accepted_paths: '3'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1701,6 +1769,8 @@ parsed_sample:
   updates_count_sent: '1531346'
   uptime: 13w2d
 - accepted_paths: '21'
+  outbound_routemap: 'DENY_ALL'
+  inbound_routemap: ''
   addr_fam_adv: ''
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast, IPv4 Unicast]
@@ -1751,6 +1821,8 @@ parsed_sample:
   updates_count_sent: '0'
   uptime: 13w2d
 - accepted_paths: '6'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1801,6 +1873,8 @@ parsed_sample:
   updates_count_sent: '1531827'
   uptime: 13w2d
 - accepted_paths: '32'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1851,6 +1925,8 @@ parsed_sample:
   updates_count_sent: '1533270'
   uptime: 13w2d
 - accepted_paths: '6'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1901,6 +1977,8 @@ parsed_sample:
   updates_count_sent: '1549371'
   uptime: 9w4d
 - accepted_paths: '110'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -1951,6 +2029,8 @@ parsed_sample:
   updates_count_sent: '1578342'
   uptime: 1d06h
 - accepted_paths: '55'
+  outbound_routemap: 'ALLOW_DEFAULT'
+  inbound_routemap: ''
   addr_fam_adv: ''
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast, IPv4 Unicast]
@@ -2001,6 +2081,8 @@ parsed_sample:
   updates_count_sent: '0'
   uptime: 13w2d
 - accepted_paths: '642'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: Sent               Rcvd
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -2051,6 +2133,8 @@ parsed_sample:
   updates_count_sent: '1527603'
   uptime: 13w2d
 - accepted_paths: '11'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -2101,6 +2185,8 @@ parsed_sample:
   updates_count_sent: '1535502'
   uptime: 13w2d
 - accepted_paths: '1'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -2151,6 +2237,8 @@ parsed_sample:
   updates_count_sent: '1533672'
   uptime: 13w2d
 - accepted_paths: '26'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -2201,6 +2289,8 @@ parsed_sample:
   updates_count_sent: '1533539'
   uptime: 13w2d
 - accepted_paths: '4'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -2251,6 +2341,8 @@ parsed_sample:
   updates_count_sent: '1563738'
   uptime: 10w5d
 - accepted_paths: '5'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -2301,6 +2393,8 @@ parsed_sample:
   updates_count_sent: '1533546'
   uptime: 13w2d
 - accepted_paths: '1'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -2351,6 +2445,8 @@ parsed_sample:
   updates_count_sent: '1534921'
   uptime: 13w2d
 - accepted_paths: '51100'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -2401,6 +2497,8 @@ parsed_sample:
   updates_count_sent: '913861'
   uptime: 12w6d
 - accepted_paths: '51100'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -2451,6 +2549,8 @@ parsed_sample:
   updates_count_sent: '955014'
   uptime: 11w4d
 - accepted_paths: '52809'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -2501,6 +2601,8 @@ parsed_sample:
   updates_count_sent: '1321374'
   uptime: 11w5d
 - accepted_paths: '12901'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast]
@@ -2551,6 +2653,8 @@ parsed_sample:
   updates_count_sent: '1506061'
   uptime: 13w2d
 - accepted_paths: '2159'
+  outbound_routemap: ''
+  inbound_routemap: ''
   addr_fam_adv: IPv4 Unicast  IPv6 Unicast  L2VPN EVPN
   addr_fam_rcv: ''
   addr_family: [IPv4 Unicast, IPv6 Unicast, L2VPN EVPN]
@@ -2600,5 +2704,3 @@ parsed_sample:
   updates_count_rcvd: ''
   updates_count_sent: '4200'
   uptime: 3w5d
-
-

--- a/tests/cisco_nxos/show_ip_bgp_neighbors/cisco_nxos_show_ip_bgp_neighbors_with_policy_names.parsed
+++ b/tests/cisco_nxos/show_ip_bgp_neighbors/cisco_nxos_show_ip_bgp_neighbors_with_policy_names.parsed
@@ -1,0 +1,53 @@
+parsed_sample:
+- accepted_paths: '38'  
+  addr_fam_adv: 'IPv4 Unicast  '  
+  addr_fam_rcv: ''  
+  addr_family: [IPv4 Unicast]
+  asn: '64514'
+  bgp_state: Established
+  capability_count_rcvd: '0'
+  capability_count_sent: '0'
+  conn_dropped: '12'
+  conn_estab: '13'
+  consumed_mem: '2128'
+  description: ''
+  ext_nh_cap: advertised received
+  fourbyte_cap: 'advertised received '
+  graceful_cap: advertised received
+  inbound_routemap: RM-GTT-IN
+  keepalives_count_rcvd: '653391'
+  keepalives_count_sent: '653262'
+  last_peer_reset: never
+  last_peer_reset_reason: No error
+  last_reset: 2d00h
+  last_reset_reason: bfd session down
+  localhost_ip: 10.20.0.1
+  localhost_port: '61055'
+  nei_table_version: ['9374']
+  neighbor: 10.20.0.2
+  notifications_count_rcvd: '0'
+  notifications_count_sent: '0'
+  opens_count_rcvd: '58'
+  opens_count_sent: '13'
+  outbound_routemap: RM-GTT-OUT
+  remote_ip: 10.20.0.2
+  remote_port: '179'
+  restart_time_adv: '120'
+  restart_time_rcv: '120'
+  route_refresh_count_rcvd: '2'
+  route_refresh_count_sent: '0'
+  rr_new_cap: 'advertised received '
+  rr_old_cap: 'advertised received '
+  sent_paths: '59'
+  source_iface: Ethernet1/6
+  stale_time: '300'
+  table_version: ['9374']
+  total_bytes_count_rcvd: '12419276'
+  total_bytes_count_sent: '12464192'
+  total_bytes_rcvd_queue: '0'
+  total_bytes_send_queue: '0'
+  total_mess_count_rcvd: '653464'
+  total_mess_count_sent: '653851'
+  updates_count_rcvd: ''
+  updates_count_sent: '576'
+  uptime: 2d00h

--- a/tests/cisco_nxos/show_ip_bgp_neighbors/cisco_nxos_show_ip_bgp_neighbors_with_policy_names.raw
+++ b/tests/cisco_nxos/show_ip_bgp_neighbors/cisco_nxos_show_ip_bgp_neighbors_with_policy_names.raw
@@ -1,0 +1,59 @@
+BGP neighbor is 10.20.0.2,  remote AS 64514, ebgp link,  Peer index 1
+  BGP version 4, remote router ID 10.10.255.1
+  BGP state = Established, up for 2d00h
+  Peer is directly attached, interface Ethernet1/6
+  Enable logging neighbor events
+  BFD live-detection is configured and enabled, state is Up
+  Last read 0.791823, hold time = 15, keepalive interval is 5 seconds
+  Last written 0.168722, keepalive timer expiry due 00:00:04
+  Received 653464 messages, 0 notifications, 0 bytes in queue
+  Sent 653851 messages, 0 notifications, 0 bytes in queue
+  Connections established 13, dropped 12
+  Last reset by us 2d00h, due to bfd session down
+  Last reset by peer never, due to No error
+  Neighbor capabilities:
+  Dynamic capability: advertised (mp, refresh, gr) received (mp, refresh, gr)
+  Dynamic capability (old): advertised received
+  Route refresh capability (new): advertised received 
+  Route refresh capability (old): advertised received 
+  4-Byte AS capability: advertised received 
+  Address family IPv4 Unicast: advertised received 
+  Graceful Restart capability: advertised received
+  Graceful Restart Parameters:
+  Address families advertised to peer:
+    IPv4 Unicast  
+  Address families received from peer:
+    IPv4 Unicast  
+  Forwarding state preserved by peer for:
+  Restart time advertised to peer: 120 seconds
+  Stale time for routes advertised by peer: 300 seconds
+  Restart time advertised by peer: 120 seconds
+  Extended Next Hop Encoding Capability: advertised received
+  Receive IPv6 next hop encoding Capability for AF:
+    IPv4 Unicast  
+  Message statistics:
+                              Sent               Rcvd
+  Opens:                        13                 13  
+  Notifications:                 0                  0  
+  Updates:                     576                 58  
+  Keepalives:               653262             653391  
+  Route Refresh:                 0                  2  
+  Capability:                    0                  0  
+  Total:                    653851             653464  
+  Total bytes:            12464192           12419276  
+  Bytes in queue:                0                  0  
+  For address family: IPv4 Unicast
+  BGP table version 9374, neighbor version 9374
+  38 accepted paths consume 2128 bytes of memory
+   First Update Rcvd           : 2d00h
+   Last Update Rcvd            : 2d00h
+  59 sent paths
+   First Update Sent           : 2d00h
+   Last Update Sent            : 2d00h
+  Inbound soft reconfiguration allowed(always)
+  Inbound route-map configured is RM-GTT-IN, handle obtained
+  Outbound route-map configured is RM-GTT-OUT, handle obtained
+  Last End-of-RIB received 00:00:01 after session start
+  Local host: 10.20.0.1, Local port: 61055
+  Foreign host: 10.20.0.2, Foreign port: 179
+  fd = 52


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Update Existing Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
- cisco_nxos_show_ip_bgp_neighbors.template
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
The change adds "inbound_routemap / outbound_routemap" keys to the existing "cisco_nxos_show_ip_bgp_neighbors.template" template. The intention is to fetch the names of the route-maps, applied in INBOUND/OUTBOUND direction, to a given BGP peer, and then further use it for network validations/audits. 

##### TESTING
```
nnaukwal/ntc-templates$ tox
collected 386 items
<snip>
tests/test_structured_data_against_parsed_reference_files.py::test_raw_data_against_mock[tests/cisco_nxos/show_ip_bgp_neighbors/cisco_nxos_show_ip_bgp_neighbors_with_policy_names.raw] PASSED                             [ 92%]
tests/test_structured_data_against_parsed_reference_files.py::test_raw_data_against_mock[tests/cisco_nxos/show_ip_bgp_neighbors/cisco_nxos_show_ip_bgp_neighbors.raw] PASSED                                               [ 92%]
<snip>
__ summary __
  py35: commands succeeded
  congratulations :)
```
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
- accepted_paths: '38'
  addr_fam_adv: 'IPv4 Unicast  '
  addr_fam_rcv: ''
  addr_family: [IPv4 Unicast]
  asn: '64514'
  bgp_state: Established
  capability_count_rcvd: '0'
  capability_count_sent: '0'
  conn_dropped: '12'
  conn_estab: '13'
  consumed_mem: '2128'
  description: ''
  ext_nh_cap: advertised received
  fourbyte_cap: 'advertised received '
  graceful_cap: advertised received
  keepalives_count_rcvd: '668381'
  keepalives_count_sent: '668251'
  last_peer_reset: never
  last_peer_reset_reason: No error
  last_reset: 2d21h
  last_reset_reason: bfd session down
  localhost_ip: 10.20.0.1
  localhost_port: '61055'
  nei_table_version: ['9396']
  neighbor: 10.20.0.2
  notifications_count_rcvd: '0'
  notifications_count_sent: '0'
  opens_count_rcvd: '58'
  opens_count_sent: '13'
  remote_ip: 10.20.0.2
  remote_port: '179'
  restart_time_adv: '120'
  restart_time_rcv: '120'
  route_refresh_count_rcvd: '2'
  route_refresh_count_sent: '0'
  rr_new_cap: 'advertised received '
  rr_old_cap: 'advertised received '
  sent_paths: '59'
  source_iface: Ethernet1/6
  stale_time: '300'
  table_version: ['9396']
  total_bytes_count_rcvd: '12704086'
  total_bytes_count_sent: '12748983'
  total_bytes_rcvd_queue: '0'
  total_bytes_send_queue: '0'
  total_mess_count_rcvd: '668454'
  total_mess_count_sent: '668840'
  updates_count_rcvd: ''
  updates_count_sent: '576'
  uptime: 2d21h

After:
- accepted_paths: '38'  
  addr_fam_adv: 'IPv4 Unicast  '  
  addr_fam_rcv: ''  
  addr_family:  [IPv4 Unicast]
  asn: '64514'
  bgp_state: Established
  capability_count_rcvd: '0'
  capability_count_sent: '0'
  conn_dropped: '12'
  conn_estab: '13'
  consumed_mem: '2128'
  description: ''
  ext_nh_cap: advertised received
  fourbyte_cap: 'advertised received '
  graceful_cap: advertised received
  inbound_routemap: RM-GTT-IN     <<<<<
  keepalives_count_rcvd: '668429'
  keepalives_count_sent: '668298'
  last_peer_reset: never
  last_peer_reset_reason: No error
  last_reset: 2d21h
  last_reset_reason: bfd session down
  localhost_ip: 10.20.0.1
  localhost_port: '61055'
  nei_table_version: ['9396']
  neighbor: 10.20.0.2
  notifications_count_rcvd: '0'
  notifications_count_sent: '0'
  opens_count_rcvd: '58'
  opens_count_sent: '13'
  outbound_routemap: RM-GTT-OUT   <<<<<
  remote_ip: 10.20.0.2
  remote_port: '179'
  restart_time_adv: '120'
  restart_time_rcv: '120'
  route_refresh_count_rcvd: '2'
  route_refresh_count_sent: '0'
  rr_new_cap: 'advertised received '
  rr_old_cap: 'advertised received '
  sent_paths: '59'
  source_iface: Ethernet1/6
  stale_time: '300'
  table_version: ['9396']
  total_bytes_count_rcvd: '12704998'
  total_bytes_count_sent: '12749876'
  total_bytes_rcvd_queue: '0'
  total_bytes_send_queue: '0'
  total_mess_count_rcvd: '668502'
  total_mess_count_sent: '668887'
  updates_count_rcvd: ''
  updates_count_sent: '576'
  uptime: 2d21h

```
