### PR TITLE
Prep for release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [3.0.0](https://github.com/networktocode/ntc-templates/tree/3.0.0) (2021-10-28)
+
+[Full Changlog](https://github.com/networktocode/ntc-templates/compare/v2.3.2...3.0.0)
+
+### Breaking Changes
+
+- Template `cisco_ios_show_mac-address-table` has `DESTINATION_PORT` as a list of ports now instead of a single string entry (#994)
+
+### What's Changed
+* cisco_ios_show_access-session: Adding Identity to MAC column by @ahlara-devcore in https://github.com/networktocode/ntc-templates/pull/990
+* [New Template] Ciena - traffic-profile standard-profile  by @georgesnow in https://github.com/networktocode/ntc-templates/pull/981
+* New template: cisco_nxos_show_ip_interface_vrf_all.textfsm by @AJatCDW in https://github.com/networktocode/ntc-templates/pull/978
+* New template: juniper_junos_show_system_uptime.textfsm by @antonalekseev in https://github.com/networktocode/ntc-templates/pull/975
+* Template Change: cisco_ios, show archive by @QuasarKid in https://github.com/networktocode/ntc-templates/pull/905
+* Bugfix: change date format in hp_comware_display_clock.textfsm by @antonalekseev in https://github.com/networktocode/ntc-templates/pull/977
+* update arista interface template + raw by @scetron in https://github.com/networktocode/ntc-templates/pull/963
+* New Template: cisco_ios_show_dhcp_lease by @lamiskin in https://github.com/networktocode/ntc-templates/pull/991
+* Fix ios_mac-addr type2 by @armartirosyan in https://github.com/networktocode/ntc-templates/pull/994
+* fix parsing with int addresses = 0 by @dainok in https://github.com/networktocode/ntc-templates/pull/982
+* New template for huawei VRP + fix. by @ak-empiak in https://github.com/networktocode/ntc-templates/pull/998
+* added VLAN value and search pattern by @dm-bell-networking in https://github.com/networktocode/ntc-templates/pull/1002
+* Ciso IOS show mac and show module fix by @armartirosyan in https://github.com/networktocode/ntc-templates/pull/1006
+* Junos show chassis by @georgesnow in https://github.com/networktocode/ntc-templates/pull/997
+
+### New Contributors
+* @ahlara-devcore made their first contribution in https://github.com/networktocode/ntc-templates/pull/990
+* @AJatCDW made their first contribution in https://github.com/networktocode/ntc-templates/pull/978
+* @antonalekseev made their first contribution in https://github.com/networktocode/ntc-templates/pull/975
+* @lamiskin made their first contribution in https://github.com/networktocode/ntc-templates/pull/991
+* @armartirosyan made their first contribution in https://github.com/networktocode/ntc-templates/pull/994
+* @ak-empiak made their first contribution in https://github.com/networktocode/ntc-templates/pull/998
+* @dm-bell-networking made their first contribution in https://github.com/networktocode/ntc-templates/pull/1002
+
+**Full Changelog**: https://github.com/networktocode/ntc-templates/compare/v2.3.2...v3.0.0
 ## [2.3.2](https://github.com/networktocode/ntc-templates/tree/2.3.2) (2021-09-13)
 
 [Full Changelog](https://github.com/networktocode/ntc-templates/compare/v2.3.1...2.3.2)

--- a/ntc_templates/__init__.py
+++ b/ntc_templates/__init__.py
@@ -1,3 +1,3 @@
 """ntc_templates - Parse raw output from network devices and return structured data."""
 
-__version__ = "2.3.2"
+__version__ = "3.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ntc_templates"
-version = "2.3.2"
+version = "3.0.0"
 description = "TextFSM Templates for Network Devices, and Python wrapper for TextFSM's CliTable."
 authors = ["Network to Code <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Update for new release

##### COMPONENT
<!--- Name of the template, os and command  -->
NTC Templates

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Moved to a version 3.0.0 due to a breaking change with Cisco `show mac-address-table` template change. The resulting value went from a string to a list of strings, which will cause updates to be needed.
