### PR TITLE
New Template: Cisco NXOS show vdc

### DIFF
--- a/templates/cisco_nxos_show_vdc.textfsm
+++ b/templates/cisco_nxos_show_vdc.textfsm
@@ -1,0 +1,10 @@
+Value VDC_ID (\d+)
+Value VDC_NAME (\S+)
+Value STATE (\S+)
+Value MAC (\S+)
+Value TYPE (\S+)
+Value LC (\S+)
+
+Start
+  ^\s*${VDC_ID}\s+${VDC_NAME}\s+${STATE}\s+${MAC}\s+${TYPE}\s+${LC} -> Record
+

--- a/templates/index
+++ b/templates/index
@@ -246,6 +246,7 @@ cisco_nxos_show_module.textfsm, .*, cisco_nxos, sh[[ow]] mod[[ule]]
 cisco_nxos_show_clock.textfsm, .*, cisco_nxos, sh[[ow]] clo[[ck]]
 cisco_nxos_show_vlan.textfsm, .*, cisco_nxos, sh[[ow]] vl[[an]]
 cisco_nxos_show_fex.textfsm, .*, cisco_nxos, sh[[ow]] fex
+cisco_nxos_show_vdc.textfsm, .*, cisco_nxos, sh[[ow]] vdc
 cisco_nxos_show_vpc.textfsm, .*, cisco_nxos, sh[[ow]] vpc
 cisco_nxos_show_vrf.textfsm, .*, cisco_nxos, sh[[ow]] vrf
 

--- a/tests/cisco_nxos/show_vdc/cisco_nxos_show_vdc.raw
+++ b/tests/cisco_nxos/show_vdc/cisco_nxos_show_vdc.raw
@@ -1,0 +1,8 @@
+
+Switchwide mode is m1 f1 m1xl f2 m2xl f2e f3
+
+vdc_id  vdc_name                          state               mac                 type        lc
+------  --------                          -----               ----------          ---------   ------
+1       not1.barr1                        active              e4:c7:22:0c:67:c1   Admin       None
+2       foo1.bar1.bazz1                   active              e4:c7:22:0c:67:c2   Ethernet    f2e
+3       foo2.bar2.bazz2                   active              e4:c7:22:0c:67:c3   Ethernet    f2e

--- a/tests/cisco_nxos/show_vdc/cisco_nxos_show_vdc.yml
+++ b/tests/cisco_nxos/show_vdc/cisco_nxos_show_vdc.yml
@@ -1,0 +1,22 @@
+---
+parsed_sample:
+- vdc_id: "1"
+  vdc_name: "not1.barr1"
+  state: "active"
+  mac: "e4:c7:22:0c:67:c1"
+  type: "Admin"
+  lc: "None"
+
+- vdc_id: "2"
+  vdc_name: "foo1.bar1.bazz1"
+  state: "active"
+  mac: "e4:c7:22:0c:67:c2"
+  type: "Ethernet"
+  lc: "f2e"
+
+- vdc_id: "3"
+  vdc_name: "foo2.bar2.bazz2"
+  state: "active"
+  mac: "e4:c7:22:0c:67:c3"
+  type: "Ethernet"
+  lc: "f2e"


### PR DESCRIPTION
##### SUMMARY

Added template with tests to parse the `show vdc` command on Cisco NXOS
devices. Useful if you are only given the IP to the default VDC but need
to retrieve info from other vdcs as well.

Modified index to include new template.

##### ISSUE TYPE

 - New Template Pull Request

##### COMPONENT

OS: Cisco NXOS
Command: `show vdc`
Template: cisco_nxos_show_vdc.textfsm
