### PR TITLE
Detect hostname on NX-OS platforms

### DIFF
--- a/templates/cisco_nxos_show_version.textfsm
+++ b/templates/cisco_nxos_show_version.textfsm
@@ -3,6 +3,7 @@ Value LAST_REBOOT_REASON (.+)
 Value OS (\d+.\d+(.+)?)
 Value BOOT_IMAGE (.*)
 Value PLATFORM (\w+)
+Value HOSTNAME (.*)
 
 Start
   ^\s+(NXOS: version|system:\s+version)\s+${OS}\s*$$
@@ -11,6 +12,7 @@ Start
   ^\s+cisco\s+Nexus\d+\s+${PLATFORM}
   # Cisco N5K platform
   ^\s+cisco\s+Nexus\s+${PLATFORM}\s+[cC]hassis
+  ^\s+Device\s+name:\s+${HOSTNAME}$$
   ^\s+cisco\s+.+-${PLATFORM}\s*
   ^Kernel\s+uptime\s+is\s+${UPTIME}
   ^\s+Reason:\s${LAST_REBOOT_REASON} -> Record

--- a/tests/cisco_nxos/show_version/cisco_nxos_show_version.yml
+++ b/tests/cisco_nxos/show_version/cisco_nxos_show_version.yml
@@ -1,7 +1,8 @@
 ---
 parsed_sample:
-  - boot_image: "bootflash:///n9000-dk9.6.1.2.I3.1.bin"
+  - uptime: "123 day(s), 5 hour(s), 15 minute(s), 19 second(s)"
     last_reboot_reason: "Unknown"
     os: "6.1(2)I3(1)"
+    boot_image: "bootflash:///n9000-dk9.6.1.2.I3.1.bin"
     platform: "C9396PX"
-    uptime: "123 day(s), 5 hour(s), 15 minute(s), 19 second(s)"
+    hostname: "N9K1"

--- a/tests/cisco_nxos/show_version/cisco_nxos_show_version1.yml
+++ b/tests/cisco_nxos/show_version/cisco_nxos_show_version1.yml
@@ -1,7 +1,8 @@
 ---
 parsed_sample:
-  - boot_image: "/bootflash/aci-n9000-dk9.14.0.1h.bin"
+  - uptime: "11 day(s), 01 hour(s), 57 minute(s), 02 second(s)"
     last_reboot_reason: "unknown"
     os: "14.0(1h) [build 14.0(1h)]"
+    boot_image: "/bootflash/aci-n9000-dk9.14.0.1h.bin"
     platform: "C9396PX"
-    uptime: "11 day(s), 01 hour(s), 57 minute(s), 02 second(s)"
+    hostname: "Leaf-101"

--- a/tests/cisco_nxos/show_version/cisco_nxos_show_version2.yml
+++ b/tests/cisco_nxos/show_version/cisco_nxos_show_version2.yml
@@ -5,3 +5,4 @@ parsed_sample:
     os: "7.1(4)N1(1)"
     boot_image: "bootflash:///n5000-uk9-kickstart.7.1.4.N1.1.bin"
     platform: "5596"
+    hostname: "IEDP02-N5K-SW01"


### PR DESCRIPTION
##### ISSUE TYPE
 - Template enhancements

##### COMPONENT
Cisco NX-OS: show version (cisco_nxos_show_version.textfsm)

##### SUMMARY
Added detection of hostname for show version on NX-OS platform, similar to what's already available for Cisco IOS