### PR TITLE
Bugfix: Re-formatted development_scripts.py and tests/test_testcases_…

### DIFF
--- a/development_scripts.py
+++ b/development_scripts.py
@@ -289,7 +289,7 @@ def transform_file(filepath):
     Example:
         >>> filepath = "tests/cisco_ios/show_version/cisco_ios_show_version.yml"
         >>> transform_parsed(filepath)
-        >>> 
+        >>>
     """
     with open(filepath, encoding="utf-8") as parsed_file:
         parsed_object = YAML_OBJECT.load(parsed_file)
@@ -315,7 +315,7 @@ def transform_glob(dirpath):
         >>> dirpath = "tests/*/*"
         >>> transform_parsed(dirpath)
         # Each filename is printed to the terminal
-        >>> 
+        >>>
     """
     # This commented out code was used for mass renaming of files;
     # it is probably not needed anymore
@@ -375,7 +375,7 @@ def parse_test_filepath(filepath):
         show version
         >>> print(filename)
         cisco_ios_show_version
-        >>> 
+        >>>
     """
     command_dir, filename = os.path.split(filepath)
     platform_dir, command = os.path.split(command_dir)
@@ -412,7 +412,7 @@ def build_parsed_data_from_output(filepath, test_dir=TEST_DIR):
         >>> build_parsed_data_from_output(filepath)
         >>> os.listdir(root_dir)
         ['cisco_ios_show_version.raw', 'cisco_ios_show_version.yml']
-        >>> 
+        >>>
     """
     platform, command, filename = parse_test_filepath(filepath)
     with open(filepath, encoding="utf-8") as output_file:
@@ -445,7 +445,7 @@ def build_parsed_data_from_dir(dirpath, test_dir=TEST_DIR):
         >>> dirpath = "tests/cisco_ios/show_mac-address-table"
         >>> build_parsed_data_from_dir(dirpath)
         # Each filename is printed to the terminal
-        >>> 
+        >>>
     """
     for file in glob.iglob("{0}/*.raw".format(dirpath)):
         print(file)

--- a/tests/test_testcases_exists.py
+++ b/tests/test_testcases_exists.py
@@ -11,8 +11,7 @@ TEST_DIRECTORIES = os.listdir("tests")
 
 
 def extract_index_data():
-    """Used to parametrize and report each test case with the necessary data.
-    """
+    """Used to parametrize and report each test case with the necessary data."""
     index = sorted(load_index_data())
     mock_directories = []
     for row in index:
@@ -36,8 +35,7 @@ def extract_index_data():
 
 @pytest.mark.parametrize("mock_directory", extract_index_data())
 def test_verify_parsed_and_reference_data_exists(mock_directory):
-    """Verify that at least one test exists for all entries in the index file.
-    """
+    """Verify that at least one test exists for all entries in the index file."""
     cases = f"{mock_directory}/*.raw"
     test_list = glob.glob(cases)
     assert len(test_list) != 0, f"Could not find tests for {mock_directory}.textfsm"


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
- tox/black

##### SUMMARY
This is an attempt at fixing issue #794.  

Running tox locally I now get a very strange error shown below but I wanted to see whether the same error occurs on Travis-CI.

```
[sic]
========== FAILURES ==========
___________________________________________________________________________________ test_verify_parsed_and_reference_data_exists[tests/cisco_ftd/show_arp] ___________________________________________________________________________________

mock_directory = 'tests/cisco_ftd/show_arp'

    @pytest.mark.parametrize("mock_directory", extract_index_data())
    def test_verify_parsed_and_reference_data_exists(mock_directory):
        """Verify that at least one test exists for all entries in the index file."""
        cases = f"{mock_directory}/*.raw"
        test_list = glob.glob(cases)
>       assert len(test_list) != 0, f"Could not find tests for {mock_directory}.textfsm"
E       AssertionError: Could not find tests for tests/cisco_ftd/show_arp.textfsm
E       assert 0 != 0
E        +  where 0 = len([])

tests/test_testcases_exists.py:41: AssertionError
========== short test summary info ==========
FAILED tests/test_testcases_exists.py::test_verify_parsed_and_reference_data_exists[tests/cisco_ftd/show_arp] - AssertionError: Could not find tests for tests/cisco_ftd/show_arp.textfsm

```

The output shows that there is no test for ```cisco_ftd/show_arp``` but there is no template for ```cisco_ftp_show_arp```. It appears as if re-formatting the two files introduced some other bug.