### PR TITLE
Support 'Fabric Extender Transceiver' type for show interface status

### DIFF
--- a/templates/cisco_nxos_show_interface_status.textfsm
+++ b/templates/cisco_nxos_show_interface_status.textfsm
@@ -4,7 +4,7 @@ Value STATUS (\S+)
 Value VLAN (\d+|routed|trunk|--)
 Value DUPLEX (\S+)
 Value SPEED (\S+)
-Value TYPE (\S+|\S+\s+\S+)
+Value TYPE (\S+|\S+\s+\S+|\S+\s+\S+\s+\S+)
 
 Start
   ^${PORT}\s+${NAME}\s+${STATUS}\s+${VLAN}\s+${DUPLEX}\s+${SPEED}\s+${TYPE}\s*$$ -> Record


### PR DESCRIPTION
The template fails for interfaces of type 'Fabric Extender Transceiver' on Cisco Nexus switches.

Example line:
Eth1/39       "FEX151"           connected 1         full    10G     Fabric Extender Transceiver

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
cisco_nxos_show_interface_status

##### SUMMARY
Current template expects either one or two white space-separated words in the TYPE field. To accept 'Fabric Extender Transceiver' I
changed it to also accept three words.

As a comparison: the Cisco IOS 'show interface status' template does not make any assumption on the structure of the TYPE field, but just uses '.*'.

```
Connecting to 10.160.1.22 (Cisco NX-OS)                                                                                                                                                                                                                                                   
SSH connection established to 10.160.1.22:22                                                                                                                                                                                                                                              
Interactive SSH session established                                                                                                                                                                                                                                                       
Connection successful                                                                                                                                                                                                                                                                     
Querying info: done                                                                                                                                                                                                                                                                       
Querying VLANs: found 56 VLANs                                                                                                                                                                                                                                                            
Querying ports: Traceback (most recent call last):                                                                                                                                                                                                                                        
  File "./manage.py", line 21, in <module>                                                                                                                                                                                                                                                
    main()                                                                                                                                                                                                                                                                                
  File "./manage.py", line 17, in main                                                                                                                                                                                                                                                    
    execute_from_command_line(sys.argv)                                                                                                                                                                                                                                                   
  File "/data/dev/venv/lib64/python3.6/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line                                                                                                                                                          
    utility.execute()                                                                                                                                                                                                                                                                     
  File "/data/dev/venv/lib64/python3.6/site-packages/django/core/management/__init__.py", line 395, in execute                                                                                                                                                                            
    self.fetch_command(subcommand).run_from_argv(self.argv)                                                                                                                                                                                                                               
  File "/data/dev/venv/lib64/python3.6/site-packages/django/core/management/base.py", line 328, in run_from_argv                                                                                                                                                                          
    self.execute(*args, **cmd_options)                                                                                                                                                                                                                                                    
  File "/data/dev/venv/lib64/python3.6/site-packages/django/core/management/base.py", line 369, in execute                                                                                                                                                                                
    output = self.handle(*args, **options)                                                                                                                                                                                                                                                
  File "/data/dev/app/nslab/switchdb/management/commands/addswitch.py", line 29, in handle                                                                                                                                                                                                
    switch_ports = self.query_ports()                                                                                                                                                                                                                                                     
  File "/data/dev/app/nslab/switchdb/support/polling.py", line 281, in query_ports                                                                                                                                                                                                        
    switch_ports = self._fetch_cmd('sh int status')                                                                                                                                                                                                                                       
  File "/data/dev/app/nslab/switchdb/support/polling.py", line 19, in new_f                                                                                                                                                                                                               
    return f(self, *args, **kwargs)                                                                                                                                                                                                                                                       
  File "/data/dev/app/nslab/switchdb/support/polling.py", line 235, in _fetch_cmd                                                                                                                                                                                                         
    return self.switch_conn.send_command(cmd, use_textfsm=True)                                                                                                                                                                                                                           
  File "/data/dev/venv/lib64/python3.6/site-packages/netmiko/utilities.py", line 347, in wrapper_decorator                                                                                                                                                                                
    return func(self, *args, **kwargs)                                                                                                                                                                                                                                                    
  File "/data/dev/venv/lib64/python3.6/site-packages/netmiko/base_connection.py", line 1448, in send_command                                                                                                                                                                              
    template=textfsm_template,                                                                                                                                                                                                                                                            
  File "/data/dev/venv/lib64/python3.6/site-packages/netmiko/utilities.py", line 280, in get_structured_data                                                                                                                                                                              
    return _textfsm_parse(textfsm_obj, raw_output, attrs)                                                                                                                                                                                                                                 
  File "/data/dev/venv/lib64/python3.6/site-packages/netmiko/utilities.py", line 252, in _textfsm_parse                                                                                                                                                                                   
    textfsm_obj.ParseCmd(raw_output, attrs)                                                                                                                                                                                                                                               
  File "/data/dev/venv/lib64/python3.6/site-packages/netmiko/_textfsm/_clitable.py", line 272, in ParseCmd                                                                                                                                                                                
    self.table = self._ParseCmdItem(self.raw, template_file=template_files[0])                                                                                                                                                                                                            
  File "/data/dev/venv/lib64/python3.6/site-packages/netmiko/_textfsm/_clitable.py", line 303, in _ParseCmdItem                                                                                                                                                                           
    for record in fsm.ParseText(cmd_input):                                                                                                                                                                                                                                               
  File "/data/dev/venv/lib64/python3.6/site-packages/textfsm/parser.py", line 895, in ParseText                                                                                                                                                                                           
    self._CheckLine(line)                                                                                                                                                                                                                                                                 
  File "/data/dev/venv/lib64/python3.6/site-packages/textfsm/parser.py", line 944, in _CheckLine                                                                                                                                                                                          
    if self._Operations(rule, line):                                                                                                                                                                                                                                                      
  File "/data/dev/venv/lib64/python3.6/site-packages/textfsm/parser.py", line 1025, in _Operations                                                                                                                                                                                        
    % (rule.line_num, line))                                                                                                                                                                                                                                                              
textfsm.parser.TextFSMError: State Error raised. Rule Line: 14. Input Line: Eth1/39       "FEX151"           connected 1         full    10G     Fabric Extender Transceiver                         
```
```
Connecting to 10.160.1.22 (Cisco NX-OS)
SSH connection established to 10.160.1.22:22
Interactive SSH session established
Connection successful
Querying info: done
Querying VLANs: found 56 VLANs
Querying ports: found 275 ports
Added new switch 'zfr11f-bx2_backup'
```