### PR TITLE
Modified cisco_ios_show_boot

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_boot.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_boot.textfsm
@@ -1,3 +1,4 @@
+Value SWITCH_NUMBER (\d+)
 Value BOOT_PATH (\S+)
 Value CONFIG_FILE (\S+)
 Value PRIV_CONFIG_FILE (\S+)
@@ -11,19 +12,24 @@ Value BUFFER_SIZE (\d+)
 Value TIMEOUT_CONFIG_DOWNLOAD (\d+)
 Value CONFIG_DOWNLOAD_DHCP (enabled|disabled)
 Value CONFIG_DOWNLOAD_DHCP_NEXT_BOOT (enabled|disabled)
+Value BOOT_MODE (\S+)
+Value CURRENT_BOOT_VARIABLES (BOOT\s*variable\s*does\s*not\s*exist|BOOT\s*variable\s*=\s*\S+)
 
 Start
-  ^BOOT\s+path-list\s+:\s+${BOOT_PATH}
+  ^Current\s*Boot\s*Variables: -> CurrentBootVariables
+  ^Switch\s+${SWITCH_NUMBER}
+  ^BOOT\s+(path-list|variable)\s+(:|=)\s+${BOOT_PATH}
   ^Config\s+file\s+:\s+${CONFIG_FILE}
   ^Private\s+Config\s+file\s+:\s+${PRIV_CONFIG_FILE}
-  ^Enable\s+Break\s+:\s+${ENABLE_BREAK}
-  ^Manual\s+Boot\s+:\s+${MANUAL_BOOT}
+  ^Enable\s+Break\s+(:|=)\s+${ENABLE_BREAK}
+  ^Manual\s+Boot\s+(:|=)\s+${MANUAL_BOOT}
   ^Allow\s+Dev\s+Key\s+:\s+${ALLOW_DEV_KEY}
   ^HELPER\s+path-list\s+:.*
   ^Auto\s+upgrade\s+:\s+${AUTO_UPGRADE}
   ^Auto\s+upgrade\s+path\s+:.*
   ^NVRAM/Config\s+file
   ^\s+buffer\s+size:\s+${BUFFER_SIZE}
+  ^iPXE\s*Timeout\s*=\s*${TIMEOUT_CONFIG_DOWNLOAD}
   ^Timeout\s+for\s+Config
   ^\s+Download:\s+${TIMEOUT_CONFIG_DOWNLOAD}
   ^Config\s+Download
@@ -31,5 +37,12 @@ Start
   # Capture time-stamp if vty line has command time-stamping turned on
   ^Load\s+for\s+
   ^Time\s+source\s+is
+  ^Boot\s*Mode\s*=\s*${BOOT_MODE}
   ^\s*$$
+  ^-+
+  ^. -> Error
+  
+CurrentBootVariables
+  ^${CURRENT_BOOT_VARIABLES}
+  ^Boot\s*Variables\s*on\s*next\s*reload: -> Start
   ^. -> Error

--- a/tests/cisco_ios/show_boot/cisco_ios_show_boot_gibraltar.raw
+++ b/tests/cisco_ios/show_boot/cisco_ios_show_boot_gibraltar.raw
@@ -1,0 +1,12 @@
+---------------------------
+Switch 1
+---------------------------
+Current Boot Variables:
+BOOT variable does not exist
+
+Boot Variables on next reload:
+BOOT variable = flash:packages.conf                                                                                                                                                                               
+Manual Boot = no                                                                                                                                                                                                  
+Enable Break = yes                                                                                                                                                                                                
+Boot Mode = DEVICE                                                                                                                                                                                                
+iPXE Timeout = 0

--- a/tests/cisco_ios/show_boot/cisco_ios_show_boot_gibraltar.yml
+++ b/tests/cisco_ios/show_boot/cisco_ios_show_boot_gibraltar.yml
@@ -1,0 +1,18 @@
+---
+parsed_sample:
+  - switch_number: "1"
+    boot_path: "flash:packages.conf"
+    config_file: ""
+    priv_config_file: ""
+    enable_break: "yes"
+    manual_boot: "no"
+    allow_dev_key: ""
+    helper_path_list: ""
+    auto_upgrade: ""
+    auto_upgrade_path: ""
+    buffer_size: ""
+    timeout_config_download: "0"
+    config_download_dhcp: ""
+    config_download_dhcp_next_boot: ""
+    boot_mode: "DEVICE"
+    current_boot_variables: "BOOT variable does not exist"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
**Template:** `ntc_templates/templates/cisco_ios_show_boot.textfsm`
**OS:** `cisco_ios`
**Command:** `show boot`

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Updated `show boot` template to include new formatting for Cisco IOS Gibraltar output.

Includes the old values and adds "Current Boot Variables", "Boot Mode", and "Switch Number"

<!-- Paste verbatim command output below, e.g. before and after your change -->
**Before:**
```
BOOT path-list      : flash:c3750e-ipbasek9-mz.150-2.SE11.bin
Config file         : flash:/config.text
Private Config file : flash:/private-config.text
Enable Break        : yes
Manual Boot         : no
Allow Dev Key         : yes
HELPER path-list    : 
Auto upgrade        : yes
Auto upgrade path   :
NVRAM/Config file
      buffer size:   524288
Timeout for Config
          Download:    0 seconds
Config Download
       via DHCP:       disabled (next boot: disabled
```
**After:**
```
---------------------------
Switch 1
---------------------------
Current Boot Variables:
BOOT variable does not exist

Boot Variables on next reload:
BOOT variable = flash:packages.conf                                                                                                                                                                               
Manual Boot = no                                                                                                                                                                                                  
Enable Break = yes                                                                                                                                                                                                
Boot Mode = DEVICE                                                                                                                                                                                                
iPXE Timeout = 0
```
