### PR TITLE
fix parsing with int addresses = 0

### DIFF
--- a/templates/cisco_nxos_show_cdp_neighbors_detail.textfsm
+++ b/templates/cisco_nxos_show_cdp_neighbors_detail.textfsm
@@ -1,0 +1,28 @@
+Value Required DEST_HOST (.*)
+Value SYSNAME (.*)
+Value MGMT_IP (.*)
+Value PLATFORM (.*)
+Value REMOTE_PORT (.*)
+Value LOCAL_PORT (.*)
+Value VERSION (.*)
+Value INTERFACE_IP (.*)
+Value CAPABILITIES (.*[^\s])
+
+Start
+  ^Device ID:${DEST_HOST}
+  ^System Name: ${SYSNAME}
+  ^Interface address\(es\): ^[1-9]\d* -> GetInterfaceIP
+  ^Mgmt address\(es\): -> GetIP
+  ^Platform: ${PLATFORM}, Capabilities: ${CAPABILITIES}\s*$$
+  ^Interface: ${LOCAL_PORT}, Port ID \(outgoing port\): ${REMOTE_PORT}
+  ^Version: -> GetVersion
+  ^----- -> Record
+
+GetIP
+  ^.*IP.+Address: ${MGMT_IP} -> Start
+
+GetInterfaceIP
+  ^.*IP.+Address: ${INTERFACE_IP} -> Start
+
+GetVersion
+  ^${VERSION} -> Start

--- a/tests/cisco_nxos/show_cdp_neighbors_detail/cisco_nxos_show_cdp_neighbors_detail2.parsed
+++ b/tests/cisco_nxos/show_cdp_neighbors_detail/cisco_nxos_show_cdp_neighbors_detail2.parsed
@@ -1,0 +1,12 @@
+---
+parsed_sample:
+
+-   dest_host: MKT1
+    local_port: Ethernet1/1
+    mgmt_ip:''
+    platform: MikroTik
+    remote_port: ether1
+    sysname: ''
+    version: 6.47.10 (long-term)
+    interface_ip: ''
+    capabilities: Router

--- a/tests/cisco_nxos/show_cdp_neighbors_detail/cisco_nxos_show_cdp_neighbors_detail2.raw
+++ b/tests/cisco_nxos/show_cdp_neighbors_detail/cisco_nxos_show_cdp_neighbors_detail2.raw
@@ -1,0 +1,14 @@
+----------------------------------------
+Device ID:MKT1
+
+Interface address(es): 0
+Platform: MikroTik, Capabilities: Router
+Interface: Ethernet1/1, Port ID (outgoing port): ether1
+Holdtime: 61 sec
+
+Version:
+6.47.10 (long-term)
+
+Advertisement Version: 1
+Local Interface MAC: b1:81:d1:d1:a1:11
+Remote Interface MAC: 00:00:00:00:00:00


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
cisco_nxos_show_cdp_neighbors_detail.textfsm

##### SUMMARY
If the output includes:

Interface address(es): 0

The parser fails.
The PR add verify non zero values:

^Interface address\(es\): ^[1-9]\d* -> GetInterfaceIP