### PR TITLE
Fixed parsing error

### DIFF
--- a/ntc_templates/templates/arista_eos_show_lldp_neighbors.textfsm
+++ b/ntc_templates/templates/arista_eos_show_lldp_neighbors.textfsm
@@ -6,5 +6,6 @@ Start
   ^Port.*TTL -> LLDP
 
 LLDP
+  ^-+ -> NoRecord
   ^${LOCAL_INTERFACE}\s+${NEIGHBOR}\s+${NEIGHBOR_INTERFACE}\s+.* -> Record
 

--- a/tests/arista_eos/show_lldp_neighbors/arista_eos_show_lldp_neighbors_header_line.parsed
+++ b/tests/arista_eos/show_lldp_neighbors/arista_eos_show_lldp_neighbors_header_line.parsed
@@ -1,0 +1,20 @@
+---
+parsed_sample:
+- neighbor: "localhost"
+  local_interface: "Et1"
+  neighbor_interface: "Ethernet1"
+
+- neighbor: "localhost"
+  local_interface: "Et2"
+  neighbor_interface: "Ethernet2"
+
+- neighbor: "tg104.sjc.aristanetworks.com"
+  local_interface: "Et3/1"
+  neighbor_interface: "Ethernet3/2"
+
+- neighbor: "dc1-rack11-tor1.sjc"
+  local_interface: "Ma1/1"
+  neighbor_interface: "1/1"
+
+
+

--- a/tests/arista_eos/show_lldp_neighbors/arista_eos_show_lldp_neighbors_header_line.raw
+++ b/tests/arista_eos/show_lldp_neighbors/arista_eos_show_lldp_neighbors_header_line.raw
@@ -1,0 +1,12 @@
+Last table change time   : 0:00:02 ago
+Number of table inserts  : 2
+Number of table deletes  : 0
+Number of table drops    : 0
+Number of table age-outs : 0
+
+Port       Neighbor Device ID             Neighbor Port ID           TTL
+---------- ---------------------------------- ---------------------- ---
+Et1        localhost                      Ethernet1                  120
+Et2        localhost                      Ethernet2                  120
+Et3/1      tg104.sjc.aristanetworks.com   Ethernet3/2                120
+Ma1/1      dc1-rack11-tor1.sjc            1/1                        120


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
arista_eos_show_lldp_neighbors.template

##### SUMMARY
Newer versions of Arista code have a table header line break made out of "---", adding logic to not record this in the output.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
[{'neighbor': '----------------------------------', 'local_interface': '----------', 'neighbor_interface': '----------------------'}, {'neighbor': 'localhost', 'local_interface': 'Et1', 'neighbor_interface': 'Ethernet1'}, {'neighbor': 'localhost', 'local_interface': 'Et2', 'neighbor_interface': 'Ethernet2'}, {'neighbor': 'tg104.sjc.aristanetworks.com', 'local_interface': 'Et3/1', 'neighbor_interface': 'Ethernet3/2'}, {'neighbor': 'dc1-rack11-tor1.sjc', 'local_interface': 'Ma1/1', 'neighbor_interface': '1/1'}]

```
[{'neighbor': 'localhost', 'local_interface': 'Et1', 'neighbor_interface': 'Ethernet1'}, {'neighbor': 'localhost', 'local_interface': 'Et2', 'neighbor_interface': 'Ethernet2'}, {'neighbor': 'tg104.sjc.aristanetworks.com', 'local_interface': 'Et3/1', 'neighbor_interface': 'Ethernet3/2'}, {'neighbor': 'dc1-rack11-tor1.sjc', 'local_interface': 'Ma1/1', 'neighbor_interface': '1/1'}]
