### PR TITLE
BugFix: IOS show standby brief - support multiline output

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,9 @@
 ### Fixed for any bug fixes
 - [#497] ASA show version: Fix `MAX_INTF` to account for `Unlimited`
 - [#497] ASA show version: Fix `HARDWARE` to properly handle trailing commas
+- [#503] IOS show standby: Fix output that spread across two lines
 ### Added for new features
+- [#503] IOS show standby: Add support for matching template when specifying specific interface
 ### Changed for changes in existing functionality
 - [#497] ASA show version: Change `SERIAL` to be a list for clusters
 ### Deprecated for soon-to-be removed features

--- a/templates/cisco_ios_show_standby_brief.template
+++ b/templates/cisco_ios_show_standby_brief.template
@@ -8,4 +8,11 @@ Value STANDBY (\S+)
 Value VIRTUALIP (\S+)
 
 Start
+  ^Interface\s+Grp\s+Pri\s+P\s+State\s+Active\s+Standby\s+Virtual\s+IP\s*$$ -> Standby
+
+Standby
   ^${IFACE}\s+${GROUP}\s+${PRIORITY}\s+${PREEMPT}\s+${STATE}\s+${ACTIVE}\s+${STANDBY}\s+${VIRTUALIP} -> Record
+  ^${IFACE}\s*$$
+  ^\s*${GROUP}\s+${PRIORITY}\s+${PREEMPT}\s+${STATE}\s+${ACTIVE}\s+${STANDBY}\s+${VIRTUALIP} -> Record
+  ^\s*$$
+  ^. -> Error

--- a/templates/index
+++ b/templates/index
@@ -164,7 +164,7 @@ cisco_ios_show_hosts_summary.template, .*, cisco_ios, sh[[ow]] ho[[sts]] summary
 cisco_ios_show_platform_diag.template, .*, cisco_ios, sh[[ow]] plat[[form]] di[[ag]]
 cisco_ios_show_processes_cpu.template, .*, cisco_ios, sh[[ow]] proc[[esses]] [[cpu]]
 cisco_ios_show_spanning-tree.template, .*, cisco_ios, sh[[ow]] sp[[anning-tree]]
-cisco_ios_show_standby_brief.template, .*, cisco_ios, sh[[ow]] standby br[[ief]]
+cisco_ios_show_standby_brief.template, .*, cisco_ios, sh[[ow]] standby(?:\s+\S+)? br[[ief]]
 cisco_ios_show_ip_interface.template, .*, cisco_ios, sh[[ow]] ip int[[erface]]
 cisco_ios_show_power_status.template, .*, cisco_ios, sh[[ow]] pow[[er]] st[[atus]]
 cisco_ios_show_access-list.template, .*, cisco_ios, sh[[ow]] acc[[ess-list]]

--- a/tests/cisco_ios/show_standby_brief/cisco_ios_show_standby_brief.raw
+++ b/tests/cisco_ios/show_standby_brief/cisco_ios_show_standby_brief.raw
@@ -7,4 +7,5 @@ Vl51        1    120 P Init    unknown         unknown         10.1.51.1
 Vl51        6    120 P Init    unknown         unknown         FE80::DEF
 Vl500       1    120 P Active  local           10.1.5.3      10.1.5.1
 Vl500       6    120 P Active  local           FE80::B         FE80::DEF
-Vl4010      1    120 P Active  local           10.1.254.3    10.1.254.1
+Vl4010 
+     1    120 P Active  local           10.1.254.3    10.1.254.1


### PR DESCRIPTION
Fixes #483 