### PR TITLE
Change TextFSM Windows failure to a runtime failure (instead of an import failure)

### DIFF
--- a/lib/ntc_templates/parse.py
+++ b/lib/ntc_templates/parse.py
@@ -1,6 +1,5 @@
 """ntc_templates.parse."""
 import os
-from textfsm import clitable
 
 # Due to TextFSM library issues on Windows, it is better to not fail on import
 # Instead fail at runtime (i.e. if method is actually used).

--- a/lib/ntc_templates/parse.py
+++ b/lib/ntc_templates/parse.py
@@ -2,6 +2,15 @@
 import os
 from textfsm import clitable
 
+# Due to TextFSM library issues on Windows, it is better to not fail on import
+# Instead fail at runtime (i.e. if method is actually used).
+try:
+    from textfsm import clitable
+
+    HAS_CLITABLE = True
+except ImportError:
+    HAS_CLITABLE = False
+
 
 def _get_template_dir():
     package_dir = os.path.dirname(__file__)
@@ -27,6 +36,18 @@ def _clitable_to_dict(cli_table):
 
 def parse_output(platform=None, command=None, data=None):
     """Return the structured data based on the output from a network device."""
+
+    if not HAS_CLITABLE:
+        msg = """
+The TextFSM library is not currently supported on Windows. If you are NOT using Windows
+you should be able to 'pip install textfsm' to fix this issue. If you are using Windows
+then you will need to install the patch referenced here:
+
+https://github.com/google/textfsm/pull/82
+
+"""
+        raise ImportError(msg)
+
     template_dir = _get_template_dir()
     cli_table = clitable.CliTable("index", template_dir)
 

--- a/templates/index
+++ b/templates/index
@@ -146,7 +146,7 @@ cisco_asa_show_version.textfsm, .*, cisco_asa, sh[[ow]] ver[[sion]]
 cisco_asa_show_route.textfsm, .*, cisco_asa, sh[[ow]] ro[[ute]]
 cisco_asa_show_xlate.textfsm, .*, cisco_asa, sh[[ow]] x[[late]]
 cisco_asa_show_name.textfsm, .*, cisco_asa, sh[[ow]] nam[[e]]
-cisco_asa_show_arp.textfsm, .*, cisco_asa, sh[[ow]] arp
+cisco_asa_show_arp.textfsm, .*, cisco_(asa|ftd), sh[[ow]] arp
 cisco_asa_show_nat.textfsm, .*, cisco_asa, sh[[ow]] nat
 cisco_asa_ping.textfsm, .*, cisco_(asa|ftd), ping
 cisco_asa_dir.textfsm, .*, cisco_asa, dir

--- a/templates/index
+++ b/templates/index
@@ -146,7 +146,7 @@ cisco_asa_show_version.textfsm, .*, cisco_asa, sh[[ow]] ver[[sion]]
 cisco_asa_show_route.textfsm, .*, cisco_asa, sh[[ow]] ro[[ute]]
 cisco_asa_show_xlate.textfsm, .*, cisco_asa, sh[[ow]] x[[late]]
 cisco_asa_show_name.textfsm, .*, cisco_asa, sh[[ow]] nam[[e]]
-cisco_asa_show_arp.textfsm, .*, cisco_(asa|ftd), sh[[ow]] arp
+cisco_asa_show_arp.textfsm, .*, cisco_asa, sh[[ow]] arp
 cisco_asa_show_nat.textfsm, .*, cisco_asa, sh[[ow]] nat
 cisco_asa_ping.textfsm, .*, cisco_(asa|ftd), ping
 cisco_asa_dir.textfsm, .*, cisco_asa, dir


### PR DESCRIPTION
Also I was getting an unrelated test failure related to there being no tests for `show arp` on the cisco_ftd. 

It looks like these tests were never included with the original PR (and I don't have an FTD) so I just removed the `cisco_ftd` from the `show arp` in the index .

It basically was saying `cisco_ftd` is the same as `cisco_asa` for `show arp`, but then provided no data in the original PR. The other option is to just copy the `cisco_asa` show arp tests over for the FTD (unless someone can get the FTD test data).

Just let me know if you want me to switch over to that (copying the `show arp` ASA data) or I can just straight remove that `index` change. Not sure why tests are working on CI-CD system, but failed for me locally due to the FTD issue.