### PR TITLE
nxos - Template for show route-map command

### DIFF
--- a/templates/cisco_nxos_show_route-map.template
+++ b/templates/cisco_nxos_show_route-map.template
@@ -1,0 +1,28 @@
+Value Required NAME (\S+)
+Value Required ACTION (\S+)
+Value Required SEQ (\d+)
+Value List MATCH_CLAUSES (.+?)
+Value List SET_CLAUSES (.+?)
+
+Start
+  ^route-map\s+${NAME},\s+${ACTION},\s+sequence\s+${SEQ}\s*$$
+  ^\s+Match\s+clauses -> Match
+  ^\s+Set\s+clauses -> Set
+  ^.+ -> Error
+
+Match
+  ^\s*$$
+  ^\s+Set\s+clauses -> Set
+  ^\s+Policy\s+routing
+  ^\s+${MATCH_CLAUSES}\s*$$
+  ^route-map -> Continue.Record
+  ^route-map\s+${NAME},\s+${ACTION},\s+sequence\s+${SEQ}\s*$$ -> Start
+  ^.+ -> Error
+
+Set
+  ^\s*$$
+  ^\s+Policy\s+routing
+  ^\s+${SET_CLAUSES}\s*$$
+  ^route-map -> Continue.Record
+  ^route-map\s+${NAME},\s+${ACTION},\s+sequence\s+${SEQ}\s*$$ -> Start
+  ^.+ -> Error

--- a/templates/cisco_nxos_show_route-map.template
+++ b/templates/cisco_nxos_show_route-map.template
@@ -8,7 +8,7 @@ Start
   ^route-map\s+${NAME},\s+${ACTION},\s+sequence\s+${SEQ}\s*$$
   ^\s+Match\s+clauses -> Match
   ^\s+Set\s+clauses -> Set
-  ^.+ -> Error
+  ^\s*$$ -> Error
 
 Match
   ^\s*$$
@@ -17,7 +17,7 @@ Match
   ^\s+${MATCH_CLAUSES}\s*$$
   ^route-map -> Continue.Record
   ^route-map\s+${NAME},\s+${ACTION},\s+sequence\s+${SEQ}\s*$$ -> Start
-  ^.+ -> Error
+  ^\s*$$ -> Error
 
 Set
   ^\s*$$
@@ -25,4 +25,4 @@ Set
   ^\s+${SET_CLAUSES}\s*$$
   ^route-map -> Continue.Record
   ^route-map\s+${NAME},\s+${ACTION},\s+sequence\s+${SEQ}\s*$$ -> Start
-  ^.+ -> Error
+  ^\s*$$ -> Error

--- a/templates/cisco_nxos_show_route-map.template
+++ b/templates/cisco_nxos_show_route-map.template
@@ -8,8 +8,8 @@ Start
   ^route-map\s+${NAME},\s+${ACTION},\s+sequence\s+${SEQ}\s*$$
   ^\s+Match\s+clauses -> Match
   ^\s+Set\s+clauses -> Set
-  ^\s*$$ -> Error
-
+  ^\s*$$
+  ^. -> Error
 Match
   ^\s*$$
   ^\s+Set\s+clauses -> Set
@@ -17,12 +17,13 @@ Match
   ^\s+${MATCH_CLAUSES}\s*$$
   ^route-map -> Continue.Record
   ^route-map\s+${NAME},\s+${ACTION},\s+sequence\s+${SEQ}\s*$$ -> Start
-  ^\s*$$ -> Error
-
+  ^\s*$$
+  ^. -> Error
 Set
   ^\s*$$
   ^\s+Policy\s+routing
   ^\s+${SET_CLAUSES}\s*$$
   ^route-map -> Continue.Record
   ^route-map\s+${NAME},\s+${ACTION},\s+sequence\s+${SEQ}\s*$$ -> Start
-  ^\s*$$ -> Error
+  ^\s*$$
+  ^. -> Error

--- a/templates/cisco_nxos_show_route-map.template
+++ b/templates/cisco_nxos_show_route-map.template
@@ -10,6 +10,7 @@ Start
   ^\s+Set\s+clauses -> Set
   ^\s*$$
   ^. -> Error
+
 Match
   ^\s*$$
   ^\s+Set\s+clauses -> Set
@@ -19,6 +20,7 @@ Match
   ^route-map\s+${NAME},\s+${ACTION},\s+sequence\s+${SEQ}\s*$$ -> Start
   ^\s*$$
   ^. -> Error
+
 Set
   ^\s*$$
   ^\s+Policy\s+routing

--- a/templates/index
+++ b/templates/index
@@ -221,6 +221,7 @@ cisco_nxos_show_access-lists.template, .*, cisco_nxos, sh[[ow]] acc[[ess-lists]]
 cisco_nxos_show_environments.template, .*, cisco_nxos, sh[[ow]] envi[[ronments]]
 cisco_nxos_show_interface.template, .*, cisco_nxos, sh[[ow]] inte[[rface]]
 cisco_nxos_show_inventory.template, .*, cisco_nxos, sh[[ow]] inv[[entory]]
+cisco_nxos_show_route-map.template, .*, cisco_nxos, sh[[ow]] route-m[[ap]]
 cisco_nxos_show_hostname.template, .*, cisco_nxos, sh[[ow]] hostn[[ame]]
 cisco_nxos_show_ip_route.template, .*, cisco_nxos, sh[[ow]] ip route
 cisco_nxos_show_feature.template, .*, cisco_nxos, sh[[ow]] feat[[ure]]

--- a/tests/cisco_nxos/show_route-map/cisco_nxos_show_route-map.parsed
+++ b/tests/cisco_nxos/show_route-map/cisco_nxos_show_route-map.parsed
@@ -1,0 +1,99 @@
+---
+parsed_sample:
+- action: permit
+  match_clauses:
+  - 'as-path (as-path filter): AS-TEST'
+  name: RM-TEST-OUT
+  seq: '10'
+  set_clauses: []
+- action: deny
+  match_clauses:
+  - 'tag: 12345'
+  name: RM-BGP-TO-OSPF
+  seq: '10'
+  set_clauses: []
+- action: permit
+  match_clauses: []
+  name: RM-BGP-TO-OSPF
+  seq: '20'
+  set_clauses: []
+- action: permit
+  match_clauses: []
+  name: RM-ISP1-IN
+  seq: '1000'
+  set_clauses:
+  - local-preference 300
+- action: permit
+  match_clauses:
+  - 'as-path (as-path filter): AS-ISP2'
+  name: RM-ISP1-OUT
+  seq: '1000'
+  set_clauses: []
+- action: permit
+  match_clauses: []
+  name: RM-ISP1-MAITENANCE
+  seq: '10'
+  set_clauses:
+  - local-preference 50
+- action: permit
+  match_clauses: []
+  name: RM-FW-LP
+  seq: '10'
+  set_clauses:
+  - local-preference 25
+- action: permit
+  match_clauses: []
+  name: RM-FW-MAITENANCE
+  seq: '10'
+  set_clauses: []
+- action: permit
+  match_clauses:
+  - 'as-path (as-path filter): TEST-AS-FW'
+  name: RM-FW-OUTBOUND
+  seq: '10'
+  set_clauses: []
+- action: permit
+  match_clauses:
+  - 'ip address prefix-lists: PF-PATH-X-INTERNAL'
+  name: RM-X-SIDE-INTERNAL
+  seq: '10'
+  set_clauses: []
+- action: permit
+  match_clauses:
+  - 'ip address prefix-lists: PF-PATH-Z-INTERNAL'
+  name: RM-Z-SIDE-INTERNAL
+  seq: '10'
+  set_clauses: []
+- action: permit
+  match_clauses:
+  - 'ip address prefix-lists: PL-PERMIT-IN'
+  name: RM-FILTER-IN
+  seq: '10'
+  set_clauses: []
+- action: permit
+  match_clauses:
+  - 'ip address (access-lists): AL_TEST_TEST'
+  name: TEST_THIS
+  seq: '10'
+  set_clauses:
+  - ip next-hop 2.2.2.2
+- action: permit
+  match_clauses:
+  - 'ip address prefix-lists: PF-N3K1-TO-N3K2'
+  name: RM-N3K1-TO-N3K2
+  seq: '10'
+  set_clauses:
+  - extcommunity RT:100:1
+- action: permit
+  match_clauses:
+  - 'ip address prefix-lists: PF-N3K2-TO-N3K1'
+  name: RM-N3K2-TO-N3K1
+  seq: '10'
+  set_clauses:
+  - extcommunity RT:200:1
+- action: permit
+  match_clauses:
+  - 'ip address prefix-lists: PF-A-DEFAULT-ROUTE'
+  name: RM-PATH-A-DEFAULT-ROUTE
+  seq: '10'
+  set_clauses: []

--- a/tests/cisco_nxos/show_route-map/cisco_nxos_show_route-map.raw
+++ b/tests/cisco_nxos/show_route-map/cisco_nxos_show_route-map.raw
@@ -1,0 +1,66 @@
+route-map RM-TEST-OUT, permit, sequence 10 
+  Match clauses:
+    as-path (as-path filter): AS-TEST 
+  Set clauses:
+route-map RM-BGP-TO-OSPF, deny, sequence 10 
+  Match clauses:
+    tag: 12345
+  Set clauses:
+route-map RM-BGP-TO-OSPF, permit, sequence 20 
+  Match clauses:
+  Set clauses:
+route-map RM-ISP1-IN, permit, sequence 1000 
+  Match clauses:
+  Set clauses:
+    local-preference 300
+route-map RM-ISP1-OUT, permit, sequence 1000 
+  Match clauses:
+    as-path (as-path filter): AS-ISP2 
+  Set clauses:
+route-map RM-ISP1-MAITENANCE, permit, sequence 10 
+  Match clauses:
+  Set clauses:
+    local-preference 50
+route-map RM-FW-LP, permit, sequence 10 
+  Match clauses:
+  Set clauses:
+    local-preference 25
+route-map RM-FW-MAITENANCE, permit, sequence 10 
+  Match clauses:
+  Set clauses:
+route-map RM-FW-OUTBOUND, permit, sequence 10 
+  Match clauses:
+    as-path (as-path filter): TEST-AS-FW 
+  Set clauses:
+
+route-map RM-X-SIDE-INTERNAL, permit, sequence 10 
+  Match clauses:
+    ip address prefix-lists: PF-PATH-X-INTERNAL 
+  Set clauses:
+route-map RM-Z-SIDE-INTERNAL, permit, sequence 10 
+  Match clauses:
+    ip address prefix-lists: PF-PATH-Z-INTERNAL 
+  Set clauses:
+route-map RM-FILTER-IN, permit, sequence 10 
+  Match clauses:
+    ip address prefix-lists: PL-PERMIT-IN 
+  Set clauses:
+route-map TEST_THIS, permit, sequence 10 
+  Match clauses:
+    ip address (access-lists): AL_TEST_TEST 
+  Set clauses:
+    ip next-hop 2.2.2.2 
+route-map RM-N3K1-TO-N3K2, permit, sequence 10 
+  Match clauses:
+    ip address prefix-lists: PF-N3K1-TO-N3K2 
+  Set clauses:
+    extcommunity RT:100:1
+route-map RM-N3K2-TO-N3K1, permit, sequence 10 
+  Match clauses:
+    ip address prefix-lists: PF-N3K2-TO-N3K1 
+  Set clauses:
+    extcommunity RT:200:1
+route-map RM-PATH-A-DEFAULT-ROUTE, permit, sequence 10 
+  Match clauses:
+    ip address prefix-lists: PF-A-DEFAULT-ROUTE 
+  Set clauses:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_nxos_show_route-map.template
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description, but you should still explain what
the change does.
-->
This request is for the addition of "show route-map" command for the Cisco Nexus Platform. The template is a copy from the "cisco_ios_show_route-map.template", which does the same thing for Cisco IOS platform. The Raw data used for testing have been collected from a lab and a PROD "cisco Nexus 3548" device in my environment.

##### TESTING
```
nnaukwal/ntc-templates$ tox
GLOB sdist-make: /home/narendra.naukwal/nnaukwal/ntc-templates/setup.py
py35 inst-nodeps: /home/narendra.naukwal/nnaukwal/ntc-templates/.tox/.tmp/package/1/ntc_templates-1.2.1.zip
<snip>
tests/test_index_order.py::test_index_ordering PASSED   <<<< template/index in OK order
<snip>
tests/test_structured_data_against_parsed_reference_files.py::test_raw_data_against_mock[tests/cisco_nxos/show_route-map/cisco_nxos_show_route-map.raw] PASSED    [ 84%]   <<< Works OK
<snip>
[  0%]
```