### PR TITLE
add the ping template for alcatel_sros

### DIFF
--- a/alcatel_sros_ping.textfsm
+++ b/alcatel_sros_ping.textfsm
@@ -1,0 +1,14 @@
+Value SENT_QTY (\d+)
+Value DESTINATION (\d+.\d+.\d+.\d+)
+Value LOSS_PCT (\d+)
+Value SUCCESS_QTY (\d+)
+Value RTT_MIN (\d+)
+Value RTT_AVG (\d+)
+Value RTT_MAX (\d+)
+Value RTT_STDDEV (\d+)
+
+
+Start
+  ^----\s+${DESTINATION}\s+PING\s+Statistics\s+---- 
+  ^${SENT_QTY}\s+\S+\s+\S+\s+${SUCCESS_QTY}\s+\S+\s+\S+\s+${LOSS_PCT}\S+\s+\S+\s+\S+
+  ^\S+\s+\S+\s+\S\s+${RTT_MIN}\S+\s+\S+\s+\S\s+${RTT_AVG}\S+\s+\S+\s+\S\s+${RTT_MAX}\S+\s+\S+\s+\S\s+${RTT_STDDEV}\S+ -> Record

--- a/templates/index
+++ b/templates/index
@@ -13,6 +13,7 @@ Template, Hostname, Platform, Command
 
 alcatel_aos_show_vlan.textfsm, .*, alcatel_aos, show vlan
 
+alcatel_sros_ping.textfsm, .*, alcatel_sros, pi[[ng]]
 alcatel_sros_show_router_bgp_routes_vpn-ipv4.textfsm, .*, alcatel_sros, sh[[ow]] router bgp rou[[tes]] vpn-ipv4
 alcatel_sros_show_service_id_base.textfsm, .*, alcatel_sros, sh[[ow]] serv[[ice]] id ba[[se]]
 alcatel_sros_oam_mac-ping.textfsm, .*, alcatel_sros, oam mac-pi[[ng]]


### PR DESCRIPTION
##### ISSUE TYPE

 - New Template Pull Request

##### COMPONENT
<!--- alcatel_sros_ping.textfsm, alcatel_sros ping  -->

##### SUMMARY
<!--- permit the parsing of the Ping command in an Alcatel SROS. That includes in term of variables :
- The destination
- Packet sents, Packets received, Packet Loss
- RTT Min, Max, Avg & Stddev-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
PING 10.10.10.1 56 data bytes
64 bytes from 10.10.10.1: icmp_seq=1 ttl=61 time=8.56ms.
64 bytes from 10.10.10.1: icmp_seq=2 ttl=61 time=8.56ms.
64 bytes from 10.10.10.1: icmp_seq=3 ttl=61 time=8.56ms.
64 bytes from 10.10.10.1: icmp_seq=4 ttl=61 time=8.60ms.
64 bytes from 10.10.10.1: icmp_seq=5 ttl=61 time=8.56ms.

---- 10.10.10.1 PING Statistics ----
5 packets transmitted, 5 packets received, 0.00% packet loss
round-trip min = 8.56ms, avg = 8.57ms, max = 8.60ms, stddev = 0.017ms
```
