### PR TITLE
New Template: cisco_s300_show_version

### DIFF
--- a/templates/cisco_s300_show_version.textfsm
+++ b/templates/cisco_s300_show_version.textfsm
@@ -3,12 +3,12 @@ Value BOOT_VERSION ([1-9]\.[0-9]\.[0-9].[0-9]*)
 Value HW_VERSION (V0[1-9])
 
 Start
-  ^SW\sversion\s+${SW_VERSION}\s.* -> FWVER1
+  ^SW\s+version\s+${SW_VERSION}\s.* -> FWVER1
   ^Active-image:\s.* -> FWVER2
 
 FWVER1
-  ^Boot\sversion\s+${BOOT_VERSION}\s.*
-  ^HW\sversion\s+${HW_VERSION} -> Record
+  ^Boot\s+version\s+${BOOT_VERSION}\s.*
+  ^HW\s+version\s+${HW_VERSION} -> Record
   ^\s*$$
   ^. -> Error
 

--- a/templates/cisco_s300_show_version.textfsm
+++ b/templates/cisco_s300_show_version.textfsm
@@ -1,0 +1,21 @@
+Value SW_VERSION ([1-9]\.[0-9]\.[0-9].[0-9]*)
+Value BOOT_VERSION ([1-9]\.[0-9]\.[0-9].[0-9]*)
+Value HW_VERSION (V0[1-9])
+
+Start
+  ^SW\sversion\s+${SW_VERSION}\s.* -> FWVER1
+  ^Active-image:\s.* -> FWVER2
+
+FWVER1
+  ^Boot\sversion\s+${BOOT_VERSION}\s.*
+  ^HW\sversion\s+${HW_VERSION} -> Record
+  ^\s*$$
+  ^. -> Error
+
+FWVER2
+  ^\s+Version:\s${SW_VERSION} -> Record
+  ^\s+MD5\s.*
+  ^\s+Date:\s.*
+  ^\s+Time:\s.* -> End
+  ^\s*$$
+  ^. -> Error

--- a/templates/index
+++ b/templates/index
@@ -255,6 +255,8 @@ cisco_nxos_show_vdc.textfsm, .*, cisco_nxos, sh[[ow]] vdc
 cisco_nxos_show_vpc.textfsm, .*, cisco_nxos, sh[[ow]] vpc
 cisco_nxos_show_vrf.textfsm, .*, cisco_nxos, sh[[ow]] vrf
 
+cisco_s300_show_version.textfsm, .*, cisco_s300, sh[[ow]] ver[[sion]]
+
 cisco_wlc_ssh_show_advanced_802.11a_channel.textfsm, .*, cisco_wlc_ssh, sh[[ow]] ad[[vanced]] 802\.11[ab] ch[[annel]]
 cisco_wlc_ssh_show_802.11a_cleanair_config.textfsm, .*, cisco_wlc_ssh, sh[[ow]] 802\.11[ab] cl[[eanair]] c[[onfig]]
 cisco_wlc_ssh_show_cdp_neighbors_detail.textfsm, .*, cisco_wlc_ssh, sh[[ow]] c[[dp]] neig[[hbors]] det[[ail]]

--- a/tests/cisco_s300/show_version/cisco_s300_show_version.raw
+++ b/tests/cisco_s300/show_version/cisco_s300_show_version.raw
@@ -1,0 +1,3 @@
+SW version    1.3.7.18 ( date  12-Jan-2014 time  18:02:59 )
+Boot version    1.1.0.6 ( date  11-May-2011 time  18:31:00 )
+HW version    V02

--- a/tests/cisco_s300/show_version/cisco_s300_show_version.yml
+++ b/tests/cisco_s300/show_version/cisco_s300_show_version.yml
@@ -1,0 +1,5 @@
+---
+parsed_sample:
+  - boot_version: "1.1.0.6"
+    hw_version: "V02"
+    sw_version: "1.3.7.18"

--- a/tests/cisco_s300/show_version/cisco_s300_show_version2.raw
+++ b/tests/cisco_s300/show_version/cisco_s300_show_version2.raw
@@ -1,0 +1,10 @@
+Active-image: flash://system/images/image1.bin
+  Version: 2.4.0.94
+  MD5 Digest: 6f5be217100f34929986f2e93dd2d5e9
+  Date: 31-May-2018
+  Time: 02:39:58
+Inactive-image: flash://system/images/_image1.bin
+  Version: 2.4.0.94
+  MD5 Digest: 6f5be217100f34929986f2e93dd2d5e9
+  Date: 31-May-2018
+  Time: 02:39:58

--- a/tests/cisco_s300/show_version/cisco_s300_show_version2.yml
+++ b/tests/cisco_s300/show_version/cisco_s300_show_version2.yml
@@ -1,0 +1,5 @@
+---
+parsed_sample:
+  - boot_version: ""
+    hw_version: ""
+    sw_version: "2.4.0.94"


### PR DESCRIPTION
##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
cisco_s300_show_version

##### SUMMARY
- Parses "show version" output from both version 1.x.y.z and 2.x.y.x Cisco Small Business NOS
- Both provide "Software version" value (`sw_version`) which is the "Firmware Version" on Cisco software download page
- ver 1.x.y.z firmware also provides separate "Boot version" (`boot_version`) and "Hardware version" (`hw_version`) values (present as tested on SG300-[##] switches), but not on ver 2.x.y.z firmware