### PR TITLE
Fix huawei vrp display version

### DIFF
--- a/ntc_templates/templates/huawei_vrp_display_version.textfsm
+++ b/ntc_templates/templates/huawei_vrp_display_version.textfsm
@@ -6,4 +6,4 @@ Value UPTIME (.+)
 
 Start
   ^.*software,\s+Version\s+${VRP_VERSION}\s+\(${PRODUCT_VERSION}\)
-  ^(HUAWEI|Quidway)\s+${MODEL}\s+uptime\s+is\s+${UPTIME}\s+ -> Record
+  ^(HUAWEI|Quidway)\s+${MODEL}\s+uptime\s+is\s+${UPTIME}$$ -> Record

--- a/ntc_templates/templates/huawei_vrp_display_version.textfsm
+++ b/ntc_templates/templates/huawei_vrp_display_version.textfsm
@@ -6,4 +6,4 @@ Value UPTIME (.+)
 
 Start
   ^.*software,\s+Version\s+${VRP_VERSION}\s+\(${PRODUCT_VERSION}\)
-  ^HUAWEI\s+${MODEL}\s+uptime\s+is\s+${UPTIME}$$
+  ^(HUAWEI|Quidway)\s+${MODEL}\s+uptime\s+is\s+${UPTIME}\s+ -> Record

--- a/tests/huawei_vrp/display_version/huawei_vrp_display_version3.raw
+++ b/tests/huawei_vrp/display_version/huawei_vrp_display_version3.raw
@@ -1,0 +1,53 @@
+Huawei Versatile Routing Platform Software
+VRP (R) software, Version 5.170 (S7700 V200R010C00SPC600)
+Copyright (C) 2000-2016 HUAWEI TECH CO., LTD
+Quidway S7706 Terabit Routing Switch uptime is 85 weeks, 4 days, 0 hour, 10 minutes
+BKP 0 version information:
+1. PCB      Version  : LE02BAKI VER.E
+2. Support  PoE      : No
+3. Board    Type     : ES0B00770600
+4. MPU Slot Quantity : 2
+5. LPU Slot Quantity : 6
+
+MPU 7(Master)  : uptime is 85 weeks, 4 days, 0 hour, 9 minutes
+SDRAM Memory Size    : 1024    M bytes
+Flash Memory Size    : 64      M bytes
+NVRAM Memory Size    : 512     K bytes
+CF Card1 Memory Size : 488     M bytes
+MPU version information : 
+1. PCB      Version  : LE02SRUA VER.D
+2. MAB      Version  : 8
+3. Board    Type     : ES0D00SRUA00
+4. CPLD0    Version  : 1411.2116
+5. BootROM  Version  : 020a.010f
+6. BootLoad Version  : 020a.012d
+
+MPU 8(Slave)  : uptime is 85 weeks, 4 days, 0 hour, 8 minutes
+SDRAM Memory Size    : 1024    M bytes
+Flash Memory Size    : 64      M bytes
+NVRAM Memory Size    : 512     K bytes
+CF Card1 Memory Size : 488     M bytes
+MPU version information : 
+1. PCB      Version  : LE02SRUA VER.D
+2. MAB      Version  : 8
+3. Board    Type     : ES0D00SRUA00
+4. CPLD0    Version  : 1411.2116
+5. BootROM  Version  : 020a.010f
+6. BootLoad Version  : 020a.012d
+
+LPU 1  : uptime is 85 weeks, 4 days, 0 hour, 7 minutes
+SDRAM Memory Size    : 1024    M bytes
+Flash Memory Size    : 64      M bytes
+LPU version information : 
+1. PCB      Version  : SWC02X32SX2S VER.A
+2. MAB      Version  : 1
+3. Board    Type     : ES1D2S16SX2S
+4. CPLD0    Version  : 1609.0516
+5. BootROM  Version  : 020a.0065
+6. BootLoad Version  : 020a.0079
+
+CMU 9(Master)  : uptime is 85 weeks, 4 days, 0 hour, 9 minutes
+CMU version information : 
+1. PCB      Version  : LE02CMUA VER.B
+2. MAB      Version  : 8
+3. Board    Type     : EH1D200CMU00

--- a/tests/huawei_vrp/display_version/huawei_vrp_display_version3.yml
+++ b/tests/huawei_vrp/display_version/huawei_vrp_display_version3.yml
@@ -3,4 +3,4 @@ parsed_sample:
   - vrp_version: "5.170"
     product_version: "S7700 V200R010C00SPC600"
     model: "S7706 Terabit Routing Switch"
-    uptime: "85 weeks, 4 days, 0 hour, 10"
+    uptime: "85 weeks, 4 days, 0 hour, 10 minutes"

--- a/tests/huawei_vrp/display_version/huawei_vrp_display_version3.yml
+++ b/tests/huawei_vrp/display_version/huawei_vrp_display_version3.yml
@@ -1,0 +1,6 @@
+---
+parsed_sample:
+  - vrp_version: "5.170"
+    product_version: "S7700 V200R010C00SPC600"
+    model: "S7706 Terabit Routing Switch"
+    uptime: "85 weeks, 4 days, 0 hour, 10"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT
<!--- Name of the template, os and command  -->

Template:

huawei_vrf
- display version

##### SUMMARY

huawei S7700 and S12700 series display have some difference.
