### PR TITLE
Adding cisco_xr_show_ospf_neighbor_area-sorted template

### DIFF
--- a/ntc_templates/templates/cisco_xr_show_ospf_neighbor_area-sorted.textfsm
+++ b/ntc_templates/templates/cisco_xr_show_ospf_neighbor_area-sorted.textfsm
@@ -1,0 +1,12 @@
+Value Filldown AREA (\S+)
+Value NEIGHBOR_ID (\d+.\d+.\d+.\d+)
+Value PRIORITY (\d+)
+Value STATE (\S+\/\s+\-|\S+)
+Value DEAD_TIME (\d+:\d+:\d+)
+Value ADDRESS (\d+.\d+.\d+.\d+)
+Value INTERFACE (\S+)
+Value NEIGHBOR_UPTIME (\S+)
+
+Start
+  ^Area\s+${AREA}
+  ^${NEIGHBOR_ID}\s+${PRIORITY}\s+${STATE}\s+${DEAD_TIME}\s+${ADDRESS}\s+${NEIGHBOR_UPTIME}\s+${INTERFACE} -> Record


### PR DESCRIPTION
##### ISSUE TYPE
New Template Pull Request 


##### COMPONENT
_cisco_xr_show_ospf_neighbor_area-sorted.textfsm
CISCO IOS XR - show ospf neighbor area-sorted_

##### SUMMARY
Adding cisco_xr_show_ospf_neighbor_area-sorted template for "**show ospf neighbor area-sorted**" command, including Area information and support for multiple OSPF Area in IOS XR platform.


<!-- Paste verbatim command output below, e.g. before and after your change -->
```
	{
		"ADDRESS": "114.1.251.240",
		"AREA": "0",
		"DEAD_TIME": "00:00:19",
		"INTERFACE": "BE102.1",
		"NEIGHBOR_ID": "0.0.0.37",
		"NEIGHBOR_UPTIME": "20w0d",
		"PRIORITY": "1",
		"STATE": "FULL/  -"
	},
	{
		"ADDRESS": "114.1.252.234",
		"AREA": "0",
		"DEAD_TIME": "00:01:44",
		"INTERFACE": "BE105.1",
		"NEIGHBOR_ID": "114.1.220.1",
		"NEIGHBOR_UPTIME": "8w2d",
		"PRIORITY": "1",
		"STATE": "FULL/  -"
	},
	{
		"ADDRESS": "114.0.188.251",
		"AREA": "37",
		"DEAD_TIME": "00:00:38",
		"INTERFACE": "BE106",
		"NEIGHBOR_ID": "114.1.212.27",
		"NEIGHBOR_UPTIME": "4w1d",
		"PRIORITY": "1",
		"STATE": "FULL/  -"
	},
	{
		"ADDRESS": "114.0.26.182",
		"AREA": "37",
		"DEAD_TIME": "00:00:38",
		"INTERFACE": "BE200",
		"NEIGHBOR_ID": "114.1.211.3",
		"NEIGHBOR_UPTIME": "2w3d",
		"PRIORITY": "1",
		"STATE": "FULL/  -"
	}
```
