### PR TITLE
fix EOS 4.28.XF bug

### DIFF
--- a/ntc_templates/templates/arista_eos_show_ip_route.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_route.textfsm
@@ -15,7 +15,7 @@ Start
   ^kernel
   ^Codes:
   # Match for codes
-  ^\s+\S+\s+-\s+\S+
+  ^\s+.+-.+
   ^\s*$$ -> Routes
   ^. -> Error
 

--- a/tests/arista_eos/show_ip_route/arista_eos_show_ip_route5.raw
+++ b/tests/arista_eos/show_ip_route/arista_eos_show_ip_route5.raw
@@ -1,0 +1,20 @@
+VRF: default
+Codes: C - connected, S - static, K - kernel,
+       O - OSPF, IA - OSPF inter area, E1 - OSPF external type 1,
+       E2 - OSPF external type 2, N1 - OSPF NSSA external type 1,
+       N2 - OSPF NSSA external type2, B - Other BGP Routes,
+       B I - iBGP, B E - eBGP, R - RIP, I L1 - IS-IS level 1,
+       I L2 - IS-IS level 2, O3 - OSPFv3, A B - BGP Aggregate,
+       A O - OSPF Summary, NG - Nexthop Group Static Route,
+       V - VXLAN Control Service, M - Martian,
+       DH - DHCP client installed default route,
+       DP - Dynamic Policy Route, L - VRF Leaked,
+       G  - gRIBI, RC - Route Cache Route
+
+ C        162.220.49.0/26 is directly connected, Vlan105
+ C        162.220.49.64/26 is directly connected, Vlan104
+ C        162.220.49.128/31 is directly connected, Tunnel11, Static Interface GRE tunnel index 11, dst 184.170.244.12, src 216.201.90.212
+ B I      162.220.49.130/31 [200/0] via 199.229.255.1, Vlan50
+ B I      162.220.49.132/31 [200/0] via 199.229.255.1, Vlan50
+ C        162.220.49.134/31 is directly connected, Tunnel12, Static Interface GRE tunnel index 12, dst 104.200.133.181, src 216.201.90.212
+ S        162.220.49.0/24 is directly connected, Null0

--- a/tests/arista_eos/show_ip_route/arista_eos_show_ip_route5.yml
+++ b/tests/arista_eos/show_ip_route/arista_eos_show_ip_route5.yml
@@ -1,0 +1,80 @@
+---
+parsed_sample:
+  - vrf: "default"
+    protocol: "C"
+    network: "162.220.49.0"
+    mask: "26"
+    distance: ""
+    metric: ""
+    direct: "directly"
+    next_hop:
+      - "connected"
+    interface:
+      - "Vlan105"
+  - vrf: "default"
+    protocol: "C"
+    network: "162.220.49.64"
+    mask: "26"
+    distance: ""
+    metric: ""
+    direct: "directly"
+    next_hop:
+      - "connected"
+    interface:
+      - "Vlan104"
+  - vrf: "default"
+    protocol: "C"
+    network: "162.220.49.128"
+    mask: "31"
+    distance: ""
+    metric: ""
+    direct: "directly"
+    next_hop:
+      - "connected"
+    interface:
+      - "Tunnel11, Static Interface GRE tunnel index 11, dst 184.170.244.12, src 216.201.90.212"
+  - vrf: "default"
+    protocol: "B I"
+    network: "162.220.49.130"
+    mask: "31"
+    distance: "200"
+    metric: "0"
+    direct: ""
+    next_hop:
+      - "199.229.255.1"
+    interface:
+      - "Vlan50"
+  - vrf: "default"
+    protocol: "B I"
+    network: "162.220.49.132"
+    mask: "31"
+    distance: "200"
+    metric: "0"
+    direct: ""
+    next_hop:
+      - "199.229.255.1"
+    interface:
+      - "Vlan50"
+  - vrf: "default"
+    protocol: "C"
+    network: "162.220.49.134"
+    mask: "31"
+    distance: ""
+    metric: ""
+    direct: "directly"
+    next_hop:
+      - "connected"
+    interface:
+      - "Tunnel12, Static Interface GRE tunnel index 12, dst 104.200.133.181, src\
+        \ 216.201.90.212"
+  - vrf: "default"
+    protocol: "S"
+    network: "162.220.49.0"
+    mask: "24"
+    distance: ""
+    metric: ""
+    direct: "directly"
+    next_hop:
+      - "connected"
+    interface:
+      - "Null0"


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT

arista_eos_show_ip_route.textfsm, arista_eos, `show ip route`


##### SUMMARY

The newest EOS release, e.g. 4.28.0F, changes the output of  `Codes` in `show ip route` which breaks the current template.
The culprit is the following line: 
```
B I - iBGP, B E - eBGP, R - RIP, I L1 - IS-IS level 1,
```
which results in the following error

```
        if rule.new_state:
          raise TextFSMError('Error: %s. Rule Line: %s. Input Line: %s.'
                             % (rule.new_state, rule.line_num, line))

>       raise TextFSMError('State Error raised. Rule Line: %s. Input Line: %s'
                           % (rule.line_num, line))
E       textfsm.parser.TextFSMError: State Error raised. Rule Line: 20. Input Line:        B I - iBGP, B E - eBGP, R - RIP, I L1 - IS-IS level 1,

.tox/py38/lib/python3.8/site-packages/textfsm/parser.py:1024: TextFSMError
```

The PR fixes the issue and adds an extra test case for it.
