### PR TITLE
Cisco ASA show access-list does not support mixed objects and fqdn

### DIFF
--- a/ntc_templates/templates/cisco_asa_show_access-list.textfsm
+++ b/ntc_templates/templates/cisco_asa_show_access-list.textfsm
@@ -39,7 +39,7 @@ Value ENTRY_SRC_HOST (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_SRC_NETWORK (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_SRC_MASK (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_SRC_ANY (any[46]{0,1})
-Value ENTRY_SRC_FQDN_STATE (unresolved)
+Value ENTRY_SRC_FQDN_STATE (unresolved|resolved)
 Value ENTRY_DST_FQDN (\S+)
 Value ENTRY_DST_RANGE_START (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_DST_RANGE_END (\d+\.\d+\.\d+\.\d+)
@@ -47,7 +47,7 @@ Value ENTRY_DST_HOST (\S+)
 Value ENTRY_DST_NETWORK (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_DST_MASK (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_DST_ANY (any[46]{0,1})
-Value ENTRY_DST_FQDN_STATE (unresolved)
+Value ENTRY_DST_FQDN_STATE (unresolved|resolved)
 Value ENTRY_ICMP_TYPE (echo-reply|unreachable|echo|time-exceeded)
 Value ENTRY_ICMP_CODE (\d+)
 Value ENTRY_PORT ([a-z\-]+\s+\d+|[\w\-]+)
@@ -66,6 +66,9 @@ Start
   ^\s+access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+(standard|extended)\s+(permit|deny)\s+${ENTRY_PROTOCOL_ICMP}\s+(fqdn\s+${ENTRY_SRC_FQDN}|range\s+${ENTRY_SRC_RANGE_START}\s+${ENTRY_SRC_RANGE_END}|host\s+${ENTRY_SRC_HOST}|${ENTRY_SRC_NETWORK}\s+${ENTRY_SRC_MASK}|${ENTRY_SRC_ANY})\s+(\(${ENTRY_SRC_FQDN_STATE}\)\s+){0,1}(fqdn\s+${ENTRY_DST_FQDN}|range\s+${ENTRY_DST_RANGE_START}\s+${ENTRY_DST_RANGE_END}|host\s+${ENTRY_DST_HOST}|${ENTRY_DST_NETWORK}\s+${ENTRY_DST_MASK}|${ENTRY_DST_ANY})\s+(\(${ENTRY_DST_FQDN_STATE}\)\s+){0,1}(${ENTRY_ICMP_TYPE}(\s+${ENTRY_ICMP_CODE}){0,1}\s+){0,1}(log\s+(${LOG_LEVEL}\s+interval\s+${LOG_INTERVAL}|disable|default)\s+){0,1}(inactive){0,1}\s*(\(hitcnt=${ENTRY_HIT_COUNT}\)){0,1}\s*(\(${ENTRY_STATE}\)){0,1}\s+${ENTRY_HASH}\s* -> Record
   ^\s+access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+(standard|extended)\s+(permit|deny)\s+(${ENTRY_PROTOCOL}\s+){0,1}(fqdn\s+${ENTRY_SRC_FQDN}|range\s+${ENTRY_SRC_RANGE_START}\s+${ENTRY_SRC_RANGE_END}|host\s+${ENTRY_SRC_HOST}|${ENTRY_SRC_NETWORK}\s+${ENTRY_SRC_MASK}|${ENTRY_SRC_ANY})\s+(\(${ENTRY_SRC_FQDN_STATE}\)\s+){0,1}((fqdn\s+${ENTRY_DST_FQDN}|range\s+${ENTRY_DST_RANGE_START}\s+${ENTRY_DST_RANGE_END}|host\s+${ENTRY_DST_HOST}|${ENTRY_DST_NETWORK}\s+${ENTRY_DST_MASK}|${ENTRY_DST_ANY})\s+){0,1}(\(${ENTRY_DST_FQDN_STATE}\)\s+){0,1}((eq\s+${ENTRY_PORT}|lt\s+${ENTRY_PORT_LESS_THAN}|gt\s+${ENTRY_PORT_GREATER_THAN}|range\s+${ENTRY_PORT_RANGE_START}\s+${ENTRY_PORT_RANGE_END})\s+){0,1}(log\s+([a-z0-9]+\s+interval\s+\d+|disable|default)\s+){0,1}(inactive){0,1}\s*(\(hitcnt=${ENTRY_HIT_COUNT}\)){0,1}\s*(\(${ENTRY_STATE}\)){0,1}\s+${ENTRY_HASH}\s* -> Record
   ^access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+(standard|extended)\s+(permit|deny)\s+(fqdn\s+${ENTRY_SRC_FQDN}|range\s+${ENTRY_SRC_RANGE_START}\s+${ENTRY_SRC_RANGE_END}|host\s+${ENTRY_SRC_HOST}|${ENTRY_SRC_NETWORK}\s+${ENTRY_SRC_MASK}|${ENTRY_SRC_ANY})\s+\((hitcnt=${ENTRY_HIT_COUNT})\)\s+${ENTRY_HASH}\s* -> Record
+  ^access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+${TYPE}\s+${ACTION}\s+(object\-group\s+${SVC_OBJECT_GRP}|object\s+${SVC_OBJECT}|${PROTOCOL})\s+(interface\s+${SRC_INTFC}|object\-group\s+${SRC_OBJECT_GRP}|object\s+${SRC_OBJECT}|host\s+${SRC_HOST}|${SRC_NETWORK}\s+${SRC_MASK}|${SRC_ANY})\s+(interface\s+${DST_INTFC}|object\-group\s+${DST_OBJECT_GRP}|object\s+${DST_OBJECT}|host\s+${DST_HOST}|${DST_NETWORK}\s+${DST_MASK}|${DST_ANY})* -> Record
+  ^access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+${TYPE}\s+${ACTION}\s+(object\-group\s+${SVC_OBJECT_GRP}|object\s+${SVC_OBJECT}|${PROTOCOL})\s+(interface\s+${SRC_INTFC}|object\-group\s+${SRC_OBJECT_GRP}|object\s+${SRC_OBJECT}|host\s+${SRC_HOST}|${SRC_NETWORK}\s+${SRC_MASK}|${SRC_ANY})\s+(interface\s+${DST_INTFC}|object\-group\s+${DST_OBJECT_GRP}|object\s+${DST_OBJECT}|host\s+${DST_HOST}|${DST_NETWORK}\s+${DST_MASK}|${DST_ANY}|fqdn\s+${ENTRY_DST_FQDN}\s+(\(${ENTRY_DST_FQDN_STATE}\)\s+){0,1}((eq\s+${ENTRY_PORT}|lt\s+${ENTRY_PORT_LESS_THAN}|gt\s+${ENTRY_PORT_GREATER_THAN}|range\s+${ENTRY_PORT_RANGE_START}\s+${ENTRY_PORT_RANGE_END})){0,1}(inactive){0,1}\s*(\(hitcnt=${ENTRY_HIT_COUNT}\)){0,1}\s*(\(${ENTRY_STATE}\)){0,1}\s+${ENTRY_HASH})* -> Record
+  ^\s+access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+${TYPE}\s+${ACTION}\s+(object\-group\s+${SVC_OBJECT_GRP}|object\s+${SVC_OBJECT}|${PROTOCOL})\s+(interface\s+${SRC_INTFC}|object\-group\s+${SRC_OBJECT_GRP}|object\s+${SRC_OBJECT}|host\s+${SRC_HOST}|${SRC_NETWORK}\s+${SRC_MASK}|${SRC_ANY})\s+(interface\s+${DST_INTFC}|object\-group\s+${DST_OBJECT_GRP}|object\s+${DST_OBJECT}|host\s+${DST_HOST}|${DST_NETWORK}\s+${DST_MASK}|${DST_ANY}|fqdn\s+${ENTRY_DST_FQDN}\s+(\(${ENTRY_DST_FQDN_STATE}\)\s+){0,1}((eq\s+${ENTRY_PORT}|lt\s+${ENTRY_PORT_LESS_THAN}|gt\s+${ENTRY_PORT_GREATER_THAN}|range\s+${ENTRY_PORT_RANGE_START}\s+${ENTRY_PORT_RANGE_END})){0,1}(inactive){0,1}\s*(\(hitcnt=${ENTRY_HIT_COUNT}\)){0,1}\s*(\(${ENTRY_STATE}\)){0,1}\s+${ENTRY_HASH})* -> Record
   ^.* -> Error "Did not match any rules"
 
 EOF

--- a/tests/cisco_asa/show_access-list/cisco_asa_show_access-list_update.raw
+++ b/tests/cisco_asa/show_access-list/cisco_asa_show_access-list_update.raw
@@ -76,3 +76,5 @@ access-list test line 38 extended permit tcp object ClientPC object-group NETWOR
   access-list test line 38 extended permit tcp host 172.31.168.7 host 10.2.88.100 inactive (hitcnt=0) (inactive) 0x4094da11 
 access-list test line 39 extended permit tcp object-group NETWORK_88 object aps0506_VIP_10.2.66.53 eq 6991 log disable (hitcnt=55) 0xe547ccd6 
   access-list test line 39 extended permit tcp 10.0.247.0 255.255.255.0 host 10.2.66.53 eq 6991 log disable (hitcnt=40) 0xea52300b 
+access-list test line 40 extended permit tcp object-group TEST-OBJ object host.example.com eq https (hitcnt=3228758) 0x3e3d87a5
+  access-list test line 40 extended permit tcp host 10.0.1.10 fqdn host.example.com (unresolved) eq https 0xc6e4eca7


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Template Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
./ntc_templates/templates/cisco_asa_show_access-list.textfsm
show access-list

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Cisco ASA show access-list does not support mixed objects and fqdn
Example:
access-list test line 40 extended permit tcp object-group TEST-OBJ object host.example.com eq https (hitcnt=3228758) 0x3e3d87a5
  access-list test line 40 extended permit tcp host 10.0.1.10 fqdn host.example.com (unresolved) eq https 0xc6e4eca7

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
