### PR TITLE
Improve cisco_ios show_etherchannel_summary

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_etherchannel_summary.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_etherchannel_summary.textfsm
@@ -26,4 +26,6 @@ PortChannel
   ^\s+
   ^-+\++
   ^\s*$$
+  ^(RU|SU)\s+-\s+L(2|3)\s+port-channel\s+UP\s+(s|S)tate
+  ^(P|S)/(bndl|susp)\s+-\s+(Bundled|Suspended)
   ^. -> Error

--- a/tests/cisco_ios/show_etherchannel_summary/show_etherchannel_summary2.raw
+++ b/tests/cisco_ios/show_etherchannel_summary/show_etherchannel_summary2.raw
@@ -1,0 +1,23 @@
+Flags:  D - down        P/bndl - bundled in port-channel
+        I - stand-alone s/susp - suspended
+        H - Hot-standby (LACP only)
+        R - Layer3      S - Layer2
+        U - in use      f - failed to allocate aggregator
+
+        M - not in use, minimum links not met
+        u - unsuitable for bundling
+        w - waiting to be aggregated
+        d - default port
+
+
+Number of channel-groups in use: 1
+Number of aggregators:           1
+
+Group  Port-channel  Protocol    Ports
+------+-------------+-----------+-----------------------------------------------
+10	Po10(RU)		LACP	 Te0/0/2(bndl) Te0/0/3(bndl)
+
+RU - L3 port-channel UP State
+SU - L2 port-channel UP state
+P/bndl -  Bundled
+S/susp  - Suspended

--- a/tests/cisco_ios/show_etherchannel_summary/show_etherchannel_summary2.yml
+++ b/tests/cisco_ios/show_etherchannel_summary/show_etherchannel_summary2.yml
@@ -1,0 +1,12 @@
+---
+parsed_sample:
+  - group: "10"
+    po_name: "Po10"
+    po_status: "RU"
+    protocol: "LACP"
+    interfaces:
+      - "Te0/0/2"
+      - "Te0/0/3"
+    interfaces_status:
+      - "bndl"
+      - "bndl"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Additional Testing

##### COMPONENT
<!--- Name of the template, os and command  -->
ntc_templates/templates/cisco_ios_show_etherchannel_summary.textfsm
cisco_ios
show etherchannel summary

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Raw output was causing errors. No new fields are captured.
New lines are superfluous and just describe the output.
Added a test with the new lines.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
RU - L3 port-channel UP State
SU - L2 port-channel UP state
```
