### PR TITLE
BugFix: (IOS) - show cdp neighbors detail - Prevent capturing trailing whitespace for capabilities

### DIFF
--- a/templates/cisco_ios_show_cdp_neighbors_detail.textfsm
+++ b/templates/cisco_ios_show_cdp_neighbors_detail.textfsm
@@ -4,12 +4,13 @@ Value PLATFORM (.*)
 Value REMOTE_PORT (.*)
 Value LOCAL_PORT (.*)
 Value SOFTWARE_VERSION (.*$)
-Value CAPABILITIES (.*?)
+Value CAPABILITIES (.+?)
 
 Start
   ^Device ID: ${DESTINATION_HOST}
   ^Entry address\(es\)\s*:\s* -> ParseIP
-  ^Platform\s*:\s*${PLATFORM}\s*,\s*Capabilities\s*:\s*${CAPABILITIES}\s*$$
+  ^Platform\s*:\s*${PLATFORM}\s*,\s*Capabilities\s*:\s*${CAPABILITIES}\s+$$
+  ^Platform\s*:\s*${PLATFORM}\s*,\s*Capabilities\s*:\s*${CAPABILITIES}$$
   ^Interface: ${LOCAL_PORT},  Port ID \(outgoing port\): ${REMOTE_PORT}
   ^Version : -> GetVersion
   # Capture time-stamp if vty line has command time-stamping turned on
@@ -18,7 +19,8 @@ Start
 
 ParseIP
   ^.*IP address: ${MANAGEMENT_IP} -> Start
-  ^Platform\s*:\s*${PLATFORM}\s*,\s*Capabilities\s*:\s*${CAPABILITIES} -> Start
+  ^Platform\s*:\s*${PLATFORM}\s*,\s*Capabilities\s*:\s*${CAPABILITIES}\s+$$ -> Start
+  ^Platform\s*:\s*${PLATFORM}\s*,\s*Capabilities\s*:\s*${CAPABILITIES}$$ -> Start
   ^.* -> Start
 
 GetVersion

--- a/templates/cisco_ios_show_cdp_neighbors_detail.textfsm
+++ b/templates/cisco_ios_show_cdp_neighbors_detail.textfsm
@@ -4,12 +4,12 @@ Value PLATFORM (.*)
 Value REMOTE_PORT (.*)
 Value LOCAL_PORT (.*)
 Value SOFTWARE_VERSION (.*$)
-Value CAPABILITIES (.*)
+Value CAPABILITIES (.*?)
 
 Start
   ^Device ID: ${DESTINATION_HOST}
   ^Entry address\(es\)\s*:\s* -> ParseIP
-  ^Platform\s*:\s*${PLATFORM}\s*,\s*Capabilities\s*:\s*${CAPABILITIES}
+  ^Platform\s*:\s*${PLATFORM}\s*,\s*Capabilities\s*:\s*${CAPABILITIES}\s*$$
   ^Interface: ${LOCAL_PORT},  Port ID \(outgoing port\): ${REMOTE_PORT}
   ^Version : -> GetVersion
   # Capture time-stamp if vty line has command time-stamping turned on

--- a/tests/cisco_ios/show_cdp_neighbors_detail/cisco_ios_show_cdp_neighbors_detail2.raw
+++ b/tests/cisco_ios/show_cdp_neighbors_detail/cisco_ios_show_cdp_neighbors_detail2.raw
@@ -1,0 +1,23 @@
+Device ID: switchxxxxx
+Entry address(es): 
+  IP address: 1.1.1.1
+Platform: cisco WS-C3560X-24P,  Capabilities: Switch IGMP 
+Interface: GigabitEthernet0/3,  Port ID (outgoing port): GigabitEthernet0/8
+Holdtime : 154 sec
+
+Version :
+Cisco IOS Software, C3560E Software (C3560E-UNIVERSALK9-M), Version 12.2(55)SE10, RELEASE SOFTWARE (fc2)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2015 by Cisco Systems, Inc.
+Compiled Wed 11-Feb-15 11:28 by prod_rel_team
+
+advertisement version: 2
+Protocol Hello:  OUI=0x00000C, Protocol ID=0x0112; payload len=27, value=00000000FFFFFFFF010221FF00000000000000C88BC41880FF0000
+VTP Management Domain: ''
+Native VLAN: 1
+Duplex: full
+Power Available TLV:
+
+    Power request id: 0, Power management id: 1, Power available: 0, Power management level: -1
+Management address(es): 
+  IP address: 1.1.1.1

--- a/tests/cisco_ios/show_cdp_neighbors_detail/cisco_ios_show_cdp_neighbors_detail2.yml
+++ b/tests/cisco_ios/show_cdp_neighbors_detail/cisco_ios_show_cdp_neighbors_detail2.yml
@@ -1,0 +1,10 @@
+---
+parsed_sample:
+  - destination_host: "switchxxxxx"
+    management_ip: "1.1.1.1"
+    platform: "cisco WS-C3560X-24P"
+    remote_port: "GigabitEthernet0/8"
+    local_port: "GigabitEthernet0/3"
+    software_version: "Cisco IOS Software, C3560E Software (C3560E-UNIVERSALK9-M),\
+      \ Version 12.2(55)SE10, RELEASE SOFTWARE (fc2)"
+    capabilities: "Switch IGMP"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_cdp_neighbors_detail.textfsm
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #683 
