### PR TITLE
Cisco IOS - Adding template for 'show ip cef' command

### DIFF
--- a/templates/cisco_ios_show_ip_cef.textfsm
+++ b/templates/cisco_ios_show_ip_cef.textfsm
@@ -1,0 +1,21 @@
+Value PREFIX (\d+\.\d+\.\d+\.+\d+\/\d+)
+Value Required,List NEXTHOP (drop|receive|attached|\d+\.\d+\.\d+\.\d+)
+Value List INTERFACE (\S+)
+
+Start
+  ^Prefix.*Next.*Interface\s*$$ -> FIB
+
+FIB
+  # Start Record on encountering a Prefix, don't substitute any values yet
+  ^\*?(\d+\.\d+\.\d+\.+\d+\/\d+) -> Continue.Record
+  # Match lines with all Values present, some entries can start with * (for multiple entries in RIB, one in FIB prefixes)
+  ^\*?${PREFIX}\s+${NEXTHOP}\s+${INTERFACE}\s*$$
+  # Match lines which do not have an interface, strange but can exists
+  ^\*?${PREFIX}\s+${NEXTHOP}\s*$$
+  # Match lines which have Nexthop and interface, and fill in the list; these are for prefixes which have multiple equal cost paths
+  ^\s+${NEXTHOP}\s+${INTERFACE}\s*$$
+  # Match other lines before erroring out on unknown input lines  
+  ^\s*$$
+  ^[-+]*$$
+  ^. -> Error
+

--- a/templates/index
+++ b/templates/index
@@ -212,6 +212,7 @@ cisco_ios_show_standby.textfsm, .*, cisco_ios, sh[[ow]] sta[[ndby]]
 cisco_ios_show_version.textfsm, .*, cisco_ios, sh[[ow]] ver[[sion]]
 cisco_ios_show_ip_arp.textfsm, .*, cisco_ios, sh[[ow]] i[[p]] a[[rp]]
 cisco_ios_show_ip_bgp.textfsm, .*, cisco_ios, sh[[ow]] i[[p]] bgp
+cisco_ios_show_ip_cef.textfsm, .*, cisco_ios, sh[[ow]] ip cef
 cisco_ios_show_tacacs.textfsm, .*, cisco_ios, sh[[ow]] tacacs
 cisco_ios_show_clock.textfsm, .*, cisco_ios, sh[[ow]] clo[[ck]]
 cisco_ios_show_dmvpn.textfsm, .*, cisco_ios, sh[[ow]] dm[[vpn]]

--- a/tests/cisco_ios/show_ip_cef/cisco_ios_show_ip_cef.raw
+++ b/tests/cisco_ios/show_ip_cef/cisco_ios_show_ip_cef.raw
@@ -1,0 +1,9 @@
+Prefix               Next Hop             Interface
+0.0.0.0/0            172.16.88.2          Port-channel1
+0.0.0.0/8            drop
+0.0.0.0/32           receive              
+10.1.2.0/24          attached             Vlan200
+224.0.0.0/4          drop
+224.0.0.0/24         receive              
+240.0.0.0/4          drop
+255.255.255.255/32   receive              

--- a/tests/cisco_ios/show_ip_cef/cisco_ios_show_ip_cef.yml
+++ b/tests/cisco_ios/show_ip_cef/cisco_ios_show_ip_cef.yml
@@ -1,0 +1,36 @@
+---
+parsed_sample:
+  - interface:
+      - "Port-channel1"
+    nexthop:
+      - "172.16.88.2"
+    prefix: "0.0.0.0/0"
+  - interface: []
+    nexthop:
+      - "drop"
+    prefix: "0.0.0.0/8"
+  - interface: []
+    nexthop:
+      - "receive"
+    prefix: "0.0.0.0/32"
+  - interface:
+      - "Vlan200"
+    nexthop:
+      - "attached"
+    prefix: "10.1.2.0/24"
+  - interface: []
+    nexthop:
+      - "drop"
+    prefix: "224.0.0.0/4"
+  - interface: []
+    nexthop:
+      - "receive"
+    prefix: "224.0.0.0/24"
+  - interface: []
+    nexthop:
+      - "drop"
+    prefix: "240.0.0.0/4"
+  - interface: []
+    nexthop:
+      - "receive"
+    prefix: "255.255.255.255/32"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_ip_cef.textfsm, cisco_ios, sh[[ow]] ip cef
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This template/logic is similar to "cisco_nxos_show_forwarding_ipv4_route.textfsm" but reads CEF for IOS.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
tox
<snip>
tests/test_testcases_exists.py::test_verify_parsed_and_reference_data_exists[tests/cisco_ios/show_ip_cef] PASSED                                                                                     [ 76%]
<snip>
=========================================================================================== 882 passed in 19.56s ===========================================================================================
_________________________________________________________________________________________________ summary __________________________________________________________________________________________________
  py36: commands succeeded
SKIPPED:  py37: InterpreterNotFound: python3.7
  py38: commands succeeded
  congratulations :)

```
