### PR TITLE
Enhancement: cisco_asa_show_inventory support inventory items w/o SN

### DIFF
--- a/templates/cisco_asa_show_inventory.textfsm
+++ b/templates/cisco_asa_show_inventory.textfsm
@@ -7,6 +7,7 @@ Value SN (\S+)
 Start
   ^Name:\s+"${NAME}"\s*,\s+DESCR:\s+"${DESCR}"
   ^PID:\s+${PID}\s*,\s+VID:\s+${VID}\s*,\s+SN:\s+${SN} -> Record
+  ^PID:\s+${PID}\s*,\s+VID:\s+${VID}\s*,\s+SN: -> Record
   ^\s*$$
   ^show_inventory_all\s+\S+ -> NoRecord
   ^.+ -> Error

--- a/tests/cisco_asa/show_inventory/cisco_asa_show_inventory_empty_sn.raw
+++ b/tests/cisco_asa/show_inventory/cisco_asa_show_inventory_empty_sn.raw
@@ -1,0 +1,5 @@
+Name: "Chassis", DESCR: "ASA 5506-X with FirePOWER services, 8GE, AC, DES"
+PID: ASA5506           , VID: V01     , SN: JMX8318372GB
+
+Name: "Storage Device 1", DESCR: "ASA 5506-X SSD"
+PID: ASA5506-SSD       , VID: N/A     , SN:

--- a/tests/cisco_asa/show_inventory/cisco_asa_show_inventory_empty_sn.yml
+++ b/tests/cisco_asa/show_inventory/cisco_asa_show_inventory_empty_sn.yml
@@ -1,0 +1,12 @@
+---
+parsed_sample:
+  - name: "Chassis"
+    descr: "ASA 5506-X with FirePOWER services, 8GE, AC, DES"
+    pid: "ASA5506"
+    sn: "JMX8318372GB"
+    vid: "V01"
+  - name: "Storage Device 1"
+    descr: "ASA 5506-X SSD"
+    pid: "ASA5506-SSD"
+    sn: ""
+    vid: "N/A"


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT

cisco_asa_show_inventory.textfsm

##### SUMMARY

Change template to allow for inventory items that do not report a serial number. 
For example, some SSD's don't seem to report a SN in the show inventory output.