### PR TITLE
Captured Administrative Mode, added support for unassigned Access VLAN

### DIFF
--- a/templates/cisco_ios_show_interfaces_switchport.textfsm
+++ b/templates/cisco_ios_show_interfaces_switchport.textfsm
@@ -3,7 +3,8 @@ Value SWITCHPORT (.+)
 Value SWITCHPORT_MONITOR (.+)
 Value SWITCHPORT_NEGOTIATION (.+)
 Value MODE (.+)
-Value ACCESS_VLAN (\d+)
+Value ADMIN_MODE (.+)
+Value ACCESS_VLAN (\d+|unassigned)
 Value NATIVE_VLAN (\d+)
 Value VOICE_VLAN (\S+)
 Value TRUNKING_VLANS (.+)
@@ -19,7 +20,7 @@ Start
   ^\s*Trunking\s+Native\s+Mode\s+VLAN:\s+${NATIVE_VLAN}
   ^\s*Voice\s+VLAN:\s+${VOICE_VLAN}
   ^\s*Trunking\s+VLANs\s+Enabled:\s+${TRUNKING_VLANS}
-  ^\s*Administrative\s+Mode
+  ^\s*Administrative\s+Mode:\s+${ADMIN_MODE}
   ^\s*(?:Operational|Administrative)\s+(?:Trunking|Native\s+VLAN|private-vlan)
   ^\s*Voice\s+VLAN:
   ^\s*Pruning\s+VLANs


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
Template: cisco_ios_show_interfaces_switchport.textfsm
OS: Cisco IOS
Command: show interfaces switchport

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added a capture group for "Administrative Mode" and added support for the case where Access VLAN is unassigned.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
{'interface': 'Gi9/10', 'switchport': 'Enabled', 'switchport_monitor': '', 'switchport_negotiation': 'Off', 'mode': 'down', 'access_vlan': '267', 'native_vlan': '1', 'voice_vlan': '1267', 'trunking_vlans': 'ALL'}

After:
{'interface': 'Gi9/10', 'switchport': 'Enabled', 'switchport_monitor': '', 'switchport_negotiation': 'Off', 'mode': 'down', 'admin_mode': 'static access', 'access_vlan': '267', 'native_vlan': '1', 'voice_vlan': '1267', 'trunking_vlans': 'ALL'}
```
