### PR TITLE
Fix template IOS show int status - added new interface status

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_interfaces_status.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_interfaces_status.textfsm
@@ -1,6 +1,6 @@
 Value PORT (\S+)
 Value NAME (.+?)
-Value STATUS (err-disabled|disabled|connected|notconnect|inactive|up|down|monitoring)
+Value STATUS (err-disabled|disabled|connected|notconnect|inactive|up|down|monitoring|suspended)
 Value VLAN (\S+)
 Value DUPLEX (\S+)
 Value SPEED (\S+)

--- a/tests/cisco_ios/show_interfaces_status/cisco_ios_show_interfaces_status.raw
+++ b/tests/cisco_ios/show_interfaces_status/cisco_ios_show_interfaces_status.raw
@@ -5,7 +5,7 @@ Gi1/0/3   John's Office      notconnect   1            auto   auto 10/100/1000Ba
 Gi1/0/4   SingleName         connected    1          a-full  a-100 10/100/1000BaseTX
 Gi1/0/5   Dashed-Name        connected    1000       a-full a-1000 10/100/1000BaseTX
 Gi1/0/6   Spaced Example     connected    8          a-full  a-100 10/100/1000BaseTX
-Gi1/0/7   Trunk Example      connected    trunk      a-full a-1000 1000BaseSX SFP
+Gi1/0/7   Trunk Example      suspended    trunk      a-full a-1000 1000BaseSX SFP
 Gi1/0/8   SFP Not Present    notconnect   1            auto   auto Not Present
 Gi1/0/9   SFP Not Present    notconnect   1            auto   auto Not Present
 Gi1/0/10  Management         notconnect   routed       auto   auto 10/100BaseTX

--- a/tests/cisco_ios/show_interfaces_status/cisco_ios_show_interfaces_status.yml
+++ b/tests/cisco_ios/show_interfaces_status/cisco_ios_show_interfaces_status.yml
@@ -50,7 +50,7 @@ parsed_sample:
     fc_mode: ""
   - port: "Gi1/0/7"
     name: "Trunk Example"
-    status: "connected"
+    status: "suspended"
     vlan: "trunk"
     duplex: "a-full"
     speed: "a-1000"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT
cisco_ios_show_interfaces_status.textfsm, ios, show interfaces status 

##### SUMMARY
Error on parsing output on a cisco ios switch using command "show interfaces status"

The template failed with the error: TextFSMError: State Error raised. Rule Line: 27. Input Line: Gi1/0/52 Trunk suspended trunk a-full a-100 10/100/1000BaseTX SFP

The error occurs due to lack of status "suspended" in the template. After the required status "suspended" has been added to the template the error has gone.
