### PR TITLE
Clarifies docs about length order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Taking a look at the example template above, you notice that we're using **\s***
 The Index file binds the templates to the commands being run. Special care has been taken on ordering, as there is potential for issues. e.g. `show ip route` picking up for `show ip router vrf <vrf-name>`. We have used a combination of ordering, as defined:
 
  - OS in alphabetical order
- - Template name in length order
+ - Template name in length order (longest to shortest)
  - When length is the same, use alphabetical order of command name
  - Keep space between OS's
 

--- a/ntc_templates/templates/index
+++ b/ntc_templates/templates/index
@@ -5,7 +5,7 @@
 #
 # Rules of Ordering:
 #  - OS in alphabetical order
-#  - Template name in length order
+#  - Template name in length order (longest to shortest)
 #  - When Length is the same, use alphabetical order
 #  - Keep space between OS's
 #


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
Index ordering docs clarification

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Docs indicate that length order is the ordering. Didn't quite clarify if longest to shortest or shortest to longest.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
