### PR TITLE
add Cisco XR show ipv4 int

### DIFF
--- a/ntc_templates/templates/cisco_xr_show_ipv4_interface.textfsm
+++ b/ntc_templates/templates/cisco_xr_show_ipv4_interface.textfsm
@@ -1,0 +1,15 @@
+Value Required INTERFACE (\S+)
+Value LINK_STATUS (\S+)
+Value PROTOCOL (\S+)
+Value PROTOCOL_STATUS (\S+)
+Value VRF (\S+)
+Value IP_ADDRESS (\S+)
+Value MTU (\d+)
+
+
+Start
+  ^\S+\s+is -> Continue.Record
+  ^${INTERFACE}\sis\s${LINK_STATUS},\s+${PROTOCOL}\sprotocol\sis\s${PROTOCOL_STATUS}.*$$
+  ^\s+Vrf\sis\s${VRF}\s.*$$
+  ^\s+Internet\saddress\sis\s${IP_ADDRESS}.*$$
+  ^\s+MTU\sis\s${MTU}\s.*$$

--- a/ntc_templates/templates/cisco_xr_show_ipv4_interface.textfsm
+++ b/ntc_templates/templates/cisco_xr_show_ipv4_interface.textfsm
@@ -8,8 +8,22 @@ Value MTU (\d+)
 
 
 Start
+  ^(Mon?)|(Tue?)|(Wed?)|(Thu?)|(Fri?)|(Sat?)|(Sun?)\s.*$$
   ^\S+\s+is -> Continue.Record
   ^${INTERFACE}\sis\s${LINK_STATUS},\s+${PROTOCOL}\sprotocol\sis\s${PROTOCOL_STATUS}.*$$
   ^\s+Vrf\sis\s${VRF}\s.*$$
   ^\s+Internet\saddress\sis\s${IP_ADDRESS}.*$$
   ^\s+MTU\sis\s${MTU}\s.*$$
+  ^\s+Helper.*$$
+  ^\s+Multicast.*$$
+  ^\s+2(?:2[4-9]|3\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d?|0)){3}$$
+  ^\s+Directed.*$$
+  ^\s+Outgoing.*$$
+  ^\s+Inbound.*$$
+  ^\s+Proxy.*$$
+  ^\s+ICMP redirects.*$$
+  ^\s+ICMP unreachables.*$$
+  ^\s+ICMP mask.*$$
+  ^\s+Table.*$$
+  ^\s*$$
+  ^. -> Error

--- a/ntc_templates/templates/index
+++ b/ntc_templates/templates/index
@@ -396,6 +396,7 @@ cisco_xr_show_interface_brief.textfsm, .*, cisco_xr, sh[[ow]] int[[erface]] br[[
 cisco_xr_admin_show_platform.textfsm, .*, cisco_xr, adm[[in]] sh[[ow]] pla[[tform]]
 cisco_xr_show_install_active.textfsm, .*, cisco_xr, sh[[ow]] install active
 cisco_xr_show_ip_bgp_summary.textfsm, .*, cisco_xr, sh[[ow]] ip b[[gp]] s[[ummary]]
+cisco_xr_show_ipv4_interface.textfsm, .*, cisco_xr, sh[[ow]] ipv4 int[[erface]]
 cisco_xr_show_ipv6_neighbors.textfsm, .*, cisco_xr, sh[[ow]] ipv6 ne[[ighbors]]
 cisco_xr_show_isis_neighbors.textfsm, .*, cisco_xr, sh[[ow]] isis ne[[ighbors]]
 cisco_xr_show_lldp_neighbors.textfsm, .*, cisco_xr, sh[[ow]] lld[[p]] neig[[hbors]]

--- a/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface.raw
+++ b/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface.raw
@@ -1,0 +1,31 @@
+Sun Jun 19 08:45:14.652 UTC
+GigabitEthernet0/0/0/0 is Up, ipv4 protocol is Up
+  Vrf is default (vrfid 0x60000000)
+  Internet address is 10.2.0.2/30
+  MTU is 1514 (1500 is available to IP)
+  Helper address is not set
+  Multicast reserved groups joined: 224.0.0.2 224.0.0.1 224.0.0.9
+      224.0.0.10
+  Directed broadcast forwarding is disabled
+  Outgoing access list is not set
+  Inbound  common access list is not set, access list is not set
+  Proxy ARP is disabled
+  ICMP redirects are never sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  Table Id is 0xe0000000
+GigabitEthernet0/0/0/1 is Up, ipv4 protocol is Up
+  Vrf is default (vrfid 0x60000000)
+  Internet address is 10.0.7.1/30
+  MTU is 1514 (1500 is available to IP)
+  Helper address is not set
+  Multicast reserved groups joined: 224.0.0.2 224.0.0.1 224.0.0.5
+      224.0.0.6
+  Directed broadcast forwarding is disabled
+  Outgoing access list is not set
+  Inbound  common access list is not set, access list is not set
+  Proxy ARP is disabled
+  ICMP redirects are never sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  Table Id is 0xe0000000

--- a/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface.yml
+++ b/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface.yml
@@ -1,0 +1,16 @@
+---
+parsed_sample:
+  - interface: "GigabitEthernet0/0/0/0"
+    ip_address: "10.2.0.2/30"
+    link_status: "Up"
+    mtu: "1514"
+    protocol: "ipv4"
+    protocol_status: "Up"
+    vrf: "default"
+  - interface: "GigabitEthernet0/0/0/1"
+    ip_address: "10.0.7.1/30"
+    link_status: "Up"
+    mtu: "1514"
+    protocol: "ipv4"
+    protocol_status: "Up"
+    vrf: "default"


### PR DESCRIPTION
##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
template: cisco_xr_show_ipv4_interface.textfsm
os: cisco_xr
command: show ipv4 interface

##### SUMMARY
Even if IP addresses are included in the "show interfaces" output, the VRF is missing.