### PR TITLE
Create cisco_ios_show_interfaces_description.textfsm

### DIFF
--- a/cisco_ios_show_interfaces_description.textfsm
+++ b/cisco_ios_show_interfaces_description.textfsm
@@ -1,0 +1,17 @@
+Value PORT (\S+)
+Value STATUS (up|down|admin\s+down|deleted)
+Value PROTOCOL (up|down)
+Value DESCRIP (\S.*?)
+
+Start
+  ^Interface\s+Status\s+Protocol\s+Description\s*$$ -> Begin
+  ^\s*$$
+  # Capture time-stamp if vty line has command time-stamping turned on
+  ^Load\s+for\s+
+  ^Time\s+source\s+is
+  ^. -> Error
+
+Begin
+  ^${PORT}\s+${STATUS}\s+${PROTOCOL}(?:\s+${DESCRIP})?\s*$$ -> Record
+  ^\s*$$
+  ^. -> Error


### PR DESCRIPTION
Adding the deleted keyword to the STATUS value to handle sub-interfaces that have been deleted

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_interfaces_description.textfsm
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added deleted keyword to the STATUS VALUE of the cisco_ios_show_interfaces_description.textfsm template.  Without this keyword, the template will throw an error as discussed here: https://github.com/networktocode/ntc-templates/issues/718 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #718 
<!-- Paste verbatim command output below, e.g. before and after your change -->
Before change
```
output = device.send_command('show int desc', delay_factor=2, use_textfsm=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\RP\AppData\Local\Programs\Python\Python38\lib\site-packages\netmiko\utilities.py", line 347, in wrapper_decorator
    return func(self, *args, **kwargs)
  File "C:\Users\RP\AppData\Local\Programs\Python\Python38\lib\site-packages\netmiko\base_connection.py", line 1444, in send_command
    structured_output = get_structured_data(
  File "C:\Users\RP\AppData\Local\Programs\Python\Python38\lib\site-packages\netmiko\utilities.py", line 280, in get_structured_data
    return _textfsm_parse(textfsm_obj, raw_output, attrs)
  File "C:\Users\RP\AppData\Local\Programs\Python\Python38\lib\site-packages\netmiko\utilities.py", line 252, in _textfsm_parse
    textfsm_obj.ParseCmd(raw_output, attrs)
  File "C:\Users\RP\AppData\Local\Programs\Python\Python38\lib\site-packages\netmiko\_textfsm\_clitable.py", line 272, in ParseCmd
    self.table = self._ParseCmdItem(self.raw, template_file=template_files[0])
  File "C:\Users\RP\AppData\Local\Programs\Python\Python38\lib\site-packages\netmiko\_textfsm\_clitable.py", line 303, in _ParseCmdItem
    for record in fsm.ParseText(cmd_input):
  File "C:\Users\RP\AppData\Local\Programs\Python\Python38\lib\site-packages\textfsm\parser.py", line 895, in ParseText
    self._CheckLine(line)
  File "C:\Users\RP\AppData\Local\Programs\Python\Python38\lib\site-packages\textfsm\parser.py", line 944, in _CheckLine
    if self._Operations(rule, line):
  File "C:\Users\RP\AppData\Local\Programs\Python\Python38\lib\site-packages\textfsm\parser.py", line 1024, in _Operations
    raise TextFSMError('State Error raised. Rule Line: %s. Input Line: %s'
textfsm.parser.TextFSMError: State Error raised. Rule Line: 17. Input Line: Gi0/0/5.25                     deleted        down
```
After change:
```
>>> output = device.send_command('show int desc', delay_factor=2, use_textfsm=True)
>>> output
[{'port': 'Gi0/0/0', 'status': 'up', 'protocol': 'up', 'descrip': 'Connected to S01 Port Gi1/6/2'}, {'port': 'Gi0/0/1', 'status': 'up', 'protocol': 'up', 'descrip': 'Connected to S02 Gi2/6/2'}, {'port': 'Gi0/0/2', 'status': 'admin down', 'protocol': 'down', 'descrip': ''}, {'port': 'Gi0/0/3', 'status': 'up', 'protocol': 'up', 'descrip': 'Bypass Link to Gi1/6/37'}, {'port': 'Gi0/0/4', 'status': 'admin down', 'protocol': 'down', 'descrip': ''}, {'port': 'Gi0/0/5', 'status': 'up', 'protocol': 'up', 'descrip': 'ISP Connection'}, {'port': 'Gi0/0/5.25', 'status': 'deleted', 'protocol': 'down', 'descrip': ''}, {'port': 'Gi0/0/5.60', 'status': 'up', 'protocol': 'up', 'descrip': 'ISP'}, {'port': 'Se0/1/0', 'status': 'admin down', 'protocol': 'down', 'descrip': ''}, {'port': 'Se0/1/1', 'status': 'admin down', 'protocol': 'down', 'descrip': ''}, {'port': 'Gi0', 'status': 'admin down', 'protocol': 'down', 'descrip': ''}, {'port': 'Lo0', 'status': 'up', 'protocol': 'up', 'descrip': ''},{'port': 'Lo10', 'status': 'up', 'protocol': 'up', 'descrip': 'TUNNEL ENDPOINT'},{'port': 'Tu0', 'status': 'up', 'protocol': 'up', 'descrip': ''}]
```