### PR TITLE
Fix netflow and wccp lines

### DIFF
--- a/templates/cisco_ios_show_ip_interface.template
+++ b/templates/cisco_ios_show_ip_interface.template
@@ -48,8 +48,8 @@ Start
   ^\s+Policy
   ^\s+Network\s+address\s+
   ^\s+BGP
-  ^\s+Sampled Netflow
-  ^\s+IP (Routed|Bridged) Flow
+  ^\s+Sampled\s+Netflow
+  ^\s+IP\s+(Routed|Bridged)\s+Flow
   ^\s+(Input|Output|Post)\s+.*features
   ^\s+(IPv4\s+)?WCCP
   ^\s*$$

--- a/templates/cisco_ios_show_ip_interface.template
+++ b/templates/cisco_ios_show_ip_interface.template
@@ -48,8 +48,10 @@ Start
   ^\s+Policy
   ^\s+Network\s+address\s+
   ^\s+BGP
+  ^\s+Sampled Netflow
+  ^\s+IP (Routed|Bridged) Flow
   ^\s+(Input|Output|Post)\s+.*features
-  ^\s+IPv4\s+WCCP
+  ^\s+(IPv4\s+)?WCCP
   ^\s*$$
   ^. -> Error
 

--- a/tests/cisco_ios/show_ip_interface/cisco_ios_show_ip_interface3.parsed
+++ b/tests/cisco_ios/show_ip_interface/cisco_ios_show_ip_interface3.parsed
@@ -1,0 +1,13 @@
+---
+parsed_sample:
+
+- intf: 'Loopback1001'
+  link_status: 'up'
+  protocol_status: 'up'
+  ipaddr: ['10.0.0.0']
+  mask: ['32']
+  vrf: ''
+  mtu: '1514'
+  ip_helper: []
+  outgoing_acl: ''
+  inbound_acl: ''

--- a/tests/cisco_ios/show_ip_interface/cisco_ios_show_ip_interface3.raw
+++ b/tests/cisco_ios/show_ip_interface/cisco_ios_show_ip_interface3.raw
@@ -1,0 +1,45 @@
+Loopback1001 is up, line protocol is up
+  Internet address is 10.0.0.0/32
+  Broadcast address is 255.255.255.255
+  Address determined by setup command
+  MTU is 1514 bytes
+  Helper address is not set
+  Directed broadcast forwarding is disabled
+  Outgoing access list is not set
+  Inbound  access list is not set
+  Proxy ARP is enabled
+  Local Proxy ARP is disabled
+  Security level is default
+  Split horizon is enabled
+  ICMP redirects are always sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  IP fast switching is enabled
+  IP Flow switching is disabled
+  IP CEF switching is enabled
+  IP CEF switching turbo vector
+  IP Null turbo vector
+  Associated unicast routing topologies:
+        Topology "base", operation state is UP
+  IP multicast fast switching is enabled
+  IP multicast distributed fast switching is disabled
+  IP route-cache flags are Fast, CEF
+  Router Discovery is disabled
+  IP output packet accounting is disabled
+  IP access violation accounting is disabled
+  TCP/IP header compression is disabled
+  RTP/IP header compression is disabled
+  Probe proxy name replies are disabled
+  Policy routing is disabled
+  Network address translation is disabled
+  BGP Policy Mapping is disabled
+  Input features: MCI Check
+  Output features: IP Post Routing Processing, HW Shortcut Installation
+  Post encapsulation features: MTU Processing, IP Protocol Output Counter, IP Sendself Check, HW Shortcut Installation
+  Sampled Netflow is disabled
+  IP Routed Flow creation is disabled in netflow table
+  IP Bridged Flow creation is disabled in netflow table
+  IPv4 WCCP Redirect outbound is disabled
+  IPv4 WCCP Redirect inbound is disabled
+  IPv4 WCCP Redirect exclude is disabled
+  IP multicast multilayer switching is disabled

--- a/tests/cisco_ios/show_ip_interface/cisco_ios_show_ip_interface4.parsed
+++ b/tests/cisco_ios/show_ip_interface/cisco_ios_show_ip_interface4.parsed
@@ -1,0 +1,13 @@
+---
+parsed_sample:
+
+- intf: 'Loopback0'
+  link_status: 'up'
+  protocol_status: 'up'
+  ipaddr: ['10.0.0.0']
+  mask: ['32']
+  vrf: ''
+  mtu: '1514'
+  ip_helper: []
+  outgoing_acl: ''
+  inbound_acl: ''

--- a/tests/cisco_ios/show_ip_interface/cisco_ios_show_ip_interface4.raw
+++ b/tests/cisco_ios/show_ip_interface/cisco_ios_show_ip_interface4.raw
@@ -1,0 +1,39 @@
+Loopback0 is up, line protocol is up
+  Internet address is 10.0.0.0/32
+  Broadcast address is 255.255.255.255
+  Address determined by non-volatile memory
+  MTU is 1514 bytes
+  Helper address is not set
+  Directed broadcast forwarding is disabled
+  Multicast reserved groups joined: 224.0.0.5
+  Outgoing access list is not set
+  Inbound  access list is not set
+  Proxy ARP is enabled
+  Local Proxy ARP is disabled
+  Security level is default
+  Split horizon is enabled
+  ICMP redirects are always sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  IP fast switching is enabled
+  IP CEF switching is enabled
+  IP CEF switching turbo vector
+  IP Null turbo vector
+  IP multicast fast switching is enabled
+  IP multicast distributed fast switching is disabled
+  IP route-cache flags are Fast, CEF
+  Router Discovery is disabled
+  IP output packet accounting is disabled
+  IP access violation accounting is disabled
+  TCP/IP header compression is disabled
+  RTP/IP header compression is disabled
+  Probe proxy name replies are disabled
+  Policy routing is disabled
+  Network address translation is disabled
+  BGP Policy Mapping is disabled
+  Input features: MCI Check
+  Output features: Check hwidb
+  WCCP Redirect outbound is disabled
+  WCCP Redirect inbound is disabled
+  WCCP Redirect exclude is disabled
+


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
cisco_ios_show_ip_interface.template

##### SUMMARY
On a 6500, ip interface are reporting some netflow configuration that breaks the parsing of the show ip interface.
On a 3750, the WCCP line does not start with IPv4.

