### PR TITLE
EOS can have N/A in the age field for show ip arp

### DIFF
--- a/templates/arista_eos_show_ip_arp.textfsm
+++ b/templates/arista_eos_show_ip_arp.textfsm
@@ -1,5 +1,5 @@
 Value ADDRESS (\d+\.\d+\.\d+\.\d+)
-Value AGE (\d+)
+Value AGE ((\d+|N\/A))
 Value MAC (\S+)
 Value INTERFACE (.*)
 

--- a/tests/arista_eos/show_ip_arp/arista_eos_show_ip_arp.raw
+++ b/tests/arista_eos/show_ip_arp/arista_eos_show_ip_arp.raw
@@ -1,4 +1,5 @@
-Address Age (min) Hardware Addr Interface
-172.25.0.2 0 004c.6211.021e Vlan101, Port-Channel2
-172.22.0.1 0 004c.6214.3699 Vlan1000, Port-Channel1
-172.22.0.2 0 004c.6219.a0f3 Ethernet1
+Address      Age (min) Hardware Addr  Interface
+172.25.0.2           0 004c.6211.021e Vlan101, Port-Channel2
+172.22.0.1           0 004c.6214.3699 Vlan1000, Port-Channel1
+172.22.0.2           0 004c.6219.a0f3 Ethernet1
+10.10.1.1          N/A 0002.00ff.0001 Vlan1, not learned

--- a/tests/arista_eos/show_ip_arp/arista_eos_show_ip_arp.yml
+++ b/tests/arista_eos/show_ip_arp/arista_eos_show_ip_arp.yml
@@ -12,3 +12,7 @@ parsed_sample:
     age: "0"
     mac: "004c.6219.a0f3"
     interface: "Ethernet1"
+  - address: "10.10.1.1"
+    age: "N/A"
+    mac: "0002.00ff.0001"
+    interface: "Vlan1, not learned"


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
arista eos "show ip arp"

##### SUMMARY
Age field can have a value of "N/A" in it.



