### PR TITLE
add monitoring status to cisco_ios_show_interfaces_status

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_interfaces_status.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_interfaces_status.textfsm
@@ -1,6 +1,6 @@
 Value PORT (\S+)
 Value NAME (.+?)
-Value STATUS (err-disabled|disabled|connected|notconnect|inactive|up|down)
+Value STATUS (err-disabled|disabled|connected|notconnect|inactive|up|down|monitoring)
 Value VLAN (\S+)
 Value DUPLEX (\S+)
 Value SPEED (\S+)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
cisco ios show interfaces status

##### SUMMARY
The file for cisco ios `show interfaces status` is missing the `monitoring` status. This PR adds it.