### PR TITLE
Update index to handle cisco_ios show_ip_bgp_all_summary

### DIFF
--- a/templates/index
+++ b/templates/index
@@ -181,7 +181,7 @@ cisco_ios_show_ip_route_summary.textfsm, .*, cisco_ios, sh[[ow]] ip ro[[ute]] su
 cisco_ios_show_ip_access-lists.textfsm, .*, cisco_ios, sh[[ow]] ip acce[[ss-lists]]
 cisco_ios_show_mpls_interfaces.textfsm, .*, cisco_ios, sh[[ow]] mpls interfa[[ces]]
 cisco_ios_show_power_available.textfsm,  .*, cisco_ios, sh[[ow]] pow[[er]] a[[vailable]]
-cisco_ios_show_ip_bgp_summary.textfsm, .*, cisco_ios, sh[[ow]] ip bgp sum[[mary]]
+cisco_ios_show_ip_bgp_summary.textfsm, .*, cisco_ios, sh[[ow]] ip bgp (?:all\s+)?sum[[mary]]
 cisco_ios_show_ip_prefix-list.textfsm, .*, cisco_ios, sh[[ow]] ip pre[[fix-list]]
 cisco_ios_show_ipv6_neighbors.textfsm, .*, cisco_ios, sh[[ow]] ipv[[6]] ne[[ighbors]]
 cisco_ios_show_isis_neighbors.textfsm, .*, cisco_ios, sh[[ow]] isis ne[[ighbors]]


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
index file updated for cisco_ios show_ip_bgp_summary

##### SUMMARY
Command parser cisco_ios_show_ip_bgp_summary.textfsm can also be used to parse the command: `show ip bgp all summary`

