### PR TITLE
BugFix: Remove reliance on static spacing for cisco_ios_show_ip_ospf_database_router

### DIFF
--- a/templates/cisco_ios_show_ip_ospf_database_router.textfsm
+++ b/templates/cisco_ios_show_ip_ospf_database_router.textfsm
@@ -27,7 +27,7 @@ LSAInfo
   ^\s+Options:\s+\(${LSA_OPTIONS}\)
   ^\s+LS\s+Type:\s+${LSA_TYPE}
   ^\s+Link\s+State\s+ID:\s+${LSA_ID}
-  ^\s+Advertising Router:\s+${LSA_ADV_ROUTER}
+  ^\s+Advertising\s+Router:\s+${LSA_ADV_ROUTER}
   ^\s+LS\s+Seq\s+Number:\s+${LSA_SEQ_NUMBER}
   ^\s+Checksum:\s+${LSA_CHECKSUM}
   ^\s+Length:\s+${LSA_LENGTH}


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
cisco_ios_show_ip_ospf_database_router

##### SUMMARY
Removed reliance on static spacing in cisco_ios_show_ip_ospf_database_router.textfsm. I overlooked this in PR #606.