### PR TITLE
Bugfix: URL ACL property in cisco_wlc_ssh_show_interface_detailed

### DIFF
--- a/templates/cisco_wlc_ssh_show_interface_detailed_id.textfsm
+++ b/templates/cisco_wlc_ssh_show_interface_detailed_id.textfsm
@@ -37,5 +37,6 @@ Start
   ^\s*Guest\s+Interface.*$$
   ^\s*3G\s+VLAN.*$$
   ^\s*L2\s+Multicast.*$$
+  ^\s*URL\s+ACL.*$$
   ^\s*$$
   ^. -> Error

--- a/tests/cisco_wlc_ssh/show_interface_detailed_id/cisco_wlc_ssh_show_interface_detailed_id_3.raw
+++ b/tests/cisco_wlc_ssh/show_interface_detailed_id/cisco_wlc_ssh_show_interface_detailed_id_3.raw
@@ -1,0 +1,36 @@
+
+
+Interface Name................................... my-interface
+MAC Address...................................... c0:12:43:56:78:90
+IP Address....................................... 8.8.8.8
+IP Netmask....................................... 255.255.254.0
+IP Gateway....................................... 8.8.8.1
+External NAT IP State............................ Disabled
+External NAT IP Address.......................... 0.0.0.0
+Link Local IPv6 Address.......................... fe80::c012:4356:7890:5643/64
+STATE ........................................... NONE
+IPv6 Address..................................... ::/128
+STATE ........................................... NONE
+IPv6 Gateway..................................... ::
+IPv6 Gateway Mac Address......................... 00:00:00:00:00:00
+STATE ........................................... NONE
+VLAN............................................. 300
+Quarantine-vlan.................................. 0
+NAS-Identifier................................... none
+Active Physical Port............................. LAG (13)
+Primary Physical Port............................ LAG (13)
+Backup Physical Port............................. Unconfigured
+DHCP Proxy Mode.................................. Global
+Primary DHCP Server.............................. Unconfigured
+Secondary DHCP Server............................ Unconfigured
+DHCP Option 82................................... Disabled
+DHCP Option 82 bridge mode insertion............. Disabled
+DHCP Option 6 Opendns Override................... Disabled
+IPv4 ACL......................................... Unconfigured
+URL ACL.......................................... Unconfigured
+mDNS Profile Name................................ Unconfigured
+AP Manager....................................... No
+Guest Interface.................................. No
+3G VLAN.......................................... Disabled
+L2 Multicast..................................... Enabled
+

--- a/tests/cisco_wlc_ssh/show_interface_detailed_id/cisco_wlc_ssh_show_interface_detailed_id_3.yml
+++ b/tests/cisco_wlc_ssh/show_interface_detailed_id/cisco_wlc_ssh_show_interface_detailed_id_3.yml
@@ -1,0 +1,9 @@
+---
+parsed_sample:
+  - interface_name: "my-interface"
+    mac_address: "c0:12:43:56:78:90"
+    ip_address: "8.8.8.8"
+    ip_netmask: "255.255.254.0"
+    ip_gateway: "8.8.8.1"
+    primary_dhcp_server: "Unconfigured"
+    secondary_dhcp_server: "Unconfigured"


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
cisco_wlc_ssh_show_interface_summary, cisco_wlc_ssh, show interface summary

##### SUMMARY
Fixes an issue for some versions of aireos showing a URL ACL property, as part of the output of the `show interface detailed` command. + added a testcase