### PR TITLE
adding the ping support in the index

### DIFF
--- a/templates/index
+++ b/templates/index
@@ -16,6 +16,7 @@ alcatel_aos_show_vlan.textfsm, .*, alcatel_aos, show vlan
 alcatel_sros_show_router_bgp_routes_vpn-ipv4.textfsm, .*, alcatel_sros, sh[[ow]] router bgp rou[[tes]] vpn-ipv4
 alcatel_sros_show_service_id_base.textfsm, .*, alcatel_sros, sh[[ow]] serv[[ice]] id ba[[se]]
 alcatel_sros_oam_mac-ping.textfsm, .*, alcatel_sros, oam mac-pi[[ng]]
+alcatel_sros_ping.textfsm, .*, pi[[ng]]
 
 arista_eos_show_mac_security_participants_detail.textfsm, .*, arista_eos, sh[[ow]] ma[[c]] secu[[rity]] part[[icipants]] det[[ail]]
 arista_eos_show_interfaces_transceiver_detail.textfsm, .*, arista_eos, sh[[ow]] inte[[rfaces]] tr[[ansceiver]] de[[tail]]


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
alcatel_sros_ping.textfsm
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
permit the parsing of a ping command and get the values below : 
 -DESTINATION
 - numbers of packet sent, packet received and the ratio of packet losses
 - RTT min/max/avg and sttdev
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
PING 10.10.10.1 56 data bytes
64 bytes from 10.10.10.1: icmp_seq=1 ttl=61 time=8.56ms.
64 bytes from 10.10.10.1: icmp_seq=2 ttl=61 time=8.56ms.
64 bytes from 10.10.10.1: icmp_seq=3 ttl=61 time=8.56ms.
64 bytes from 10.10.10.1: icmp_seq=4 ttl=61 time=8.60ms.
64 bytes from 10.10.10.1: icmp_seq=5 ttl=61 time=8.56ms.

---- 10.10.10.1 PING Statistics ----
5 packets transmitted, 5 packets received, 0.00% packet loss
round-trip min = 8.56ms, avg = 8.57ms, max = 8.60ms, stddev = 0.017ms
```
