### PR TITLE
Fix for issue #1034

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_interfaces_status.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_interfaces_status.textfsm
@@ -1,6 +1,6 @@
 Value PORT (\S+)
 Value NAME (.+?)
-Value STATUS (err-disabled|disabled|connected|notconnect|inactive|up|down|monitoring|suspended)
+Value STATUS (err-disabled|disabled|connected|connected:|notconnect|notconnect:|inactive|up|down|monitoring|suspended)
 Value VLAN (\S+)
 Value DUPLEX (\S+)
 Value SPEED (\S+)


### PR DESCRIPTION
Template update to fix compatibility issues with show interface status on interfaces that are undergoing cable-diagnostics tdr testing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_interfaces_status.textfsm 
Cisco IOS
show interface status

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #1034 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
Traceback (most recent call last):
  File "/Users/serverwrangler/src/cisco-ise-migtool/./get-ditreport.py", line 79, in <module>
    int_table = parse_output(platform="cisco_ios", command="show int status | exclude CPU|Trunk|Te", data=intsuck)
  File "/opt/homebrew/lib/python3.9/site-packages/ntc_templates/parse.py", line 57, in parse_output
    cli_table.ParseCmd(data, attrs)
  File "/opt/homebrew/lib/python3.9/site-packages/textfsm/clitable.py", line 282, in ParseCmd
    self.table = self._ParseCmdItem(self.raw, template_file=template_files[0])
  File "/opt/homebrew/lib/python3.9/site-packages/textfsm/clitable.py", line 315, in _ParseCmdItem
    for record in fsm.ParseText(cmd_input):
  File "/opt/homebrew/lib/python3.9/site-packages/textfsm/parser.py", line 897, in ParseText
    self._CheckLine(line)
  File "/opt/homebrew/lib/python3.9/site-packages/textfsm/parser.py", line 946, in _CheckLine
    if self._Operations(rule, line):
  File "/opt/homebrew/lib/python3.9/site-packages/textfsm/parser.py", line 1026, in _Operations
    raise TextFSMError('State Error raised. Rule Line: %s. Input Line: %s'
textfsm.parser.TextFSMError: State Error raised. Rule Line: 27. Input Line: Gi3/0/16  No Description            notconnect:  1            auto   auto 10/100/1000BaseTX


After:
[{'port': 'Gi3/0/16', 'name': 'No Description', 'status': 'notconnect:', 'vlan': '1', 'duplex': 'auto', 'speed': 'auto', 'type': '10/100/1000BaseTX', 'fc_mode': ''}]
```
