### PR TITLE
Template Change: cisco_ios, show archive

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_archive.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_archive.textfsm
@@ -1,7 +1,7 @@
 Value STATE (\w+\s\w+)
 Value NEXT_FILENAME (\S+)
 Value List FILENAMES (\S+)
-Value Required CURRENT_INDEX (\d+)
+Value CURRENT_INDEX (\d+)
 
 Start
   ^The\s+maximum\s+archive\s+configurations\s+allowed\s+is\s+\d+.

--- a/ntc_templates/templates/cisco_ios_show_archive.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_archive.textfsm
@@ -10,6 +10,7 @@ Start
   ^\s+Archive\s+#\s+Name
   ^\s+${CURRENT_INDEX}\s+${FILENAMES}\s+<-\s+Most\s+Recent
   ^\s+\d+\s+${FILENAMES}
+  ^\s+\d+ -> Record
   ^\sArchive feature ${STATE} -> Record
   # Capture time-stamp if vty line has command time-stamping turned on
   ^Load\s+for\s+

--- a/ntc_templates/templates/cisco_ios_show_archive.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_archive.textfsm
@@ -1,7 +1,17 @@
 Value STATE (\w+\s\w+)
+Value NEXT_FILENAME (\S+)
+Value List FILENAMES (\S+)
+Value Required CURRENT_INDEX (\d+)
 
 Start
+  ^The\s+maximum\s+archive\s+configurations\s+allowed\s+is\s+\d+.
+  ^There\s+(are|is)\s+currently\s+\d+\s+archive\s+configuration(s|)\s+saved.
+  ^The\s+next\s+archive\s+file\s+will\s+be\s+named\s+${NEXT_FILENAME}
+  ^\s+Archive\s+#\s+Name
+  ^\s+${CURRENT_INDEX}\s+${FILENAMES}\s+<-\s+Most\s+Recent
+  ^\s+\d+\s+${FILENAMES}
   ^\sArchive feature ${STATE} -> Record
   # Capture time-stamp if vty line has command time-stamping turned on
   ^Load\s+for\s+
   ^Time\s+source\s+is
+  ^. -> Error

--- a/tests/cisco_ios/show_archive/cisco_ios_show_archive.yml
+++ b/tests/cisco_ios/show_archive/cisco_ios_show_archive.yml
@@ -1,3 +1,6 @@
 ---
 parsed_sample:
   - state: "not enabled"
+    next_filename: ""
+    filenames: []
+    current_index: ""

--- a/tests/cisco_ios/show_archive/cisco_ios_show_archive_filelist.raw
+++ b/tests/cisco_ios/show_archive/cisco_ios_show_archive_filelist.raw
@@ -1,0 +1,18 @@
+The maximum archive configurations allowed is 14.
+There are currently 10 archive configurations saved.
+The next archive file will be named flash:002-rtr-1-Mar-18-20-30-52.969-CDT-10
+ Archive #  Name
+   1        flash:002-rtr-1-Mar-17-07-53-52.484-CDT-0
+   2        flash:002-rtr-1-Mar-17-20-41-40.639-CDT-1
+   3        flash:002-rtr-1-Mar-17-20-46-54.242-CDT-2
+   4        flash:002-rtr-1-Mar-17-20-50-10.784-CDT-3
+   5        flash:002-rtr-1-Mar-17-20-51-44.032-CDT-4
+   6        flash:002-rtr-1-Mar-17-20-53-59.347-CDT-5
+   7        flash:002-rtr-1-Mar-18-09-59-49.072-CDT-6
+   8        flash:002-rtr-1-Mar-18-10-00-02.188-CDT-7
+   9        flash:002-rtr-1-Mar-18-14-16-54.198-CDT-8
+   10       flash:002-rtr-1-Mar-18-16-08-16.319-CDT-9 <- Most Recent
+   11
+   12
+   13
+   14

--- a/tests/cisco_ios/show_archive/cisco_ios_show_archive_filelist.yml
+++ b/tests/cisco_ios/show_archive/cisco_ios_show_archive_filelist.yml
@@ -1,0 +1,16 @@
+---
+parsed_sample:
+  - state: ""
+    next_filename: "flash:002-rtr-1-Mar-18-20-30-52.969-CDT-10"
+    filenames:
+      - "flash:002-rtr-1-Mar-17-07-53-52.484-CDT-0"
+      - "flash:002-rtr-1-Mar-17-20-41-40.639-CDT-1"
+      - "flash:002-rtr-1-Mar-17-20-46-54.242-CDT-2"
+      - "flash:002-rtr-1-Mar-17-20-50-10.784-CDT-3"
+      - "flash:002-rtr-1-Mar-17-20-51-44.032-CDT-4"
+      - "flash:002-rtr-1-Mar-17-20-53-59.347-CDT-5"
+      - "flash:002-rtr-1-Mar-18-09-59-49.072-CDT-6"
+      - "flash:002-rtr-1-Mar-18-10-00-02.188-CDT-7"
+      - "flash:002-rtr-1-Mar-18-14-16-54.198-CDT-8"
+      - "flash:002-rtr-1-Mar-18-16-08-16.319-CDT-9"
+    current_index: "10"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Template Addition Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_archive.textfsm, cisco_ios, show_archive

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added lines to capture filenames and most recent archive if archiving is enabled. Want to capture the index of the most recent to be able to reference which file in flash is startup-config. Relying on the implicit EOF -> Record in the case that the last line also has a filename in it. Otherwise we should record all the data the first empty index we match.
