### PR TITLE
Fixes #903 - Updated cisco_ios_show_interfaces_switchport.textfsm

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_interfaces_switchport.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_interfaces_switchport.textfsm
@@ -21,7 +21,6 @@ Start
   ^\s*Voice\s+VLAN:\s+${VOICE_VLAN}
   ^\s*Trunking\s+VLANs\s+Enabled:\s+${TRUNKING_VLANS},\s*$$ -> Trunk
   ^\s*Trunking\s+VLANs\s+Enabled:\s+${TRUNKING_VLANS}$$
-  ^\s+${TRUNKING_VLANS}$$
   ^\s*Administrative\s+Mode:\s+${ADMIN_MODE}$$
   ^\s*(?:Operational|Administrative)\s+(?:Trunking|Native\s+VLAN|private-vlan)
   ^\s*Voice\s+VLAN:
@@ -40,5 +39,6 @@ Start
   ^. -> Error
 
 Trunk
-  ^\s+${TRUNKING_VLANS},\s*$$ -> Start
-  ^\s+${TRUNKING_VLANS}\s*$$
+  ^\s+${TRUNKING_VLANS},\s*$$
+  ^\s+${TRUNKING_VLANS}\s*$$ -> Start
+  ^. -> Error

--- a/tests/cisco_ios/show_interfaces_switchport/cisco_ios_show_interfaces_switchport2.raw
+++ b/tests/cisco_ios/show_interfaces_switchport/cisco_ios_show_interfaces_switchport2.raw
@@ -29,3 +29,35 @@ Unknown unicast blocked: disabled
 Unknown multicast blocked: disabled
 Vepa Enabled: false
 Appliance trust: none
+
+Name: Te5/0/2
+Switchport: Enabled
+Administrative Mode: trunk
+Operational Mode: trunk
+Administrative Trunking Encapsulation: dot1q
+Operational Trunking Encapsulation: dot1q
+Negotiation of Trunking: Off
+Access Mode VLAN: 1 (default)
+Trunking Native Mode VLAN: 1 (default)
+Administrative Native VLAN tagging: disabled
+Voice VLAN: none
+Administrative private-vlan host-association: none 
+Administrative private-vlan mapping: none 
+Administrative private-vlan trunk native VLAN: none
+Administrative private-vlan trunk Native VLAN tagging: enabled
+Administrative private-vlan trunk encapsulation: dot1q
+Administrative private-vlan trunk normal VLANs: none
+Administrative private-vlan trunk associations: none
+Administrative private-vlan trunk mappings: none
+Operational private-vlan: none
+Trunking VLANs Enabled: 1,12,15,31-36,40-42,80,85,101,201,240,410,420,602,604,
+     900,910,920,930,940
+Pruning VLANs Enabled: 2-1001
+Capture Mode Disabled
+Capture VLANs Allowed: ALL
+
+Protected: false
+Unknown unicast blocked: disabled
+Unknown multicast blocked: disabled
+Vepa Enabled: false
+Appliance trust: none

--- a/tests/cisco_ios/show_interfaces_switchport/cisco_ios_show_interfaces_switchport2.yml
+++ b/tests/cisco_ios/show_interfaces_switchport/cisco_ios_show_interfaces_switchport2.yml
@@ -12,3 +12,15 @@ parsed_sample:
     trunking_vlans:
       - "1,12,15,31-36,40-42,80,85,101,201,240,410,420,602,604"
       - "900,910,920,930,940"
+  - interface: "Te5/0/2"
+    switchport: "Enabled"
+    switchport_monitor: ""
+    switchport_negotiation: "Off"
+    mode: "trunk"
+    admin_mode: "trunk"
+    access_vlan: "1"
+    native_vlan: "1"
+    voice_vlan: "none"
+    trunking_vlans:
+      - "1,12,15,31-36,40-42,80,85,101,201,240,410,420,602,604"
+      - "900,910,920,930,940"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_interfaces_switchport.textfsm

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Modified Trunk state in template to address issue described in #903. Updated corresponding raw and yml files. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
[{'interface': 'Te5/0/1',
  'switchport': 'Enabled',
  'switchport_monitor': '',
  'switchport_negotiation': 'Off',
  'mode': 'trunk',
  'admin_mode': 'trunk',
  'access_vlan': '1',
  'native_vlan': '1',
  'voice_vlan': 'none',
  'trunking_vlans': ['1,12,15,31-36,40-42,80,85,101,201,240,410,420,602,604',
   '900,910,920,930,940',
   '900,910,920,930,940']}]
```
After:
```
[{'interface': 'Te5/0/1',
  'switchport': 'Enabled',
  'switchport_monitor': '',
  'switchport_negotiation': 'Off',
  'mode': 'trunk',
  'admin_mode': 'trunk',
  'access_vlan': '1',
  'native_vlan': '1',
  'voice_vlan': 'none',
  'trunking_vlans': ['1,12,15,31-36,40-42,80,85,101,201,240,410,420,602,604',
   '900,910,920,930,940']},
 {'interface': 'Te5/0/2',
  'switchport': 'Enabled',
  'switchport_monitor': '',
  'switchport_negotiation': 'Off',
  'mode': 'trunk',
  'admin_mode': 'trunk',
  'access_vlan': '1',
  'native_vlan': '1',
  'voice_vlan': 'none',
  'trunking_vlans': ['1,12,15,31-36,40-42,80,85,101,201,240,410,420,602,604',
   '900,910,920,930,940']}]
```