### PR TITLE
Cisco IOS uptime parsing

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_version.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_version.textfsm
@@ -2,6 +2,11 @@ Value VERSION (.+?)
 Value ROMMON (\S+)
 Value HOSTNAME (\S+)
 Value UPTIME (.+)
+Value UPTIME_YEARS (\d+)
+Value UPTIME_WEEKS (\d+)
+Value UPTIME_DAYS (\d+)
+Value UPTIME_HOURS (\d+)
+Value UPTIME_MINUTES (\d+)
 Value RELOAD_REASON (.+?)
 Value RUNNING_IMAGE (\S+)
 Value List HARDWARE (\S+|\S+\d\S+)
@@ -13,7 +18,12 @@ Value RESTARTED (.+)
 Start
   ^.*Software\s.+\),\sVersion\s${VERSION},*\s+RELEASE.*
   ^ROM:\s+${ROMMON}
-  ^\s*${HOSTNAME}\s+uptime\s+is\s+${UPTIME}
+  ^\s*${HOSTNAME}\s+uptime\s+is\s+${UPTIME} -> Continue
+  ^.*\s+uptime\s+is.*\s+${UPTIME_YEARS}\syear -> Continue
+  ^.*\s+uptime\s+is.*\s+${UPTIME_WEEKS}\sweek -> Continue
+  ^.*\s+uptime\s+is.*\s+${UPTIME_DAYS}\sday -> Continue
+  ^.*\s+uptime\s+is.*\s+${UPTIME_HOURS}\shour -> Continue
+  ^.*\s+uptime\s+is.*\s+${UPTIME_MINUTES}\sminute
   ^[sS]ystem\s+image\s+file\s+is\s+"(.*?):${RUNNING_IMAGE}"
   ^(?:[lL]ast\s+reload\s+reason:|System\s+returned\s+to\s+ROM\s+by)\s+${RELOAD_REASON}\s*$$
   ^[Pp]rocessor\s+board\s+ID\s+${SERIAL}

--- a/tests/cisco_ios/show_version/cisco_ios_show_version.yml
+++ b/tests/cisco_ios/show_version/cisco_ios_show_version.yml
@@ -4,6 +4,11 @@ parsed_sample:
     rommon: "12.2(44r)SG9"
     hostname: "router1"
     uptime: "2 years, 31 weeks, 6 days, 9 hours, 55 minutes"
+    uptime_days: "6"
+    uptime_hours: "9"
+    uptime_minutes: "55"
+    uptime_weeks: "31"
+    uptime_years: "2"
     reload_reason: "reload"
     running_image: "cat4500e-entservicesk9-mz.122-54.SG1.bin"
     hardware:

--- a/tests/cisco_ios/show_version/cisco_ios_show_version1.yml
+++ b/tests/cisco_ios/show_version/cisco_ios_show_version1.yml
@@ -4,6 +4,11 @@ parsed_sample:
     rommon: "IOS-XE"
     hostname: "city-building-4-sw"
     uptime: "28 weeks, 1 day, 7 hours, 54 minutes"
+    uptime_days: "1"
+    uptime_hours: "7"
+    uptime_minutes: "54"
+    uptime_weeks: "28"
+    uptime_years: ""
     reload_reason: "Reload Command"
     running_image: "packages.conf"
     hardware:

--- a/tests/cisco_ios/show_version/cisco_ios_show_version2.yml
+++ b/tests/cisco_ios/show_version/cisco_ios_show_version2.yml
@@ -4,6 +4,11 @@ parsed_sample:
     rommon: "IOS-XE"
     hostname: "my_device"
     uptime: "1 day, 15 hours, 32 minutes"
+    uptime_days: "1"
+    uptime_hours: "15"
+    uptime_minutes: "32"
+    uptime_weeks: ""
+    uptime_years: ""
     reload_reason: "LocalSoft"
     running_image: "asr1001-universalk9.03.09.01.S.153-2.S1.bin"
     hardware:

--- a/tests/cisco_ios/show_version/cisco_ios_show_version3.yml
+++ b/tests/cisco_ios/show_version/cisco_ios_show_version3.yml
@@ -4,6 +4,11 @@ parsed_sample:
     rommon: "Bootstrap"
     hostname: "rtr-01"
     uptime: "1 week, 3 days, 16 hours, 11 minutes"
+    uptime_days: "3"
+    uptime_hours: "16"
+    uptime_minutes: "11"
+    uptime_weeks: "1"
+    uptime_years: ""
     reload_reason: "Unknown reason"
     running_image: "/vios-adventerprisek9-m"
     hardware:

--- a/tests/cisco_ios/show_version/cisco_ios_show_version4.yml
+++ b/tests/cisco_ios/show_version/cisco_ios_show_version4.yml
@@ -4,6 +4,11 @@ parsed_sample:
     rommon: "IOS-XE"
     hostname: "AKBTESTW01"
     uptime: "1 year, 22 weeks, 6 days, 9 hours, 38 minutes"
+    uptime_days: "6"
+    uptime_hours: "9"
+    uptime_minutes: "38"
+    uptime_weeks: "22"
+    uptime_years: "1"
     reload_reason: "Reload Command"
     running_image: "packages.conf"
     hardware:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = py36,py37,py38,black,flake8,yamllint
+envlist = py36,py37,py38,py39,black,flake8,yamllint
 skip_missing_interpreters = true
 download = true
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Template Change

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_version, cisco_ios, show version

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds additional value parsing for individual uptime items (days, weeks, hours, etc.)

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
    uptime: "2 years, 31 weeks, 6 days, 9 hours, 55 minutes"
```

After:
```
    uptime: "2 years, 31 weeks, 6 days, 9 hours, 55 minutes"
    uptime_days: "6"
    uptime_hours: "9"
    uptime_minutes: "55"
    uptime_weeks: "31"
    uptime_years: "2"
```
