### PR TITLE
Add Environment Variable Option for Custom Template Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ $
 >>> 
 ```
 
+### Define Custom Templates Directory
+
+To use a custom templates directory set the environmental variable `NTC_TEMPLATES_DIR`.
+Note: The `templates` directory will automatically be appended to the end of the `NTC_TEMPLATES_DIR`.
+
+To manaully set variable:
+```shell
+export NTC_TEMPLATES_DIR=/path/to/new/location
+```
+
+To set within your program:
+```python
+import os
+os.environ["NTC_TEMPLATES_DIR"] = "/path/to/new/templates/location"
+```
+
 Contributing
 ------------
 

--- a/README.md
+++ b/README.md
@@ -87,17 +87,20 @@ $
 ### Define Custom Templates Directory
 
 To use a custom templates directory set the environmental variable `NTC_TEMPLATES_DIR`.
-Note: The `templates` directory will automatically be appended to the end of the `NTC_TEMPLATES_DIR`.
+
+**Requirements**
+1. `index` file needs to be defined with standard structure. [See](#Index-File)
+2. Each custom template should be defined.
 
 To manaully set variable:
 ```shell
-export NTC_TEMPLATES_DIR=/path/to/new/location
+export NTC_TEMPLATES_DIR=/path/to/new/location/templates
 ```
 
 To set within your program:
 ```python
 import os
-os.environ["NTC_TEMPLATES_DIR"] = "/path/to/new/templates/location"
+os.environ["NTC_TEMPLATES_DIR"] = "/path/to/new/templates/location/templates"
 ```
 
 Contributing

--- a/lib/ntc_templates/parse.py
+++ b/lib/ntc_templates/parse.py
@@ -15,7 +15,7 @@ def _get_template_dir():
     env_dir = os.environ.get("NTC_TEMPLATES_DIR")
     if env_dir is not None:
         template_dir = os.path.join(env_dir, "templates")
-    if template_dir is not None:
+    if template_dir is None:
         package_dir = os.path.dirname(__file__)
         template_dir = os.path.join(package_dir, "templates")
         if not os.path.isdir(template_dir):

--- a/lib/ntc_templates/parse.py
+++ b/lib/ntc_templates/parse.py
@@ -12,10 +12,9 @@ except ImportError:
 
 
 def _get_template_dir():
-    env_dir = os.environ.get("NTC_TEMPLATES_DIR")
-    if env_dir is not None:
-        template_dir = os.path.join(env_dir, "templates")
-    if template_dir is None:
+    if os.environ.get("NTC_TEMPLATES_DIR") is not None:
+        template_dir = os.path.join(os.environ.get("NTC_TEMPLATES_DIR"), "templates")
+    else:
         package_dir = os.path.dirname(__file__)
         template_dir = os.path.join(package_dir, "templates")
         if not os.path.isdir(template_dir):
@@ -23,6 +22,14 @@ def _get_template_dir():
             template_dir = os.path.join(project_dir, "templates")
 
     return template_dir
+
+    # package_dir = os.path.dirname(__file__)
+    # template_dir = os.path.join(package_dir, "templates")
+    # if not os.path.isdir(template_dir):
+    #     project_dir = os.path.dirname(os.path.dirname(os.path.dirname(template_dir)))
+    #     template_dir = os.path.join(project_dir, "templates")
+
+    # return template_dir
 
 
 def _clitable_to_dict(cli_table):

--- a/lib/ntc_templates/parse.py
+++ b/lib/ntc_templates/parse.py
@@ -12,10 +12,8 @@ except ImportError:
 
 
 def _get_template_dir():
-    env_dir = os.environ.get("NTC_TEMPLATES_DIR")
-    if env_dir is not None:
-        template_dir = os.path.join(env_dir, "templates")
-    else:
+    template_dir = os.environ.get("NTC_TEMPLATES_DIR")
+    if template_dir is None:
         package_dir = os.path.dirname(__file__)
         template_dir = os.path.join(package_dir, "templates")
         if not os.path.isdir(template_dir):

--- a/lib/ntc_templates/parse.py
+++ b/lib/ntc_templates/parse.py
@@ -12,8 +12,9 @@ except ImportError:
 
 
 def _get_template_dir():
-    if os.environ.get("NTC_TEMPLATES_DIR") is not None:
-        template_dir = os.path.join(os.environ.get("NTC_TEMPLATES_DIR"), "templates")
+    env_dir = os.environ.get("NTC_TEMPLATES_DIR")
+    if env_dir is not None:
+        template_dir = os.path.join(env_dir, "templates")
     else:
         package_dir = os.path.dirname(__file__)
         template_dir = os.path.join(package_dir, "templates")
@@ -22,14 +23,6 @@ def _get_template_dir():
             template_dir = os.path.join(project_dir, "templates")
 
     return template_dir
-
-    # package_dir = os.path.dirname(__file__)
-    # template_dir = os.path.join(package_dir, "templates")
-    # if not os.path.isdir(template_dir):
-    #     project_dir = os.path.dirname(os.path.dirname(os.path.dirname(template_dir)))
-    #     template_dir = os.path.join(project_dir, "templates")
-
-    # return template_dir
 
 
 def _clitable_to_dict(cli_table):

--- a/lib/ntc_templates/parse.py
+++ b/lib/ntc_templates/parse.py
@@ -12,11 +12,14 @@ except ImportError:
 
 
 def _get_template_dir():
-    package_dir = os.path.dirname(__file__)
-    template_dir = os.path.join(package_dir, "templates")
-    if not os.path.isdir(template_dir):
-        project_dir = os.path.dirname(os.path.dirname(os.path.dirname(template_dir)))
-        template_dir = os.path.join(project_dir, "templates")
+    env_dir = os.environ.get("NTC_TEMPLATE_DIR")
+    template_dir = os.path.join(env_dir, "templates")
+    if template_dir is not None:
+        package_dir = os.path.dirname(__file__)
+        template_dir = os.path.join(package_dir, "templates")
+        if not os.path.isdir(template_dir):
+            project_dir = os.path.dirname(os.path.dirname(os.path.dirname(template_dir)))
+            template_dir = os.path.join(project_dir, "templates")
 
     return template_dir
 

--- a/lib/ntc_templates/parse.py
+++ b/lib/ntc_templates/parse.py
@@ -12,8 +12,9 @@ except ImportError:
 
 
 def _get_template_dir():
-    env_dir = os.environ.get("NTC_TEMPLATE_DIR")
-    template_dir = os.path.join(env_dir, "templates")
+    env_dir = os.environ.get("NTC_TEMPLATES_DIR")
+    if env_dir is not None:
+        template_dir = os.path.join(env_dir, "templates")
     if template_dir is not None:
         package_dir = os.path.dirname(__file__)
         template_dir = os.path.join(package_dir, "templates")


### PR DESCRIPTION
##### ISSUE TYPE
 - Enhancements

##### COMPONENT
core update to `parse` to add ability to set custom template location via environment variable.

##### SUMMARY
Allow for custom templates directory to be specified and used.  This is helpful when you need to develop custom templates and usages within a project directory.

If the environment variable is not defined it reverts to existing logic to load from installed path.  I have tested the change.
