### PR TITLE
HP Procurve show trunks

### DIFF
--- a/templates/hp_procurve_show_trunks.textfsm
+++ b/templates/hp_procurve_show_trunks.textfsm
@@ -9,7 +9,7 @@ Start
   ^\s+Port\s+|\s+Name\s+Type\s+|\s+Group\s+Type.*$$
   ^\s+-+\s+\+\s+\-+.* -> TRUNKS
   ^\s*$$
-  ^.* -> Error
+  ^. -> Error
 
 TRUNKS
   ^\s+${LOCAL_PORT}\s+\|\s${INT_NAME}\s+ ${INT_TYPE}\s+ \|\s${TRUNK}\s+${TRUNK_TYPE}.*$$ -> Record

--- a/templates/hp_procurve_show_trunks.textfsm
+++ b/templates/hp_procurve_show_trunks.textfsm
@@ -1,0 +1,18 @@
+Value Required LOCAL_PORT (\S+)
+Value INT_NAME (.*?)
+Value INT_TYPE (.*?)
+Value TRUNK (\S+)
+Value TRUNK_TYPE (\S+)
+
+Start
+  ^\s*Load\sBalancing\sMethod.*$$
+  ^\s+Port\s+|\s+Name\s+Type\s+|\s+Group\s+Type.*$$
+  ^\s+-+\s+\+\s+\-+.* -> TRUNKS
+  ^\s*$$
+  ^.* -> Error
+
+TRUNKS
+  ^\s+${LOCAL_PORT}\s+\|\s${INT_NAME}\s+ ${INT_TYPE}\s+ \|\s${TRUNK}\s+${TRUNK_TYPE}.*$$ -> Record
+  ^\S+\#\s*$$
+  ^\s*$$
+  ^. -> Error

--- a/templates/index
+++ b/templates/index
@@ -350,6 +350,7 @@ hp_comware_display_arp.textfsm, .*, hp_comware, di[[splay]] a[[rp]]
 hp_procurve_show_tech_buffers.textfsm, .*, hp_procurve, sh[[ow]] tec[[h]] buf[[ffers]]
 hp_procurve_show_mac-address.textfsm, .*, hp_procurve, sh[[ow]] mac-a[[ddress]]
 hp_procurve_show_system.textfsm, .*, hp_procurve, sh[[ow]] syst[[em]]
+hp_procurve_show_trunks.textfsm, .*, hp_procurve, sh[[ow]] tr[[unks]]
 hp_procurve_show_vlans.textfsm, .*, hp_procurve, sh[[ow]] vl[[ans]]
 hp_procurve_show_arp.textfsm, .*, hp_procurve, sh[[ow]] ar[[p]]
 

--- a/tests/hp_procurve/show_trunks/hp_procurve_show_trunks.raw
+++ b/tests/hp_procurve/show_trunks/hp_procurve_show_trunks.raw
@@ -1,0 +1,8 @@
+
+ Load Balancing Method:  L3-based (default)
+
+  Port   | Name                             Type       | Group Type    
+  ------ + -------------------------------- ---------- + ----- --------
+  49     | Uplink 65432p-swi001             1000LX     | Trk2  LACP    
+  50     | Uplink 65432p-swi001             1000LX     | Trk2  LACP    
+ 

--- a/tests/hp_procurve/show_trunks/hp_procurve_show_trunks.yml
+++ b/tests/hp_procurve/show_trunks/hp_procurve_show_trunks.yml
@@ -1,0 +1,12 @@
+---
+parsed_sample:
+  - int_name: "Uplink 65432p-swi001"
+    int_type: "1000LX"
+    local_port: "49"
+    trunk: "Trk2"
+    trunk_type: "LACP"
+  - int_name: "Uplink 65432p-swi001"
+    int_type: "1000LX"
+    local_port: "50"
+    trunk: "Trk2"
+    trunk_type: "LACP"


### PR DESCRIPTION
##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
HP Procurve show trunks command added


##### SUMMARY
Keeping the HP Procurve/aruba naming as it's easy to confuse with cisco "trunks" which are not the same thing.
