### PR TITLE
Fix#826-2 cisco ios show ip eigrp topology

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_ip_eigrp_topology.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_ip_eigrp_topology.textfsm
@@ -7,6 +7,8 @@ Value SUCCESSORS (\d+)
 Value FD (\d+|Inaccessible)
 Value TAG (\d+)
 Value List ADV_ROUTER (\d+\.\d+\.\d+\.\d+|\w+)
+Value List ADV_FD (\d+)
+Value List ADV_RD (\d+)
 Value List OUT_INTERFACE (\S+)
 Value SOURCE (R\S+)
 
@@ -16,7 +18,7 @@ Start
   # Skips over the code line that explains what each code means
   ^Codes:
   # Skips over the definitions for the codes
-  ^\s+\S+\s+-\s+
+  ^\s*\S\s-\s\S+
   # Matches a route and captures if ${TAG} is use for the route and then moves to Gateway section
   ^${CODE}\s+${ROUTE}/${MASK},\s+${SUCCESSORS}\s+successors,\s+FD\s+is\s+${FD},\s+tag\s+is\s+${TAG} -> Gateway
   # Matches a route and captures it and then moves to Gateway section
@@ -27,10 +29,12 @@ Start
   ^. -> Error
 
 Gateway
+  # This captures adv router, FD to router, and Reported Distance(RD)
+  ^\s*via\s+${ADV_ROUTER}\s+\(${ADV_FD}/${ADV_RD}\),\s+${OUT_INTERFACE}
   # This captures the advertising router and outgoing interface
-  ^\s+via\s+${ADV_ROUTER},\s+${OUT_INTERFACE}
+  ^\s*via\s+${ADV_ROUTER},\s+${OUT_INTERFACE}
   # This captures the scenarion where the route is injected via Redistribution.
-  ^\s+via\s+${SOURCE}
+  ^\s*via\s+${SOURCE}
   # This will not capture anything but if it encounters another route, it will continue and record what it already captured
   ^\S+\s+(?:\d+(?:\.|)){4}/\d+,\s+\d+\s+successors -> Continue.Record
   # These are the same as above and capture the next set of routes

--- a/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology.yml
+++ b/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology.yml
@@ -11,6 +11,8 @@ parsed_sample:
     adv_router:
       - "10.254.11.9"
       - "10.254.11.33"
+    adv_fd: []
+    adv_rd: []
     out_interface:
       - "TenGigabitEthernet1/1"
       - "TenGigabitEthernet2/1"
@@ -25,6 +27,8 @@ parsed_sample:
     tag: ""
     adv_router:
       - "10.254.6.14"
+    adv_fd: []
+    adv_rd: []
     out_interface:
       - "Port-channel10"
     source: ""
@@ -39,6 +43,8 @@ parsed_sample:
     adv_router:
       - "10.254.11.9"
       - "10.254.11.33"
+    adv_fd: []
+    adv_rd: []
     out_interface:
       - "TenGigabitEthernet1/1"
       - "TenGigabitEthernet2/1"
@@ -53,6 +59,8 @@ parsed_sample:
     tag: ""
     adv_router:
       - "10.254.10.34"
+    adv_fd: []
+    adv_rd: []
     out_interface:
       - "GigabitEthernet9/29"
     source: ""
@@ -66,6 +74,8 @@ parsed_sample:
     tag: ""
     adv_router:
       - "10.254.1.34"
+    adv_fd: []
+    adv_rd: []
     out_interface:
       - "Port-channel3"
     source: ""
@@ -79,6 +89,8 @@ parsed_sample:
     tag: ""
     adv_router:
       - "10.254.2.22"
+    adv_fd: []
+    adv_rd: []
     out_interface:
       - "TenGigabitEthernet3/3"
     source: ""
@@ -99,6 +111,8 @@ parsed_sample:
       - "10.254.4.10"
       - "10.254.4.14"
       - "10.254.54.6"
+    adv_fd: []
+    adv_rd: []
     out_interface:
       - "TenGigabitEthernet1/4"
       - "TenGigabitEthernet1/6"

--- a/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology1.yml
+++ b/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology1.yml
@@ -1,100 +1,107 @@
 ---
 parsed_sample:
-  - router_id: "10.255.11.6"
+  - process_id: "100"
+    router_id: "10.255.11.6"
     code: "P"
-    out_interface:
-      - "TenGigabitEthernet1/1"
-      - "TenGigabitEthernet2/1"
     route: "66.128.208.232"
     mask: "32"
-    adv_router:
-      - "10.254.11.9"
-      - "10.254.11.33"
-    process_id: "100"
+    successors: "2"
     fd: "264448"
     tag: ""
-    successors: "2"
-    source: ""
-  - router_id: "10.255.11.6"
-    code: "P"
-    out_interface:
-      - "Port-channel10"
-    route: "10.254.6.8"
-    mask: "30"
-    adv_router:
-      - "10.254.6.14"
-    process_id: "100"
-    fd: "1024"
-    tag: ""
-    successors: "1"
-    source: ""
-  - router_id: "10.255.11.6"
-    code: "P"
-    out_interface:
-      - "TenGigabitEthernet1/1"
-      - "TenGigabitEthernet2/1"
-    route: "67.230.223.128"
-    mask: "28"
     adv_router:
       - "10.254.11.9"
       - "10.254.11.33"
-    process_id: "100"
+    adv_fd: []
+    adv_rd: []
+    out_interface:
+      - "TenGigabitEthernet1/1"
+      - "TenGigabitEthernet2/1"
+    source: ""
+  - process_id: "100"
+    router_id: "10.255.11.6"
+    code: "P"
+    route: "10.254.6.8"
+    mask: "30"
+    successors: "1"
+    fd: "1024"
+    tag: ""
+    adv_router:
+      - "10.254.6.14"
+    adv_fd: []
+    adv_rd: []
+    out_interface:
+      - "Port-channel10"
+    source: ""
+  - process_id: "100"
+    router_id: "10.255.11.6"
+    code: "P"
+    route: "67.230.223.128"
+    mask: "28"
+    successors: "2"
     fd: "5632"
     tag: "53471"
-    successors: "2"
-    source: ""
-  - router_id: "10.255.11.6"
-    code: "P"
+    adv_router:
+      - "10.254.11.9"
+      - "10.254.11.33"
+    adv_fd: []
+    adv_rd: []
     out_interface:
-      - "GigabitEthernet9/29"
+      - "TenGigabitEthernet1/1"
+      - "TenGigabitEthernet2/1"
+    source: ""
+  - process_id: "100"
+    router_id: "10.255.11.6"
+    code: "P"
     route: "10.255.10.5"
     mask: "32"
-    adv_router:
-      - "10.254.10.34"
-    process_id: "100"
+    successors: "1"
     fd: "130816"
     tag: ""
-    successors: "1"
-    source: ""
-  - router_id: "10.255.11.6"
-    code: "P"
+    adv_router:
+      - "10.254.10.34"
+    adv_fd: []
+    adv_rd: []
     out_interface:
-      - "Port-channel3"
+      - "GigabitEthernet9/29"
+    source: ""
+  - process_id: "100"
+    router_id: "10.255.11.6"
+    code: "P"
     route: "10.255.1.14"
     mask: "32"
-    adv_router:
-      - "10.254.1.34"
-    process_id: "100"
+    successors: "1"
     fd: "128768"
     tag: ""
-    successors: "1"
-    source: ""
-  - router_id: "10.255.11.6"
-    code: "P"
+    adv_router:
+      - "10.254.1.34"
+    adv_fd: []
+    adv_rd: []
     out_interface:
-      - "TenGigabitEthernet3/3"
+      - "Port-channel3"
+    source: ""
+  - process_id: "100"
+    router_id: "10.255.11.6"
+    code: "P"
     route: "10.254.2.12"
     mask: "30"
-    adv_router:
-      - "10.254.2.22"
-    process_id: "100"
+    successors: "1"
     fd: "768"
     tag: ""
-    successors: "1"
-    source: ""
-  - router_id: "10.255.11.6"
-    code: "P"
+    adv_router:
+      - "10.254.2.22"
+    adv_fd: []
+    adv_rd: []
     out_interface:
-      - "TenGigabitEthernet1/4"
-      - "TenGigabitEthernet1/6"
-      - "TenGigabitEthernet2/1"
-      - "TenGigabitEthernet1/1"
-      - "TenGigabitEthernet1/5"
-      - "TenGigabitEthernet4/4"
-      - "TenGigabitEthernet4/5"
-      - "TenGigabitEthernet1/3"
+      - "TenGigabitEthernet3/3"
+    source: ""
+  - process_id: "100"
+    router_id: "10.255.11.6"
+    code: "P"
     route: "10.255.11.4"
     mask: "32"
+    successors: "4"
+    fd: "128768"
+    tag: ""
     adv_router:
       - "10.254.56.6"
       - "10.254.55.6"
@@ -104,60 +111,75 @@ parsed_sample:
       - "10.254.4.10"
       - "10.254.4.14"
       - "10.254.54.6"
-    process_id: "100"
-    fd: "128768"
-    tag: ""
-    successors: "4"
-    source: ""
-  - router_id: "10.2.0.1"
-    code: "P"
+    adv_fd: []
+    adv_rd: []
     out_interface:
-      - "GigabitEthernet1/1"
-      - "GigabitEthernet1/2"
+      - "TenGigabitEthernet1/4"
+      - "TenGigabitEthernet1/6"
+      - "TenGigabitEthernet2/1"
+      - "TenGigabitEthernet1/1"
+      - "TenGigabitEthernet1/5"
+      - "TenGigabitEthernet4/4"
+      - "TenGigabitEthernet4/5"
+      - "TenGigabitEthernet1/3"
+    source: ""
+  - process_id: "65000"
+    router_id: "10.2.0.1"
+    code: "P"
     route: "10.50.20.4"
     mask: "32"
+    successors: "2"
+    fd: "128039168"
+    tag: ""
     adv_router:
       - "10.4.0.1"
       - "10.4.0.2"
-    process_id: "65000"
-    fd: "128039168"
-    tag: ""
-    successors: "2"
-    source: ""
-  - router_id: "10.2.0.1"
-    code: "P"
+    adv_fd: []
+    adv_rd: []
     out_interface:
       - "GigabitEthernet1/1"
       - "GigabitEthernet1/2"
+    source: ""
+  - process_id: "65000"
+    router_id: "10.2.0.1"
+    code: "P"
     route: "10.50.21.0"
     mask: "27"
+    successors: "0"
+    fd: "Inaccessible"
+    tag: "6508497"
     adv_router:
       - "10.4.0.1"
       - "10.4.0.2"
-    process_id: "65000"
-    fd: "Inaccessible"
-    tag: "6508497"
-    successors: "0"
+    adv_fd: []
+    adv_rd: []
+    out_interface:
+      - "GigabitEthernet1/1"
+      - "GigabitEthernet1/2"
     source: ""
-  - router_id: "10.2.0.1"
+  - process_id: "65000"
+    router_id: "10.2.0.1"
     code: "P"
-    out_interface: []
     route: "10.50.75.0"
     mask: "24"
-    adv_router: []
-    process_id: "65000"
+    successors: "1"
     fd: "2816"
     tag: ""
-    successors: "1"
-    source: "Rstatic"
-  - router_id: "10.2.0.1"
-    code: "P"
+    adv_router: []
+    adv_fd: []
+    adv_rd: []
     out_interface: []
+    source: "Rstatic"
+  - process_id: "65000"
+    router_id: "10.2.0.1"
+    code: "P"
     route: "10.50.23.92"
     mask: "30"
-    adv_router: []
-    process_id: "65000"
+    successors: "1"
     fd: "3840256"
     tag: "5507497"
-    successors: "1"
+    adv_router: []
+    adv_fd: []
+    adv_rd: []
+    out_interface: []
     source: "Redistributed"

--- a/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology2.raw
+++ b/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology2.raw
@@ -1,0 +1,19 @@
+EIGRP-IPv4 Topology Table for AS(1)/ID(172.16.0.1)
+Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply,
+r - reply Status, s - sia Status
+
+P 172.16.0.1/32, 1 successors, FD is 128256
+via Connected, Loopback0
+P 172.16.0.2/32, 1 successors, FD is 130816
+via 192.168.100.1 (130816/128256), GigabitEthernet0/0
+P 10.2.2.0/24, 1 successors, FD is 3072
+via 192.168.100.1 (3072/2816), GigabitEthernet0/0
+P 192.168.100.4/31, 1 successors, FD is 3072
+via 192.168.100.1 (3072/2816), GigabitEthernet0/0
+P 192.168.100.0/31, 1 successors, FD is 2816
+via Connected, GigabitEthernet0/0
+P 192.168.100.2/31, 1 successors, FD is 2816
+via Connected, GigabitEthernet0/1
+P 192.168.100.6/31, 1 successors, FD is 3072
+via 192.168.100.1 (3072/2816), GigabitEthernet0/0
+

--- a/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology2.yml
+++ b/tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology2.yml
@@ -1,0 +1,115 @@
+---
+parsed_sample:
+  - process_id: "1"
+    router_id: "172.16.0.1"
+    code: "P"
+    route: "172.16.0.1"
+    mask: "32"
+    successors: "1"
+    fd: "128256"
+    tag: ""
+    adv_router:
+      - "Connected"
+    adv_fd: []
+    adv_rd: []
+    out_interface:
+      - "Loopback0"
+    source: ""
+  - process_id: "1"
+    router_id: "172.16.0.1"
+    code: "P"
+    route: "172.16.0.2"
+    mask: "32"
+    successors: "1"
+    fd: "130816"
+    tag: ""
+    adv_router:
+      - "192.168.100.1"
+    adv_fd:
+      - "130816"
+    adv_rd:
+      - "128256"
+    out_interface:
+      - "GigabitEthernet0/0"
+    source: ""
+  - process_id: "1"
+    router_id: "172.16.0.1"
+    code: "P"
+    route: "10.2.2.0"
+    mask: "24"
+    successors: "1"
+    fd: "3072"
+    tag: ""
+    adv_router:
+      - "192.168.100.1"
+    adv_fd:
+      - "3072"
+    adv_rd:
+      - "2816"
+    out_interface:
+      - "GigabitEthernet0/0"
+    source: ""
+  - process_id: "1"
+    router_id: "172.16.0.1"
+    code: "P"
+    route: "192.168.100.4"
+    mask: "31"
+    successors: "1"
+    fd: "3072"
+    tag: ""
+    adv_router:
+      - "192.168.100.1"
+    adv_fd:
+      - "3072"
+    adv_rd:
+      - "2816"
+    out_interface:
+      - "GigabitEthernet0/0"
+    source: ""
+  - process_id: "1"
+    router_id: "172.16.0.1"
+    code: "P"
+    route: "192.168.100.0"
+    mask: "31"
+    successors: "1"
+    fd: "2816"
+    tag: ""
+    adv_router:
+      - "Connected"
+    adv_fd: []
+    adv_rd: []
+    out_interface:
+      - "GigabitEthernet0/0"
+    source: ""
+  - process_id: "1"
+    router_id: "172.16.0.1"
+    code: "P"
+    route: "192.168.100.2"
+    mask: "31"
+    successors: "1"
+    fd: "2816"
+    tag: ""
+    adv_router:
+      - "Connected"
+    adv_fd: []
+    adv_rd: []
+    out_interface:
+      - "GigabitEthernet0/1"
+    source: ""
+  - process_id: "1"
+    router_id: "172.16.0.1"
+    code: "P"
+    route: "192.168.100.6"
+    mask: "31"
+    successors: "1"
+    fd: "3072"
+    tag: ""
+    adv_router:
+      - "192.168.100.1"
+    adv_fd:
+      - "3072"
+    adv_rd:
+      - "2816"
+    out_interface:
+      - "GigabitEthernet0/0"
+    source: ""


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request Fixes #826
 - Additional Testing
 
(Actual fix after reorder of yml in https://github.com/networktocode/ntc-templates/pull/1012 )

##### COMPONENT
<!--- Name of the template, os and command  -->
modified:   ntc_templates/templates/cisco_ios_show_ip_eigrp_topology.textfsm
add: tests/cisco_ios/show_ip_eigrp_topology/cisco_ios_show_ip_eigrp_topology2.raw

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #826 
1. where the eigrp output, has additional  FD(Feasible distance) and RD(Reported distance) in via output.
e.g. current: `    via 10.254.11.9, TenGigabitEthernet1/1`
e.g.new:      `via 192.168.100.1 (130816/128256), GigabitEthernet0/0`
Add match and capture values in two new lists.
```
Value List ADV_FD (\d+)
Value List ADV_RD (\d+)
```
2. the new output also has the via output with no starting spaces, changed "\s+" to "\s*" for start of line matches.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
e.g. of additional fields. after
```
parsed_sample:
  - process_id: "100"
    adv_router:
      - "10.254.11.9"
      - "10.254.11.33"
    adv_fd: []
    adv_rd: []
```
before
```
parsed_sample:
  - process_id: "100"
    adv_router:
      - "10.254.11.9"
      - "10.254.11.33"
```