### PR TITLE
Fix nxos_show_interface_transceiver failure (#952)

### DIFF
--- a/ntc_templates/templates/cisco_nxos_show_interface_transceiver.textfsm
+++ b/ntc_templates/templates/cisco_nxos_show_interface_transceiver.textfsm
@@ -17,5 +17,7 @@ Start
   ^\s+Link\s+
   ^\s+cisco\s+id
   ^\s+cisco\s+extended
+  ^\s+cisco\s+part\s+number
+  ^\s+cisco\s+product\s+id
   ^\s*$$ -> Record
   ^. -> Error

--- a/tests/cisco_nxos/show_interface_transceiver/cisco_nxos_show_interface_transceiver.raw
+++ b/tests/cisco_nxos/show_interface_transceiver/cisco_nxos_show_interface_transceiver.raw
@@ -84,3 +84,19 @@ Ethernet1/47
     Link length supported for SMF fiber is 10 km
     cisco id is --
     cisco extended id number is 196
+
+Ethernet1/48
+    transceiver is present
+    type is 10Gbase-SR
+    name is CISCO-OEM
+    part number is SFP-10GB-SR
+    revision is B4
+    serial number is GTWG0000
+    nominal bitrate is 10300 MBit/sec
+    Link length supported for 50/125um OM2 fiber is 82 m
+    Link length supported for 62.5/125um fiber is 26 m
+    Link length supported for 50/125um OM3 fiber is 300 m
+    cisco id is 3
+    cisco extended id number is 4
+    cisco part number is 10-2415-01
+    cisco product id is SFP-10G-SR

--- a/tests/cisco_nxos/show_interface_transceiver/cisco_nxos_show_interface_transceiver.yml
+++ b/tests/cisco_nxos/show_interface_transceiver/cisco_nxos_show_interface_transceiver.yml
@@ -30,3 +30,8 @@ parsed_sample:
     manufacturer: "Arista"
     part_number: "QSFP-40G-LR4-AR"
     serial: "AROOGAH"
+  - interface: "Ethernet1/48"
+    type: "10Gbase-SR"
+    manufacturer: "CISCO-OEM"
+    part_number: "SFP-10GB-SR"
+    serial: "GTWG0000"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_nxos_show_interface_transceiver
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Update the cisco_nxos_show_interface_transceiver template to account for the following lines:
```
cisco part number is 10-2415-01
cisco product id is SFP-10G-SR
```

<!-- Paste verbatim command output below, e.g. before and after your change -->
Output:
```
Ethernet1/48
    transceiver is present
    type is 10Gbase-SR
    name is CISCO-OEM
    part number is SFP-10GB-SR
    revision is B4
    serial number is GTWG0000
    nominal bitrate is 10300 MBit/sec
    Link length supported for 50/125um OM2 fiber is 82 m
    Link length supported for 62.5/125um fiber is 26 m
    Link length supported for 50/125um OM3 fiber is 300 m
    cisco id is 3
    cisco extended id number is 4
    cisco part number is 10-2415-01
    cisco product id is SFP-10G-SR
```

Before:
```
TextFSMError: State Error raised. Rule Line: 21. Input Line:     cisco part number is 10-2415-01
```

After:
```
[{'interface': 'Ethernet1/48',
  'manufacturer': 'CISCO-OEM',
  'type': '10Gbase-SR',
  'serial': 'GTWG9412',
  'part_number': 'SFP-10GB-SR'}]
```
