### PR TITLE
Update fortinet_fortios_get_router_info_bgp_summary.textfsm

### DIFF
--- a/templates/fortinet_fortios_get_router_info_bgp_summary.textfsm
+++ b/templates/fortinet_fortios_get_router_info_bgp_summary.textfsm
@@ -1,6 +1,6 @@
 Value BGP_NEIGH (\d+?\.\d+?\.\d+?\.\d+?)
 Value NEIGH_AS (\d+)
-Value UP_DOWN (\w+)
+Value UP_DOWN (\S+)
 Value STATE_PFXRCD (\w+)
 
 Start


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
fortinet_fortios_get_router_info_bgp_summary.textfsm

##### SUMMARY
Sometimes output has an ":" character in it for uptime which will break the pre-existing regex

Example:

BGP router identifier 10.235.50.1, local AS number 65100
BGP table version is 17
1073 BGP AS-PATH entries
0 BGP community entries

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
172.16.3.225    4      65021  404807  400507       16    0    0 05:48:47      282
172.16.12.225    4      65021  400540  396160       15    0    0 01w6d16h      282
172.16.20.225   4      65022  404307  400489       16    0    0 05:48:30      285
172.16.28.225   4      65022  400482  396197       15    0    0 01w6d16h      285

