### PR TITLE
Fix Mikrotik interface ethernet monitor name once when no link partner advertising

### DIFF
--- a/ntc_templates/templates/mikrotik_routeros_interface_ethernet_monitor_name_once.textfsm
+++ b/ntc_templates/templates/mikrotik_routeros_interface_ethernet_monitor_name_once.textfsm
@@ -17,6 +17,6 @@ Start
   ^\s*tx-flow-control:\s${tx_flow_control}
   ^\s*rx-flow-control:\s${rx_flow_control}
   ^\s*advertising:\s${advertising}
-  ^\s*link-partner-advertising:\s${link_partner_advertising}
+  ^\s*link-partner-advertising:\s*(${link_partner_advertising})?
   ^\s*(?:\d{2}:){2}\d{2}\s+echo:\s*.*$$ -> Next
   ^. -> Error

--- a/tests/mikrotik_routeros/interface_ethernet_monitor_name_once/mikrotik_routeros_interface_ethernet_monitor_name_once2.raw
+++ b/tests/mikrotik_routeros/interface_ethernet_monitor_name_once/mikrotik_routeros_interface_ethernet_monitor_name_once2.raw
@@ -1,0 +1,5 @@
+                     name: ether30
+                    status: no-link
+          auto-negotiation: done
+               advertising: 10M-half,10M-full,100M-half,100M-full,1000M-half,1000M-full
+  link-partner-advertising:

--- a/tests/mikrotik_routeros/interface_ethernet_monitor_name_once/mikrotik_routeros_interface_ethernet_monitor_name_once2.yml
+++ b/tests/mikrotik_routeros/interface_ethernet_monitor_name_once/mikrotik_routeros_interface_ethernet_monitor_name_once2.yml
@@ -1,0 +1,11 @@
+---
+parsed_sample:
+  - name: "ether30"
+    status: "no-link"
+    auto_negotiation: "done"
+    rate: ""
+    full_duplex: ""
+    tx_flow_control: ""
+    rx_flow_control: ""
+    advertising: "10M-half,10M-full,100M-half,100M-full,1000M-half,1000M-full"
+    link_partner_advertising: ""


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request
 - Additional Testing

##### COMPONENT
mikrotik routeros 
interface ethernet monitor {name} once

##### SUMMARY
Fixes #1148 
And adding corresponding test case