### PR TITLE
Create cisco_ios_show_ip_route_vrf_wildcard.textfsm

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_ip_route_vrf_*.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_ip_route_vrf_*.textfsm
@@ -1,0 +1,53 @@
+Value Filldown VRF (\S+)
+Value Filldown PROTOCOL (\w)
+Value Filldown TYPE (\w{0,2})
+Value Required,Filldown NETWORK (\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3})
+Value Filldown MASK (\d{1,2})
+Value DISTANCE (\d+)
+Value METRIC (\d+)
+Value NEXTHOP_IP (\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3})
+Value NEXTHOP_IF ([A-Z][\w\-\.:/]+)
+Value UPTIME (\d[\w:\.]+)
+
+Start
+  # Continue on empty lines
+  ^\s* -> Continue
+  #
+  ^Routing\sTable:\s${VRF}
+  #
+  ^Gateway\sof\slast\sresort\sis\s${NEXTHOP_IP}\sto\snetwork\s${NETWORK}
+  # For "is (variably )subnetted" line, capture mask, clear all values.
+  ^\s+\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}\/${MASK}\sis -> Clear
+  #
+  # Match directly connected route with explicit mask
+  ^${PROTOCOL}(\s|\*)${TYPE}\s+${NETWORK}\/${MASK}\sis\sdirectly\sconnected,\s${NEXTHOP_IF} -> Record
+  #
+  # Match directly connected route (mask is inherited from "is subnetted")
+  ^${PROTOCOL}(\s|\*)${TYPE}\s+${NETWORK}\sis\sdirectly\sconnected,\s${NEXTHOP_IF} -> Record
+  #
+  # Match regular routes, with mask, where all data in same line
+  ^${PROTOCOL}(\s|\*)${TYPE}\s+${NETWORK}\/${MASK}\s\[${DISTANCE}/${METRIC}\]\svia\s${NEXTHOP_IP}(,\s${UPTIME})?(,\s${NEXTHOP_IF})? -> Record
+  #
+  # Match regular route, all one line, where mask is learned from "is subnetted" line
+  ^${PROTOCOL}(\s|\*)${TYPE}\s+${NETWORK}\s\[${DISTANCE}\/${METRIC}\]\svia\s${NEXTHOP_IP}(,\s${UPTIME})?(,\s${NEXTHOP_IF})? -> Record
+  #
+  # Match route with no via statement (Null via protocol)
+  ^${PROTOCOL}(\s|\*)${TYPE}\s+${NETWORK}\/${MASK}\s\[${DISTANCE}/${METRIC}\],\s${UPTIME},\s${NEXTHOP_IF} -> Record
+  #
+  # Match "is a summary" routes (often Null0)
+  ^${PROTOCOL}(\s|\*)${TYPE}\s+${NETWORK}\/${MASK}\sis\sa\ssummary,\s${UPTIME},\s${NEXTHOP_IF} -> Record
+  #
+  # Match regular routes where the network/mask is on the line above the rest of the route
+  ^${PROTOCOL}(\s|\*)${TYPE}\s+${NETWORK}\/${MASK} -> Next
+  #
+  # Match regular routes where the network only (mask from subnetted line) is on the line above the rest of the route
+  ^${PROTOCOL}(\s|\*)${TYPE}\s+${NETWORK} -> Next
+  #
+  # Match the rest of the route information on line below network (and possibly mask)
+  ^\s+\[${DISTANCE}\/${METRIC}\]\svia\s${NEXTHOP_IP}(,\s${UPTIME})?(,\s${NEXTHOP_IF})? -> Record
+  #
+  # Match load-balanced routes
+  ^\s+\[${DISTANCE}\/${METRIC}\]\svia\s${NEXTHOP_IP} -> Record
+  #
+
+EOF


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
New Template for modern IOS routers.

##### COMPONENT
NAME: cisco_ios_show_ip_route_vrf_wild.textfsm CMD: show ip route vrf *

##### SUMMARY
This new template works for Cisco IOS routers that are VRF aware (most I would say). Instead of running a single "show ip route vrf {VRF}" cmd on a device, using the wildcard option "show ip route vrf *" always you to see all routes on the router, on every VRF. This template provides the VRF data as it relates to those routes, on an entry basis.


<!-- Paste verbatim command output below, e.g. before and after your change -->
Below is an routing table
```
#sh ip route vrf *
Codes: L - local, C - connected, S - static, R - RIP, M - mobile, B - BGP
       D - EIGRP, EX - EIGRP external, O - OSPF, IA - OSPF inter area
       N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
       E1 - OSPF external type 1, E2 - OSPF external type 2
       i - IS-IS, su - IS-IS summary, L1 - IS-IS level-1, L2 - IS-IS level-2
       ia - IS-IS inter area, * - candidate default, U - per-user static route
       o - ODR, P - periodic downloaded static route, H - NHRP, l - LISP
       a - application route
       + - replicated route, % - next hop override, p - overrides from PfR

Gateway of last resort is not set


Routing Table: Mgmt
Codes: L - local, C - connected, S - static, R - RIP, M - mobile, B - BGP
       D - EIGRP, EX - EIGRP external, O - OSPF, IA - OSPF inter area
       N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
       E1 - OSPF external type 1, E2 - OSPF external type 2
       i - IS-IS, su - IS-IS summary, L1 - IS-IS level-1, L2 - IS-IS level-2
       ia - IS-IS inter area, * - candidate default, U - per-user static route
       o - ODR, P - periodic downloaded static route, H - NHRP, l - LISP
       a - application route
       + - replicated route, % - next hop override, p - overrides from PfR

Gateway of last resort is not set


Routing Table: CODE-DAVE-INSIDE
Codes: L - local, C - connected, S - static, R - RIP, M - mobile, B - BGP
       D - EIGRP, EX - EIGRP external, O - OSPF, IA - OSPF inter area
       N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
       E1 - OSPF external type 1, E2 - OSPF external type 2
       i - IS-IS, su - IS-IS summary, L1 - IS-IS level-1, L2 - IS-IS level-2
       ia - IS-IS inter area, * - candidate default, U - per-user static route
       o - ODR, P - periodic downloaded static route, H - NHRP, l - LISP
       a - application route
       + - replicated route, % - next hop override, p - overrides from PfR

Gateway of last resort is 10.195.96.1 to network 0.0.0.0

B*    0.0.0.0/0 [20/0] via 10.195.96.1, 6d15h
      3.0.0.0/8 is variably subnetted, 2 subnets, 2 masks
B        3.0.0.0/8 [20/0] via 10.195.96.1, 6d15h
C        3.234.166.213/32 is directly connected, Loopback0
      10.0.0.0/8 is variably subnetted, 14 subnets, 8 masks
B        10.0.0.0/8 [20/0] via 10.195.96.1, 6d15h
B        10.195.49.112/29 [20/0] via 10.195.96.1, 6d15h
B        10.195.53.32/28 [20/0] via 10.195.96.1, 6d15h
C        10.195.96.0/25 is directly connected, Tunnel101530151
L        10.195.96.58/32 is directly connected, Tunnel101530151
S        10.197.70.0/23 is directly connected, Null0
C        10.197.70.0/26 is directly connected, GigabitEthernet0/0/1.70
L        10.197.70.2/32 is directly connected, GigabitEthernet0/0/1.70
C        10.197.70.64/26 is directly connected, GigabitEthernet0/0/1.170
L        10.197.70.66/32 is directly connected, GigabitEthernet0/0/1.170
C        10.197.70.128/25 is directly connected, GigabitEthernet0/0/1.270
L        10.197.70.130/32 is directly connected, GigabitEthernet0/0/1.270
C        10.197.71.0/24 is directly connected, GigabitEthernet0/0/1.370
L        10.197.71.2/32 is directly connected, GigabitEthernet0/0/1.370

Routing Table: CODE-DAVE-OUTSIDE
Codes: L - local, C - connected, S - static, R - RIP, M - mobile, B - BGP
       D - EIGRP, EX - EIGRP external, O - OSPF, IA - OSPF inter area
       N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
       E1 - OSPF external type 1, E2 - OSPF external type 2
       i - IS-IS, su - IS-IS summary, L1 - IS-IS level-1, L2 - IS-IS level-2
       ia - IS-IS inter area, * - candidate default, U - per-user static route
       o - ODR, P - periodic downloaded static route, H - NHRP, l - LISP
       a - application route
       + - replicated route, % - next hop override, p - overrides from PfR

Gateway of last resort is 1.1.1.1 to network 0.0.0.0

S*    0.0.0.0/0 [200/0] via 1.1.1.1
      1.0.0.0/8 is variably subnetted, 2 subnets, 2 masks
C        1.1.1.0/30 is directly connected, GigabitEthernet0/0/0
L        1.1.1.1/32 is directly connected, GigabitEthernet0/0/0


```
