### PR TITLE
Add SERIAL of neighboring device

### DIFF
--- a/templates/cisco_ios_show_lldp_neighbors_detail.textfsm
+++ b/templates/cisco_ios_show_lldp_neighbors_detail.textfsm
@@ -7,6 +7,7 @@ Value SYSTEM_DESCRIPTION (.*)
 Value CAPABILITIES (.*)
 Value MANAGEMENT_IP (\S+)
 Value VLAN (\d+)
+Value SERIAL (.*)
 
 Start
   ^.*not advertised
@@ -63,6 +64,7 @@ IgnoreDescription
   ^.* -> Error
 
 Med
+  ^\s+Serial\s+number:\s+${SERIAL}
   ^\s+\S+
   ^\s*$$
   ^\s*Total\s+entries\s+displayed -> Record


### PR DESCRIPTION
Tested on IOS and IOS-XE

##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
show lldp neighbors detail

##### SUMMARY
Adds `serial` as a parsed field from the MED Information some devices report. 
