### PR TITLE
fix unconfigured DHCP issue in cisco_wlc_ssh_show_interface_detailed

### DIFF
--- a/templates/cisco_wlc_ssh_show_interface_detailed_id.textfsm
+++ b/templates/cisco_wlc_ssh_show_interface_detailed_id.textfsm
@@ -3,8 +3,8 @@ Value MAC_ADDRESS (\w+\.\w+\.\w+|\w+\:\w+\:\w+\:\w+\:\w+\:\w+)
 Value IP_ADDRESS (\d+.\d+.\d+.\d+)
 Value IP_NETMASK (\d+.\d+.\d+.\d+)
 Value IP_GATEWAY (\d+.\d+.\d+.\d+)
-Value PRIMARY_DHCP_SERVER (\d+.\d+.\d+.\d+)
-Value SECONDARY_DHCP_SERVER (\d+.\d+.\d+.\d+)
+Value PRIMARY_DHCP_SERVER (\d+.\d+.\d+.\d+|Unconfigured)
+Value SECONDARY_DHCP_SERVER (\d+.\d+.\d+.\d+|Unconfigured)
 
 Start
   ^\s*Interface\s+Name\.+\s+${INTERFACE_NAME}\s*$$

--- a/tests/cisco_wlc_ssh/show_interface_detailed_id/cisco_wlc_ssh_show_interface_detailed_id_2.raw
+++ b/tests/cisco_wlc_ssh/show_interface_detailed_id/cisco_wlc_ssh_show_interface_detailed_id_2.raw
@@ -1,0 +1,35 @@
+
+
+Interface Name................................... my-interface
+MAC Address...................................... c0:12:43:56:78:90
+IP Address....................................... 8.8.8.8
+IP Netmask....................................... 255.255.254.0
+IP Gateway....................................... 8.8.8.1
+External NAT IP State............................ Disabled
+External NAT IP Address.......................... 0.0.0.0
+Link Local IPv6 Address.......................... fe80::c012:4356:7890:5643/64
+STATE ........................................... NONE
+IPv6 Address..................................... ::/128
+STATE ........................................... NONE
+IPv6 Gateway..................................... ::
+IPv6 Gateway Mac Address......................... 00:00:00:00:00:00
+STATE ........................................... NONE
+VLAN............................................. 300
+Quarantine-vlan.................................. 0
+NAS-Identifier................................... none
+Active Physical Port............................. LAG (13)
+Primary Physical Port............................ LAG (13)
+Backup Physical Port............................. Unconfigured
+DHCP Proxy Mode.................................. Global
+Primary DHCP Server.............................. Unconfigured
+Secondary DHCP Server............................ Unconfigured
+DHCP Option 82................................... Disabled
+DHCP Option 82 bridge mode insertion............. Disabled
+DHCP Option 6 Opendns Override................... Disabled
+IPv4 ACL......................................... Unconfigured
+mDNS Profile Name................................ Unconfigured
+AP Manager....................................... No
+Guest Interface.................................. No
+3G VLAN.......................................... Disabled
+L2 Multicast..................................... Enabled
+

--- a/tests/cisco_wlc_ssh/show_interface_detailed_id/cisco_wlc_ssh_show_interface_detailed_id_2.yml
+++ b/tests/cisco_wlc_ssh/show_interface_detailed_id/cisco_wlc_ssh_show_interface_detailed_id_2.yml
@@ -1,0 +1,9 @@
+---
+parsed_sample:
+  - interface_name: "my-interface"
+    mac_address: "c0:12:43:56:78:90"
+    ip_address: "8.8.8.8"
+    ip_netmask: "255.255.254.0"
+    ip_gateway: "8.8.8.1"
+    primary_dhcp_server: "Unconfigured"
+    secondary_dhcp_server: "Unconfigured"


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
cisco_wlc_ssh_show_interface_detailed, cisco_wlc, show interface detailed

##### SUMMARY
Fixes an issue when no DHCP server(s) has been configured on the interface and adds a test case for this situation
```
+Value PRIMARY_DHCP_SERVER (\d+.\d+.\d+.\d+|Unconfigured)
+Value SECONDARY_DHCP_SERVER (\d+.\d+.\d+.\d+|Unconfigured)
```
