### PR TITLE
New Template support for broadcom_icos as a new OS and added show_version command

### DIFF
--- a/templates/broadcom_icos_show_version.textfsm
+++ b/templates/broadcom_icos_show_version.textfsm
@@ -1,41 +1,40 @@
-Value System_Description (.+)
-Value Machine_Type (.+)
-Value Machine_Model (.+)
-Value Serial_Number (.+)
-Value Fru_Number (.+)
-Value Part_Number (.+)
-Value Maintenance_Level (.+)
-Value Manufacturer (.+)
-Value Burned_In_MAC_Address (.+)
-Value Software_Version (.+)
-Value Operating_System (.+)
-Value Network_Processing_Device (.+)
-Value CPLD_version (.+)
-Value Board_Revision (.+)
-Value List Additional_Packages (.+)
+Value DESCRIPTION (.+)
+Value SWITCH_TYPE (.+)
+Value SWITCH_MODEL (.+)
+Value SERIAL (.+)
+Value FRU_NUMBER (.+)
+Value PART_NUMBER (.+)
+Value MAINTENANCE_LEVEL (.+)
+Value MANUFACTURER (.+)
+Value MAC (.+)
+Value VERSION (.+)
+Value OS_VERSION (.+)
+Value NETWORK_PROCESSING_DEVICE (.+)
+Value CPLD_VERSION (.+)
+Value BOARD_REVISION (.+)
+Value List ADDITIONAL_PACKAGES (.+)
 
 Start
   # Captures show version for:
   # Accton AS4610-54P, Accton AS5610-52X, Quanta LY2R, Quanta LB9, DNI AG3448P-R   
   # The following can be an empty value as it doesnt exist in all the models:
   # FruNumber, PartNumber, CPLDversion, BoardRevision
-  ^\s*$$
   ^\s*Switch\s*:\s*\d+\s*$$
   ^\s*$$
-  ^\s*System\s*Description\s*\.+\s*${System_Description}$$
-  ^\s*Machine\s*Type\s*\.+\s*${Machine_Type}$$
-  ^\s*Machine\s*Model\s*\.+\s*${Machine_Model}$$
-  ^\s*Serial\s*Number\s*\.+\s*${Serial_Number}$$
-  ^\s*FRU\s*Number\s*\.+\s*${Fru_Number}$$
-  ^\s*Part\s*Number\s*\.+\s*${Part_Number}$$
-  ^\s*Maintenance\s*Level\s*\.+\s*${Maintenance_Level}$$
-  ^\s*Manufacturer\s*\.+\s*${Manufacturer}$$
-  ^\s*Burned\s*In\s*MAC\s*Address\s*\.+\s*${Burned_In_MAC_Address}$$
-  ^\s*Software\s*Version\s*\.+\s*${Software_Version}$$
-  ^\s*Operating\s*System\s*\.+\s*${Operating_System}$$
-  ^\s*Network\s*Processing\s*Device\s*\.+\s*${Network_Processing_Device}$$
-  ^\s*CPLD\s*version\s*\.+\s*${CPLD_version}$$
-  ^\s*Board\s*Revision\s*\.+\s*${Board_Revision}$$
-  ^\S \S\S -> Continue.Record
-  ^\s*Additional\s*Packages\s*\.+\s*${Additional_Packages}$$
-  ^\s*${Additional_Packages}$$
+  ^\s*System\s*Description\s*\.+\s*${DESCRIPTION}$$
+  ^\s*Machine\s*Type\s*\.+\s*${SWITCH_TYPE}$$
+  ^\s*Machine\s*Model\s*\.+\s*${SWITCH_MODEL}$$
+  ^\s*Serial\s*Number\s*\.+\s*${SERIAL}$$
+  ^\s*FRU\s*Number\s*\.+\s*${FRU_NUMBER}$$
+  ^\s*Part\s*Number\s*\.+\s*${PART_NUMBER}$$
+  ^\s*Maintenance\s*Level\s*\.+\s*${MAINTENANCE_LEVEL}$$
+  ^\s*Manufacturer\s*\.+\s*${MANUFACTURER}$$
+  ^\s*Burned\s*In\s*MAC\s*Address\s*\.+\s*${MAC}$$
+  ^\s*Software\s*Version\s*\.+\s*${VERSION}$$
+  ^\s*Operating\s*System\s*\.+\s*${OS_VERSION}$$
+  ^\s*Network\s*Processing\s*Device\s*\.+\s*${NETWORK_PROCESSING_DEVICE}$$
+  ^\s*CPLD\s*version\s*\.+\s*${CPLD_VERSION}$$
+  ^\s*Board\s*Revision\s*\.+\s*${BOARD_REVISION}$$
+  ^\s*Additional\s*Packages\s*\.+\s*${ADDITIONAL_PACKAGES}$$
+  ^\s+${ADDITIONAL_PACKAGES}$$
+  ^. -> Error

--- a/templates/broadcom_icos_show_version.textfsm
+++ b/templates/broadcom_icos_show_version.textfsm
@@ -1,0 +1,41 @@
+Value System_Description (.+)
+Value Machine_Type (.+)
+Value Machine_Model (.+)
+Value Serial_Number (.+)
+Value Fru_Number (.+)
+Value Part_Number (.+)
+Value Maintenance_Level (.+)
+Value Manufacturer (.+)
+Value Burned_In_MAC_Address (.+)
+Value Software_Version (.+)
+Value Operating_System (.+)
+Value Network_Processing_Device (.+)
+Value CPLD_version (.+)
+Value Board_Revision (.+)
+Value List Additional_Packages (.+)
+
+Start
+  # Captures show version for:
+  # Accton AS4610-54P, Accton AS5610-52X, Quanta LY2R, Quanta LB9, DNI AG3448P-R   
+  # The following can be an empty value as it doesnt exist in all the models:
+  # FruNumber, PartNumber, CPLDversion, BoardRevision
+  ^\s*$$
+  ^\s*Switch\s*:\s*\d+\s*$$
+  ^\s*$$
+  ^\s*System\s*Description\s*\.+\s*${System_Description}$$
+  ^\s*Machine\s*Type\s*\.+\s*${Machine_Type}$$
+  ^\s*Machine\s*Model\s*\.+\s*${Machine_Model}$$
+  ^\s*Serial\s*Number\s*\.+\s*${Serial_Number}$$
+  ^\s*FRU\s*Number\s*\.+\s*${Fru_Number}$$
+  ^\s*Part\s*Number\s*\.+\s*${Part_Number}$$
+  ^\s*Maintenance\s*Level\s*\.+\s*${Maintenance_Level}$$
+  ^\s*Manufacturer\s*\.+\s*${Manufacturer}$$
+  ^\s*Burned\s*In\s*MAC\s*Address\s*\.+\s*${Burned_In_MAC_Address}$$
+  ^\s*Software\s*Version\s*\.+\s*${Software_Version}$$
+  ^\s*Operating\s*System\s*\.+\s*${Operating_System}$$
+  ^\s*Network\s*Processing\s*Device\s*\.+\s*${Network_Processing_Device}$$
+  ^\s*CPLD\s*version\s*\.+\s*${CPLD_version}$$
+  ^\s*Board\s*Revision\s*\.+\s*${Board_Revision}$$
+  ^\S \S\S -> Continue.Record
+  ^\s*Additional\s*Packages\s*\.+\s*${Additional_Packages}$$
+  ^\s*${Additional_Packages}$$

--- a/templates/index
+++ b/templates/index
@@ -67,6 +67,8 @@ avaya_ers_show_mlt.textfsm, .*, avaya_ers, sh[[ow]] ml[[t]]
 
 avaya_vsp_show_software.textfsm, .*, avaya_vsp, sho[[w]] so[[ftware]]
 
+broadcom_icos_show_version.textfsm, .*, broadcom_icos, sh[[ow]] ver[[sion]]
+
 brocade_fastiron_show_lldp_neighbors_detail.textfsm, .*, brocade_fastiron, sh[[ow]] ll[[dp]] n[[eighbors]] d[[etail]]
 brocade_fastiron_show_running-config_vlan.textfsm, .*, brocade_fastiron, sh[[ow]] ru[[nning-config]] v[[lan]]
 brocade_fastiron_show_interfaces_brief.textfsm, .*, brocade_fastiron, sh[[ow]] in[[terfaces]] b[[rief]]

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version.raw
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version.raw
@@ -1,0 +1,23 @@
+
+Switch: 1
+
+System Description............................. Accton AS4610-54P , 3.2.2.42, Linux 3.6.5, U-Boot 2012.10-gd563f4a (Apr 13 2017 - 12:08:06) - 2012.10.0.5
+Machine Type................................... Accton AS4610-54P
+Machine Model.................................. BCM-56643
+Serial Number.................................. EC1726004357
+Maintenance Level.............................. A
+Manufacturer................................... 0xbc00
+Burned In MAC Address.......................... A8:2B:B5:55:58:01
+Software Version............................... 3.2.2.42
+Operating System............................... Linux 3.6.5
+Network Processing Device...................... BCM56340_A0
+Additional Packages............................ BGP-4
+                                                QOS
+                                                Multicast
+                                                IPv6
+                                                Routing
+                                                Data Center
+                                                OpEN API
+                                                Prototype Open API
+
+

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version.yml
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version.yml
@@ -1,17 +1,17 @@
 ---
 parsed_sample:
-  - system_description: "Accton AS4610-54P , 3.2.2.42, Linux 3.6.5, U-Boot 2012.10-gd563f4a\
+  - description: "Accton AS4610-54P , 3.2.2.42, Linux 3.6.5, U-Boot 2012.10-gd563f4a\
       \ (Apr 13 2017 - 12:08:06) - 2012.10.0.5"
-    machine_type: "Accton AS4610-54P"
-    machine_model: "BCM-56643"
-    serial_number: "EC1726004357"
+    switch_type: "Accton AS4610-54P"
+    switch_model: "BCM-56643"
+    serial: "EC1726004357"
     fru_number: ""
     part_number: ""
     maintenance_level: "A"
     manufacturer: "0xbc00"
-    burned_in_mac_address: "A8:2B:B5:55:58:01"
-    software_version: "3.2.2.42"
-    operating_system: "Linux 3.6.5"
+    mac: "A8:2B:B5:55:58:01"
+    version: "3.2.2.42"
+    os_version: "Linux 3.6.5"
     network_processing_device: "BCM56340_A0"
     cpld_version: ""
     board_revision: ""

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version.yml
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version.yml
@@ -1,0 +1,26 @@
+---
+parsed_sample:
+  - system_description: "Accton AS4610-54P , 3.2.2.42, Linux 3.6.5, U-Boot 2012.10-gd563f4a\
+      \ (Apr 13 2017 - 12:08:06) - 2012.10.0.5"
+    machine_type: "Accton AS4610-54P"
+    machine_model: "BCM-56643"
+    serial_number: "EC1726004357"
+    fru_number: ""
+    part_number: ""
+    maintenance_level: "A"
+    manufacturer: "0xbc00"
+    burned_in_mac_address: "A8:2B:B5:55:58:01"
+    software_version: "3.2.2.42"
+    operating_system: "Linux 3.6.5"
+    network_processing_device: "BCM56340_A0"
+    cpld_version: ""
+    board_revision: ""
+    additional_packages:
+      - "BGP-4"
+      - "QOS"
+      - "Multicast"
+      - "IPv6"
+      - "Routing"
+      - "Data Center"
+      - "OpEN API"
+      - "Prototype Open API"

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version2.raw
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version2.raw
@@ -1,0 +1,23 @@
+
+Switch: 1
+
+System Description............................. Data Center Switch Software AS5610-52X, 48x10Gb, 4x40Gb, 3.2.2.42, Linux 3.8.13-rt9-4143e257, U-Boot 2013.01.01-gb4d916c (Jun 06 2017 - 10:45:46) - 3.0.3.15
+Machine Type................................... Data Center Switch Software AS5610-52X, 48x10Gb, 4x40Gb
+Machine Model.................................. AS5610-52X
+Serial Number.................................. 561052X1727264
+Maintenance Level.............................. A
+Manufacturer................................... 0xbc00
+Burned In MAC Address.......................... A8:2B:B5:57:CC:8D
+Software Version............................... 3.2.2.42
+Operating System............................... Linux 3.8.13-rt9-4143e257
+Network Processing Device...................... BCM56846_A1
+CPLD version................................... 0x2
+Board Revision................................. 0x2
+Additional Packages............................ BGP-4
+                                                QOS
+                                                Multicast
+                                                IPv6
+                                                Routing
+                                                Data Center
+                                                OpEN API
+                                                Prototype Open API

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version2.yml
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version2.yml
@@ -1,0 +1,27 @@
+---
+parsed_sample:
+  - system_description: "Data Center Switch Software AS5610-52X, 48x10Gb, 4x40Gb,\
+      \ 3.2.2.42, Linux 3.8.13-rt9-4143e257, U-Boot 2013.01.01-gb4d916c (Jun 06 2017\
+      \ - 10:45:46) - 3.0.3.15"
+    machine_type: "Data Center Switch Software AS5610-52X, 48x10Gb, 4x40Gb"
+    machine_model: "AS5610-52X"
+    serial_number: "561052X1727264"
+    fru_number: ""
+    part_number: ""
+    maintenance_level: "A"
+    manufacturer: "0xbc00"
+    burned_in_mac_address: "A8:2B:B5:57:CC:8D"
+    software_version: "3.2.2.42"
+    operating_system: "Linux 3.8.13-rt9-4143e257"
+    network_processing_device: "BCM56846_A1"
+    cpld_version: "0x2"
+    board_revision: "0x2"
+    additional_packages:
+      - "BGP-4"
+      - "QOS"
+      - "Multicast"
+      - "IPv6"
+      - "Routing"
+      - "Data Center"
+      - "OpEN API"
+      - "Prototype Open API"

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version2.yml
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version2.yml
@@ -1,18 +1,18 @@
 ---
 parsed_sample:
-  - system_description: "Data Center Switch Software AS5610-52X, 48x10Gb, 4x40Gb,\
-      \ 3.2.2.42, Linux 3.8.13-rt9-4143e257, U-Boot 2013.01.01-gb4d916c (Jun 06 2017\
-      \ - 10:45:46) - 3.0.3.15"
-    machine_type: "Data Center Switch Software AS5610-52X, 48x10Gb, 4x40Gb"
-    machine_model: "AS5610-52X"
-    serial_number: "561052X1727264"
+  - description: "Data Center Switch Software AS5610-52X, 48x10Gb, 4x40Gb, 3.2.2.42,\
+      \ Linux 3.8.13-rt9-4143e257, U-Boot 2013.01.01-gb4d916c (Jun 06 2017 - 10:45:46)\
+      \ - 3.0.3.15"
+    switch_type: "Data Center Switch Software AS5610-52X, 48x10Gb, 4x40Gb"
+    switch_model: "AS5610-52X"
+    serial: "561052X1727264"
     fru_number: ""
     part_number: ""
     maintenance_level: "A"
     manufacturer: "0xbc00"
-    burned_in_mac_address: "A8:2B:B5:57:CC:8D"
-    software_version: "3.2.2.42"
-    operating_system: "Linux 3.8.13-rt9-4143e257"
+    mac: "A8:2B:B5:57:CC:8D"
+    version: "3.2.2.42"
+    os_version: "Linux 3.8.13-rt9-4143e257"
     network_processing_device: "BCM56846_A1"
     cpld_version: "0x2"
     board_revision: "0x2"

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version3.raw
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version3.raw
@@ -1,0 +1,25 @@
+
+Switch: 1
+
+System Description............................. LY2R - 48 TENGIG, Four 40GbE  PORTS, 3.2.2.42, Linux 3.8.13-rt9-4143e257, U-Boot 2010.12 (Feb 10 2015 - 10:01:12) - ONIE 2014.05.03-d
+Machine Type................................... LY2R - 48 TENGIG, Four 40GbE  PORTS
+Machine Model.................................. LY2R
+Serial Number.................................. QTFCEA530009C
+FRU Number..................................... 1LY2BZZ001A
+Maintenance Level.............................. A
+Manufacturer................................... 0xbc00
+Burned In MAC Address.......................... 2C:60:0C:C0:6A:0C
+Software Version............................... 3.2.2.42
+Operating System............................... Linux 3.8.13-rt9-4143e257
+Network Processing Device...................... BCM56846_A1
+CPLD version................................... 0x1
+Additional Packages............................ BGP-4
+                                                QOS
+                                                Multicast
+                                                IPv6
+                                                Routing
+                                                Data Center
+                                                OpEN API
+                                                Prototype Open API
+
+

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version3.yml
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version3.yml
@@ -1,0 +1,26 @@
+---
+parsed_sample:
+  - system_description: "LY2R - 48 TENGIG, Four 40GbE  PORTS, 3.2.2.42, Linux 3.8.13-rt9-4143e257,\
+      \ U-Boot 2010.12 (Feb 10 2015 - 10:01:12) - ONIE 2014.05.03-d"
+    machine_type: "LY2R - 48 TENGIG, Four 40GbE  PORTS"
+    machine_model: "LY2R"
+    serial_number: "QTFCEA530009C"
+    fru_number: "1LY2BZZ001A"
+    part_number: ""
+    maintenance_level: "A"
+    manufacturer: "0xbc00"
+    burned_in_mac_address: "2C:60:0C:C0:6A:0C"
+    software_version: "3.2.2.42"
+    operating_system: "Linux 3.8.13-rt9-4143e257"
+    network_processing_device: "BCM56846_A1"
+    cpld_version: "0x1"
+    board_revision: ""
+    additional_packages:
+      - "BGP-4"
+      - "QOS"
+      - "Multicast"
+      - "IPv6"
+      - "Routing"
+      - "Data Center"
+      - "OpEN API"
+      - "Prototype Open API"

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version3.yml
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version3.yml
@@ -1,17 +1,17 @@
 ---
 parsed_sample:
-  - system_description: "LY2R - 48 TENGIG, Four 40GbE  PORTS, 3.2.2.42, Linux 3.8.13-rt9-4143e257,\
+  - description: "LY2R - 48 TENGIG, Four 40GbE  PORTS, 3.2.2.42, Linux 3.8.13-rt9-4143e257,\
       \ U-Boot 2010.12 (Feb 10 2015 - 10:01:12) - ONIE 2014.05.03-d"
-    machine_type: "LY2R - 48 TENGIG, Four 40GbE  PORTS"
-    machine_model: "LY2R"
-    serial_number: "QTFCEA530009C"
+    switch_type: "LY2R - 48 TENGIG, Four 40GbE  PORTS"
+    switch_model: "LY2R"
+    serial: "QTFCEA530009C"
     fru_number: "1LY2BZZ001A"
     part_number: ""
     maintenance_level: "A"
     manufacturer: "0xbc00"
-    burned_in_mac_address: "2C:60:0C:C0:6A:0C"
-    software_version: "3.2.2.42"
-    operating_system: "Linux 3.8.13-rt9-4143e257"
+    mac: "2C:60:0C:C0:6A:0C"
+    version: "3.2.2.42"
+    os_version: "Linux 3.8.13-rt9-4143e257"
     network_processing_device: "BCM56846_A1"
     cpld_version: "0x1"
     board_revision: ""

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version4.raw
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version4.raw
@@ -1,0 +1,24 @@
+
+Switch: 1
+
+System Description............................. Quanta LB9, 2.3.2.12, Linux 2.6.34.6, U-Boot 1.3.0 (Dec 14 2012 - 10:30:09)
+Machine Type................................... Quanta LB9
+Machine Model.................................. LB9
+Serial Number.................................. QTFCA63150162
+FRU Number..................................... 1LB9BZZ0STK
+Part Number.................................... BCM56538
+Maintenance Level.............................. A
+Manufacturer................................... 0xbc00
+Burned In MAC Address.......................... 08:9E:01:A0:32:FC
+Software Version............................... 2.3.2.12
+Operating System............................... Linux 2.6.34.6
+Network Processing Device...................... BCM56538_B0
+Additional Packages............................ BGP-4
+                                                QOS
+                                                IPv6
+                                                Routing
+                                                Data Center
+                                                OpEN API
+                                                Prototype Open API
+
+

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version4.yml
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version4.yml
@@ -1,17 +1,17 @@
 ---
 parsed_sample:
-  - system_description: "Quanta LB9, 2.3.2.12, Linux 2.6.34.6, U-Boot 1.3.0 (Dec 14\
-      \ 2012 - 10:30:09)"
-    machine_type: "Quanta LB9"
-    machine_model: "LB9"
-    serial_number: "QTFCA63150162"
+  - description: "Quanta LB9, 2.3.2.12, Linux 2.6.34.6, U-Boot 1.3.0 (Dec 14 2012\
+      \ - 10:30:09)"
+    switch_type: "Quanta LB9"
+    switch_model: "LB9"
+    serial: "QTFCA63150162"
     fru_number: "1LB9BZZ0STK"
     part_number: "BCM56538"
     maintenance_level: "A"
     manufacturer: "0xbc00"
-    burned_in_mac_address: "08:9E:01:A0:32:FC"
-    software_version: "2.3.2.12"
-    operating_system: "Linux 2.6.34.6"
+    mac: "08:9E:01:A0:32:FC"
+    version: "2.3.2.12"
+    os_version: "Linux 2.6.34.6"
     network_processing_device: "BCM56538_B0"
     cpld_version: ""
     board_revision: ""

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version4.yml
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version4.yml
@@ -1,0 +1,25 @@
+---
+parsed_sample:
+  - system_description: "Quanta LB9, 2.3.2.12, Linux 2.6.34.6, U-Boot 1.3.0 (Dec 14\
+      \ 2012 - 10:30:09)"
+    machine_type: "Quanta LB9"
+    machine_model: "LB9"
+    serial_number: "QTFCA63150162"
+    fru_number: "1LB9BZZ0STK"
+    part_number: "BCM56538"
+    maintenance_level: "A"
+    manufacturer: "0xbc00"
+    burned_in_mac_address: "08:9E:01:A0:32:FC"
+    software_version: "2.3.2.12"
+    operating_system: "Linux 2.6.34.6"
+    network_processing_device: "BCM56538_B0"
+    cpld_version: ""
+    board_revision: ""
+    additional_packages:
+      - "BGP-4"
+      - "QOS"
+      - "IPv6"
+      - "Routing"
+      - "Data Center"
+      - "OpEN API"
+      - "Prototype Open API"

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version5.raw
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version5.raw
@@ -1,0 +1,25 @@
+
+Switch: 1
+
+System Description............................. DNI-3448P 48x1Gb POE, 2x10G, 2x20G Helix4 L3 System, 3.2.2.42, Linux 3.6.5-c428db7a
+Machine Type................................... DNI-3448P 48x1Gb POE, 2x10G, 2x20G Helix4 L3 System
+Machine Model.................................. BCM-56340
+Serial Number.................................. 3448BCN1603101
+Maintenance Level.............................. A
+Manufacturer................................... 0xbc00
+Burned In MAC Address.......................... 00:30:AB:F2:48:DE
+Software Version............................... 3.2.2.42
+Operating System............................... Linux 3.6.5-c428db7a
+Network Processing Device...................... BCM56340_A0
+CPLD version................................... 0xd
+Board Revision................................. 0x5
+Additional Packages............................ BGP-4
+                                                QOS
+                                                Multicast
+                                                IPv6
+                                                Routing
+                                                Data Center
+                                                OpEN API
+                                                Prototype Open API
+
+

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version5.yml
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version5.yml
@@ -1,0 +1,26 @@
+---
+parsed_sample:
+  - system_description: "DNI-3448P 48x1Gb POE, 2x10G, 2x20G Helix4 L3 System, 3.2.2.42,\
+      \ Linux 3.6.5-c428db7a"
+    machine_type: "DNI-3448P 48x1Gb POE, 2x10G, 2x20G Helix4 L3 System"
+    machine_model: "BCM-56340"
+    serial_number: "3448BCN1603101"
+    fru_number: ""
+    part_number: ""
+    maintenance_level: "A"
+    manufacturer: "0xbc00"
+    burned_in_mac_address: "00:30:AB:F2:48:DE"
+    software_version: "3.2.2.42"
+    operating_system: "Linux 3.6.5-c428db7a"
+    network_processing_device: "BCM56340_A0"
+    cpld_version: "0xd"
+    board_revision: "0x5"
+    additional_packages:
+      - "BGP-4"
+      - "QOS"
+      - "Multicast"
+      - "IPv6"
+      - "Routing"
+      - "Data Center"
+      - "OpEN API"
+      - "Prototype Open API"

--- a/tests/broadcom_icos/show_version/broadcom_icos_show_version5.yml
+++ b/tests/broadcom_icos/show_version/broadcom_icos_show_version5.yml
@@ -1,17 +1,17 @@
 ---
 parsed_sample:
-  - system_description: "DNI-3448P 48x1Gb POE, 2x10G, 2x20G Helix4 L3 System, 3.2.2.42,\
-      \ Linux 3.6.5-c428db7a"
-    machine_type: "DNI-3448P 48x1Gb POE, 2x10G, 2x20G Helix4 L3 System"
-    machine_model: "BCM-56340"
-    serial_number: "3448BCN1603101"
+  - description: "DNI-3448P 48x1Gb POE, 2x10G, 2x20G Helix4 L3 System, 3.2.2.42, Linux\
+      \ 3.6.5-c428db7a"
+    switch_type: "DNI-3448P 48x1Gb POE, 2x10G, 2x20G Helix4 L3 System"
+    switch_model: "BCM-56340"
+    serial: "3448BCN1603101"
     fru_number: ""
     part_number: ""
     maintenance_level: "A"
     manufacturer: "0xbc00"
-    burned_in_mac_address: "00:30:AB:F2:48:DE"
-    software_version: "3.2.2.42"
-    operating_system: "Linux 3.6.5-c428db7a"
+    mac: "00:30:AB:F2:48:DE"
+    version: "3.2.2.42"
+    os_version: "Linux 3.6.5-c428db7a"
     network_processing_device: "BCM56340_A0"
     cpld_version: "0xd"
     board_revision: "0x5"

--- a/tests/test_index_order.py
+++ b/tests/test_index_order.py
@@ -69,6 +69,7 @@ def test_index_ordering():
         "aruba_os",
         "avaya_ers",
         "avaya_vsp",
+        "broadcom_icos",
         "brocade_fastiron",
         "brocade_netiron",
         "brocade_nos",


### PR DESCRIPTION
Added support for broadcom_icos as a new OS and added show_version command

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->

```
template --> broadcom_icos_show_version.textfsm
os --> broadcom_icos
cmd --> show version
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

As discussed in https://github.com/networktocode/ntc-templates/issues/726 support for Broadcom Icos devices is not present current in ntc_templates. This is the first attemp at adding the os all together as well as the 1st command: show version.

Even tho the following models share the same OS(icos), is expected, much like anywhere else, that each hardware model may display different values based on the model the command is ran on. For that i included 5 different outputs from 5 different hardware models in order to be as inclusive with the captures as possible. The models available to me are below and the all run ICOS in a version or another, as described in the show version command itself:

```
1- Accton AS4610-54P
2- Data Center Switch Software AS5610-52X(technically Accton AS5610-52X)
3- Quanta LY2R
4- Quanta LB9
5- DNI-3448P

Potentially i may also be able to get a Quanta LB8 to be even more inclusive
``` 