### PR TITLE
Update cisco_ios_show_processes_memory_sorted.textfsm

### DIFF
--- a/templates/cisco_ios_show_processes_memory_sorted.textfsm
+++ b/templates/cisco_ios_show_processes_memory_sorted.textfsm
@@ -16,6 +16,5 @@ Start
 
 Process
   ^\s*${PROCESS_ID}\s+\d+\s+${PROCESS_ALLOCATED}\s+${PROCESS_FREED}\s+${PROCESS_HOLDING}\s+\d+\s+\d+\s+${PROCESS}\s*$$
-  ^\s*$$
   ^\s*\d\s\s$$
   ^. -> Error

--- a/templates/cisco_ios_show_processes_memory_sorted.textfsm
+++ b/templates/cisco_ios_show_processes_memory_sorted.textfsm
@@ -16,5 +16,5 @@ Start
 
 Process
   ^\s*${PROCESS_ID}\s+\d+\s+${PROCESS_ALLOCATED}\s+${PROCESS_FREED}\s+${PROCESS_HOLDING}\s+\d+\s+\d+\s+${PROCESS}\s*$$
-  ^\s*\d*\s\Total\s*$$
+  ^\s*\d*\sTotal\s*$$
   ^. -> Error

--- a/templates/cisco_ios_show_processes_memory_sorted.textfsm
+++ b/templates/cisco_ios_show_processes_memory_sorted.textfsm
@@ -16,5 +16,5 @@ Start
 
 Process
   ^\s*${PROCESS_ID}\s+\d+\s+${PROCESS_ALLOCATED}\s+${PROCESS_FREED}\s+${PROCESS_HOLDING}\s+\d+\s+\d+\s+${PROCESS}\s*$$
-  ^\s*\d*\s\Total$$
+  ^\s*\d*\s\Total\s*$$
   ^. -> Error

--- a/templates/cisco_ios_show_processes_memory_sorted.textfsm
+++ b/templates/cisco_ios_show_processes_memory_sorted.textfsm
@@ -17,4 +17,5 @@ Start
 Process
   ^\s*${PROCESS_ID}\s+\d+\s+${PROCESS_ALLOCATED}\s+${PROCESS_FREED}\s+${PROCESS_HOLDING}\s+\d+\s+\d+\s+${PROCESS}\s*$$
   ^\s*$$
+  ^\s*\d\s\s$$
   ^. -> Error

--- a/templates/cisco_ios_show_processes_memory_sorted.textfsm
+++ b/templates/cisco_ios_show_processes_memory_sorted.textfsm
@@ -16,5 +16,5 @@ Start
 
 Process
   ^\s*${PROCESS_ID}\s+\d+\s+${PROCESS_ALLOCATED}\s+${PROCESS_FREED}\s+${PROCESS_HOLDING}\s+\d+\s+\d+\s+${PROCESS}\s*$$
-  ^\s*\d\s\s$$
+  ^\s*\d*\s\Total$$
   ^. -> Error


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 
 - Bugfix Pull Request
 
##### COMPONENT
<!--- Name of the template, os and command  -->
show  processes memory sorted
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Output on a couple of different routers have an extra line at the very end.  Right after the process list we see a line giving the total RAM.  E.g.

631   0       4248          0      58192          0          0 ONEP Dispatch XD
 632   0      74296       1424      84616          3          3 ONEP Network Ele
 PID TTY  Allocated      Freed    Holding    Getbufs    Retbufs Process
                                342936032 Total


<!---
I
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
