### PR TITLE
cisco_ios_show_license - avoid trailing white spaces

### DIFF
--- a/templates/cisco_ios_show_license.textfsm
+++ b/templates/cisco_ios_show_license.textfsm
@@ -8,7 +8,7 @@ Value LICENSE_PRIORITY (.*)
 
 Start
   ^Index\s+\d+\s+Feature: -> Continue.Record
-  ^Index\s+\d+\s+Feature:\s+${FEATURE}$$
+  ^Index\s+\d+\s+Feature:\s+${FEATURE}\s*$$
   ^\s+Period\s+left:\s+${PERIOD_LEFT}$$
   ^\s+Period\s+Used:\s+${PERIOD_USED}$$
   ^\s+License\s+Type:\s+${LICENSE_TYPE}$$
@@ -17,4 +17,3 @@ Start
   ^\s+License\s+Priority:\s+${LICENSE_PRIORITY}$$
   ^\s*$$
   ^. -> Error
-

--- a/tests/cisco_ios/show_license/cisco_ios_show_license.raw
+++ b/tests/cisco_ios/show_license/cisco_ios_show_license.raw
@@ -1,60 +1,60 @@
-Index 1 Feature: appxk9
+Index 1 Feature: appxk9                         
         Period left: Life time
         License Type: Permanent
         License State: Active, In Use
         License Count: Non-Counted
         License Priority: Medium
-Index 2 Feature: uck9
+Index 2 Feature: uck9                           
         Period left: Not Activated
         Period Used: 0  minute  0  second
         License Type: EvalRightToUse
         License State: Active, Not in Use, EULA not accepted
         License Count: Non-Counted
         License Priority: None
-Index 3 Feature: securityk9
+Index 3 Feature: securityk9                     
         Period left: Life time
         License Type: Permanent
         License State: Active, In Use
         License Count: Non-Counted
         License Priority: Medium
-Index 4 Feature: ipbasek9
+Index 4 Feature: ipbasek9                       
         Period left: Life time
         License Type: Permanent
         License State: Active, In Use
         License Count: Non-Counted
         License Priority: Medium
-Index 5 Feature: FoundationSuiteK9
+Index 5 Feature: FoundationSuiteK9              
         Period left: Not Activated
         Period Used: 0  minute  0  second
         License Type: EvalRightToUse
         License State: Active, Not in Use, EULA not accepted
         License Count: Non-Counted
         License Priority: None
-Index 6 Feature: AdvUCSuiteK9
+Index 6 Feature: AdvUCSuiteK9                   
         Period left: Not Activated
         Period Used: 0  minute  0  second
         License Type: EvalRightToUse
         License State: Active, Not in Use, EULA not accepted
         License Count: Non-Counted
         License Priority: None
-Index 7 Feature: cme-srst
+Index 7 Feature: cme-srst                       
         Period left: Not Activated
         Period Used: 0  minute  0  second
         License Type: EvalRightToUse
         License State: Active, Not in Use, EULA not accepted
         License Count: 0/0  (In-use/Violation)
         License Priority: None
-Index 8 Feature: hseck9
+Index 8 Feature: hseck9                         
         Period left: Life time
         License Type: Permanent
         License State: Active, In Use
         License Count: Non-Counted
         License Priority: Medium
-Index 9 Feature: throughput
+Index 9 Feature: throughput                     
         Period left: Not Activated
         Period Used: 0  minute  0  second
         License Type: EvalRightToUse
         License State: Active, Not in Use, EULA not accepted
         License Count: Non-Counted
         License Priority: None
-Index 10 Feature: internal_service
+Index 10 Feature: internal_service              


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request
 - Bugfix Pull Request [X]
 - Additional Testing
 - Docs Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
Template: cisco_ios_show_license.textfsm
OS: Cisco IOS
Command: show license

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Some Cisco IOS (for example, Cisco 2900 version 15.5(3)M1) adds several final spaces to the output in the ```feature``` field of the ```show license``` command. Without the ```\s*``` at the end of the regex, the ```feature``` line does not match and the parser ends with error.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Example of output (quotes added by me):
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
"Index 1 Feature: ipbasek9                       "  <-- blank spaces
"	Period left: Life time"
"	License Type: Permanent"
"	License State: Active, In Use"
"	License Count: Non-Counted"
"	License Priority: Medium"
"Index 2 Feature: securityk9                     "  <-- blank spaces
"	Period left: Life time"
        ......
```
