### PR TITLE
Bugfix: added 'Autostate exclude' to avoid error

### DIFF
--- a/templates/cisco_ios_show_interfaces_switchport.textfsm
+++ b/templates/cisco_ios_show_interfaces_switchport.textfsm
@@ -27,6 +27,7 @@ Start
   ^\s*Voice\s+VLAN:
   ^\s*Pruning\s+VLANs
   ^\s*Capture\s+(?:Mode|VLANs)
+  ^\s*Autostate\s+mode\s+exclude
   ^\s*Protected
   ^\s*Unknown\s+(unicast|multicast)
   ^\s*Vepa\s+Enabled


### PR DESCRIPTION
IOS (15?) includes an optional 'Autostate exclude' switchport configuration option. Adding this prevents the filter throwing an error when the option is configured on an interface.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
Cisco IOS 'show interfaces switchport'

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The filter does not take into account the possibility of the 'Autostate exclude' option being configured on the switch port.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Before the filter throws an error when 'Autostate exclude' is configured on the interface, after it does not (otherwise no difference in output).
```
