### PR TITLE
Update state transitions to provide more consistency across platforms

### DIFF
--- a/templates/cisco_ios_show_environment_temperature.template
+++ b/templates/cisco_ios_show_environment_temperature.template
@@ -11,22 +11,29 @@ Value HOTSPOT_RED_THRESHOLD (\d+)
 
 Start
   ^Switch\s+\d -> Continue.Record
-  ^Switch\s+${SWITCH}:\s+SYSTEM\s+TEMPERATURE\s+is\s+${SWITCH_TEMPERATURE}\s*$$ -> Inlet
+  ^Switch\s+${SWITCH}:\s+SYSTEM\s+TEMPERATURE\s+is\s+${SWITCH_TEMPERATURE}\s*$$
+  ^Inlet\s+Temperature\s+Value:\s+${INLET_TEMPERATURE_VALUE}\s+Degree\s+Celsius\s*$$ -> Inlet
+  ^Hotspot\s+Temperature\s+Value:\s+${HOTSPOT_TEMPERATURE_VALUE}\s+Degree\s+Celsius\s*$$ -> Hotspot
   ^\s*$$
   ^. -> Error 
  
 Inlet
-  ^Inlet\s+Temperature\s+Value:\s+${INLET_TEMPERATURE_VALUE}\s+Degree\s+Celsius\s*$$ 
   ^Temperature\s+State:\s+${INLET_TEMPERATURE_STATE}\s*$$
   ^Yellow\s+Threshold\s+:\s+${INLET_YELLOW_THRESHOLD}\s+Degree\s+Celsius\s*$$
-  ^Red\s+Threshold\s+:\s+${INLET_RED_THRESHOLD}\s+Degree\s+Celsius\s*$$ -> Hotspot
+  ^Red\s+Threshold\s+:\s+${INLET_RED_THRESHOLD}\s+Degree\s+Celsius\s*$$
+  ^Hotspot\s+Temperature\s+Value:\s+${HOTSPOT_TEMPERATURE_VALUE}\s+Degree\s+Celsius\s*$$ -> Hotspot
+  ^Switch\s+\d -> Continue.Record
+  ^Switch\s+${SWITCH}:\s+SYSTEM\s+TEMPERATURE\s+is\s+${SWITCH_TEMPERATURE}\s*$$ -> Start
   ^\s*$$
   ^. -> Error 
  
 Hotspot
-  ^Hotspot\s+Temperature\s+Value:\s+${HOTSPOT_TEMPERATURE_VALUE}\s+Degree\s+Celsius\s*$$
   ^Temperature\s+State:\s+${HOTSPOT_TEMPERATURE_STATE}\s*$$
   ^Yellow\s+Threshold\s+:\s+${HOTSPOT_YELLOW_THRESHOLD}\s+Degree\s+Celsius\s*$$
-  ^Red\s+Threshold\s+:\s+${HOTSPOT_RED_THRESHOLD}\s+Degree\s+Celsius\s*$$ -> Start
+  ^Red\s+Threshold\s+:\s+${HOTSPOT_RED_THRESHOLD}\s+Degree\s+Celsius\s*$$
+  ^Switch\s+\d -> Continue.Record
+  ^Switch\s+${SWITCH}:\s+SYSTEM\s+TEMPERATURE\s+is\s+${SWITCH_TEMPERATURE}\s*$$ -> Start
+  ^Inlet\s+Temperature\s+Value:\s+${INLET_TEMPERATURE_VALUE}\s+Degree\s+Celsius\s*$$ -> Inlet
   ^\s*$$
-  ^. -> Error 
+  ^. -> Error
+


### PR DESCRIPTION
1) The point of using `Continue.Record` is to not be dependent on inconsistent "last lines" of the output, which means the only way to safely transition back to start is to transition back to `Start` after capturing the data from the next entry.

2) Only transition to a new state when a keyword for that state occurs. Ex: `  ^Inlet\s+Temperature\s+Value:\s+${INLET_TEMPERATURE_VALUE}\s+Degree\s+Celsius\s*$$ -> Inlet` 

3) Each State should have matches to transition to all other States in case the order of the output is different (such as Hotspot comes before Inlet in the command output).


