### PR TITLE
Fixed regex for fortinet bgp template and added new template standards

### DIFF
--- a/templates/fortinet_fortios_get_router_info_bgp_summary.textfsm
+++ b/templates/fortinet_fortios_get_router_info_bgp_summary.textfsm
@@ -1,9 +1,15 @@
 Value BGP_NEIGH (\d+?\.\d+?\.\d+?\.\d+?)
 Value NEIGH_AS (\d+)
-Value UP_DOWN (\w+)
+Value UP_DOWN ((?:\w|:)*)
 Value STATE_PFXRCD (\w+)
 
 Start
+  ^BGP router identifier.*$$
+  ^BGP table version is.*$$
+  ^\d*\s+BGP AS-PATH entries.*$$
+  ^\d*\s+BGP community entries.*$$
+  ^Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+TblVer\s+InQ\s+OutQ\s+Up/Down\s+State/PfxRcd.*$$
   ^${BGP_NEIGH}\s+\S+\s+${NEIGH_AS}(?:\s+\S+\s+){5}${UP_DOWN}\s+${STATE_PFXRCD}\s*$$ -> Record
-
-EOF
+  ^Total number of neighbors \d*.*$$
+  ^\s*$$
+  ^. -> Error

--- a/templates/fortinet_fortios_get_router_info_bgp_summary.textfsm
+++ b/templates/fortinet_fortios_get_router_info_bgp_summary.textfsm
@@ -1,15 +1,15 @@
 Value BGP_NEIGH (\d+?\.\d+?\.\d+?\.\d+?)
 Value NEIGH_AS (\d+)
-Value UP_DOWN ((?:\w|:)*)
+Value UP_DOWN (\S+)
 Value STATE_PFXRCD (\w+)
 
 Start
-  ^BGP router identifier.*$$
-  ^BGP table version is.*$$
-  ^\d*\s+BGP AS-PATH entries.*$$
-  ^\d*\s+BGP community entries.*$$
-  ^Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+TblVer\s+InQ\s+OutQ\s+Up/Down\s+State/PfxRcd.*$$
+  ^BGP\s+router\s+identifier\s+\d+?\.\d+?\.\d+?\.\d+?,\s+local\s+AS\s+number\s+\d+\s*$$
+  ^BGP\s+table\s+version\s+is\s+\d+?$$
+  ^\d+\s+BGP\s+AS-PATH\s+entries\s*$$
+  ^\d+\s+BGP\s+community\s+entries\s*$$
+  ^Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+TblVer\s+InQ\s+OutQ\s+Up\/Down\s+State\/PfxRcd.*$$
   ^${BGP_NEIGH}\s+\S+\s+${NEIGH_AS}(?:\s+\S+\s+){5}${UP_DOWN}\s+${STATE_PFXRCD}\s*$$ -> Record
-  ^Total number of neighbors \d*.*$$
+  ^Total number\s+of\s+neighbors\s+\d*\s*$$
   ^\s*$$
   ^. -> Error

--- a/tests/fortinet_fortios/get_router_info_bgp_summary/get_router_info_bgp_summary.raw
+++ b/tests/fortinet_fortios/get_router_info_bgp_summary/get_router_info_bgp_summary.raw
@@ -5,7 +5,7 @@ BGP table version is 13
 
 Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
 10.204.35.84   4      65302   43173   43182        0    0    0 09w3d01h Active     
-10.205.35.95   4      65302  107081  107168       12    0    0 04w5d09h        1
+10.205.35.95   4      65302  107081  107168       12    0    0 05:48:47        1
 169.132.250.17  4       4224       0       0        0    0    0    never Idle       
 169.132.250.21  4       4224       0       0        0    0    0    never Idle       
 

--- a/tests/fortinet_fortios/get_router_info_bgp_summary/get_router_info_bgp_summary.yml
+++ b/tests/fortinet_fortios/get_router_info_bgp_summary/get_router_info_bgp_summary.yml
@@ -7,7 +7,7 @@ parsed_sample:
   - bgp_neigh: "10.205.35.95"
     neigh_as: "65302"
     state_pfxrcd: "1"
-    up_down: "04w5d09h"
+    up_down: "05:48:47"
   - bgp_neigh: "169.132.250.17"
     neigh_as: "4224"
     state_pfxrcd: "Idle"


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
* Name of template: `fortinet_fortios_get_router_info_bgp_summary.textfsm`
* OS: `Fortinet FortiOS`
* Command: `get router info bgp summary`

##### SUMMARY

This fixes an issue with some of the output returned from the `get router info bgp summary` command on `fortinet fortios`. Sometimes time returned output from the device has ":" in the UP_DOWN portion (i.e. 05:48:47). The previous regex did not account for the ":" character. I have updated that with this PR

Additionally, I have updated the template to account for all potential lines of output from the command, finishing on an error state if a line is presented without a regex match.
