### PR TITLE
Update paloalto_panos_show_interface_hardware.textfsm

### DIFF
--- a/templates/paloalto_panos_show_interface_hardware.textfsm
+++ b/templates/paloalto_panos_show_interface_hardware.textfsm
@@ -1,8 +1,9 @@
 Value INTF (\S+)
-Value SPEED (\d+|\[n\/a\])
+Value ID (\S+)
+Value SPEED (\S+)
 Value DUPLEX (\S+)
 Value STATE (\S+)
+Value ADDRESS ([a-fA-F0-9]{2}\:[a-fA-F0-9]{2}\:[a-fA-F0-9]{2}\:[a-fA-F0-9]{2}\:[a-fA-F0-9]{2}\:[a-fA-F0-9]{2})
 
 Start
-  #^${INTF}\s+\d+\s+[n/a]/[n/a]/${STATE}\s+\S+ -> Record
-  ^${INTF}\s+\d+\s+${SPEED}/${DUPLEX}/${STATE}\s+\S+ -> Record
+  ^${INTF}\s+${ID}\s+${SPEED}/${DUPLEX}/${STATE}\s+${ADDRESS} -> Record


### PR DESCRIPTION
- Fixed speed to also match for "ukn/ukn/down(autoneg)"
- Added support for ID and mac address.
