### PR TITLE
added fortinet get system arp

### DIFF
--- a/templates/fortinet_get_system_arp.textfsm
+++ b/templates/fortinet_get_system_arp.textfsm
@@ -5,4 +5,6 @@ Value INTERFACE (.*)
 
 Start
   ^${ADDRESS}\s+${AGE}\s+${MAC}\s+${INTERFACE} -> Record
-
+  ^Address\s+Age(min)\s+Hardware\s+Addr\s+Interface\s*$$
+  ^\s*
+  ^. -> Error

--- a/templates/fortinet_get_system_arp.textfsm
+++ b/templates/fortinet_get_system_arp.textfsm
@@ -1,0 +1,8 @@
+Value ADDRESS (\d+\.\d+\.\d+\.\d+)
+Value AGE (\d+)
+Value MAC (\S+)
+Value INTERFACE (.*)
+
+Start
+  ^${ADDRESS}\s+${AGE}\s+${MAC}\s+${INTERFACE} -> Record
+

--- a/templates/index
+++ b/templates/index
@@ -376,6 +376,7 @@ dell_powerconnect_show_interfaces_status.textfsm, .*, dell_powerconnect, sh[[ow]
 fortinet_get_router_info_bgp_summary.textfsm, .*, fortinet, g[[et]] r[[outer]] info bg[[p]] su[[mmary]]
 fortinet_get_system_interface.textfsm, .*, fortinet, [[g]]et [[s]]ystem [[i]]nterface
 fortinet_get_system_status.textfsm, .*, fortinet, [[g]]et [[s]]ystem [[s]]tatus
+fortinet_get_system_arp.textfsm, .*, fortinet, [[g]]et [[sy]]stem arp
 
 hp_comware_display_lldp_neighbor-information_verbose.textfsm, .*, hp_comware, di[[splay]] ll[[dp]] n[[eighbor-information]] v[[erbose]]
 hp_comware_display_counters_bound_interface.textfsm, .*, hp_comware, di[[splay]] cou[[nters]] (\S+) i[[nterface]]

--- a/tests/fortinet/get_system_arp/fortinet_get_system_arp.raw
+++ b/tests/fortinet/get_system_arp/fortinet_get_system_arp.raw
@@ -1,0 +1,5 @@
+Address           Age(min)   Hardware Addr      Interface
+192.168.1.4       0          b0:a8:6e:01:61:81 lan
+192.168.1.110     0          3c:9b:d6:66:52:ab lan
+192.168.1.111     0          18:64:72:c9:02:d2 lan
+192.168.1.114     4          40:cb:c0:ce:81:85 lan

--- a/tests/fortinet/get_system_arp/fortinet_get_system_arp.yml
+++ b/tests/fortinet/get_system_arp/fortinet_get_system_arp.yml
@@ -1,0 +1,21 @@
+---
+parsed_sample:
+  - address: "192.168.1.4"
+    age: "0"
+    interface: "lan"
+    mac: "b0:a8:6e:01:61:81"
+
+  - address: "192.168.1.110"
+    age: "0"
+    interface: "lan"
+    mac: "3c:9b:d6:66:52:ab"
+
+  - address: "192.168.1.111"
+    age: "0"
+    interface: "lan"
+    mac: "18:64:72:c9:02:d2"
+
+  - address: "192.168.1.114"
+    age: "4"
+    interface: "lan"
+    mac: "40:cb:c0:ce:81:85"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request


##### COMPONENT
<!--- Name of the template, os and command  -->
 - `fortinet_get_system_arp.textfsm` template for arp table for Fortinet

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added template fortinet_get_system_arp to parse the ARP table output of Fortinet's Fortigate devices.
Tested against a live FGT-60D running v6.0.6.
