### PR TITLE
Improve cisco_ios show_module

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_module_status.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_module_status.textfsm
@@ -1,7 +1,7 @@
 Value Key MODULE (\d+)
 Value MAC_ADDR (\S+\s+to\s+\S+)
 Value MOD_HW (\S+)
-Value MOD_FW (\S+)
+Value MOD_FW (\S+(\s+\[\w+\])?)
 Value MOD_SW (\S+)
 Value STATUS (\w+)
 

--- a/tests/cisco_ios/show_module/cisco_ios_show_module4.raw
+++ b/tests/cisco_ios/show_module/cisco_ios_show_module4.raw
@@ -1,0 +1,16 @@
+Chassis Type: C9500-24Y4C
+
+Mod Ports Card Type                                   Model          Serial No.
+---+-----+--------------------------------------+--------------+--------------
+1   28   Cisco Catalyst 9500 Series Router           C9500-24Y4C      CAT2239L323
+
+Mod MAC addresses                    Hw   Fw           Sw                 Status
+---+--------------------------------+----+------------+------------------+--------
+1   F4DB.E65C.F500 to F4DB.E65C.F51B 1.0  16.8.1r [FC4] 16.08.01a          ok
+
+Mod Redundancy Role     Operating Redundancy Mode Configured Redundancy Mode
+---+-------------------+-------------------------+---------------------------
+1   Active              active                    Non-redundant
+
+Chassis MAC address range: 160 addresses from f4db.e65c.f500 to f4db.e65c.f59f
+

--- a/tests/cisco_ios/show_module/cisco_ios_show_module4.yml
+++ b/tests/cisco_ios/show_module/cisco_ios_show_module4.yml
@@ -1,0 +1,18 @@
+---
+parsed_sample:
+  - module: "1"
+    port: "28"
+    cardtype: "Cisco Catalyst 9500 Series Router"
+    model: "C9500-24Y4C"
+    serial: "CAT2239L323"
+    mac_addr: "F4DB.E65C.F500 to F4DB.E65C.F51B"
+    mod_hw: "1.0"
+    mod_fw: "16.8.1r [FC4]"
+    mod_sw: "16.08.01a"
+    status: "ok"
+    submodule: ""
+    submodule_model: ""
+    submodule_serial: ""
+    submodule_hw: ""
+    submodule_status: ""
+    online_diag: ""


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Additional Testing

##### COMPONENT
<!--- Name of the template, os and command  -->
ntc_templates/templates/cisco_ios_show_module_status.textfsm
cisco_ios
show module

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Update regex for `MOD_FW` to include `[FC4]`.
This occurs on Catalyst 9500s.
Added a new test for this edge case.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Mod MAC addresses                    Hw   Fw           Sw                 Status
---+--------------------------------+----+------------+------------------+--------
1   F4DB.E65C.F500 to F4DB.E65C.F51B 1.0  16.8.1r [FC4] 16.08.01a          ok


mod_fw: "16.8.1r [FC4]"

```
