### PR TITLE
Remove "terminal" dependency

### DIFF
--- a/lib/ntc_templates/parse.py
+++ b/lib/ntc_templates/parse.py
@@ -1,10 +1,6 @@
 """ntc_templates.parse."""
 import os
-
-try:
-    from textfsm import clitable
-except ImportError:
-    import clitable
+from textfsm import clitable
 
 
 def _get_template_dir():

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ config = {
     "author": "network.toCode()",
     "author_email": "info@networktocode.com",
     "url": "https://github.com/networktocode/ntc-templates",
-    "install_requires": ["textfsm", "terminal"],
+    "install_requires": ["textfsm>=1.1.0"],
     "extras_require": {"dev": ["pytest", "PyYAML", "black", "yamllint", "ruamel.yaml"]},
     "classifiers": [
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
There was a long-standing issue in TextFSM which caused textfsm to break on Windows. This was due to the TextFSM library importing the "fcntl" library (inside TextFSM's terminal.py module).

ntc-templates had a workaround for this problem where they installed a completely different `terminal` library.

This worked in textfsm 0.4.1 as textfsm_0_4_1 would put all of its Python files directly into site-packages (literally ./site-packages/terminal.py). Consequently, the install of the other `terminal` module would overwrite the `terminal.py` that came installed with textfsm.

With this fix here:

https://github.com/google/textfsm/blob/v1.1.1/textfsm/terminal.py#L25-L29

And with the fact that textfsm is now installed as a proper package in site-packages (in other words `site-packages/textfsm/` and then the package files inside that directory).

The installation of the other `terminal` package should now be useless.

The relevance to me is that I am interested in making ntc-templates a direct Netmiko dependency, but I don't really like installing this separate terminal.py file (https://github.com/lepture/terminal) as that library is unmaintained (last commit in 2013)

Additionally, I have had interoperability issues with the ntc-templates fix to this problem in the paste. And now that it is obsolete, it would be good to get rid of it.

There is no code that is actually by in terminal.py by ntc-templates or Netmiko (in either the old or the new solution). The problem is entirely an import issue.
