### PR TITLE
Update Arista EOS `show vrf` to handle multiple headers and interface types

### DIFF
--- a/ntc_templates/templates/arista_eos_show_vrf.textfsm
+++ b/ntc_templates/templates/arista_eos_show_vrf.textfsm
@@ -3,7 +3,7 @@ Value RD (\d\S+|<.+>)
 Value List INTERFACES (\w+)
 
 Start
-  ^\s+Vrf\s+RD\s+Protocols\s+State\s+Interfaces -> VRF
+  ^\s+V[rR][fF]\s+RD\s+Protocols\s+State\s+Interfaces -> VRF
   ^Maximum
   ^\s*$$
   ^. -> Error

--- a/ntc_templates/templates/arista_eos_show_vrf.textfsm
+++ b/ntc_templates/templates/arista_eos_show_vrf.textfsm
@@ -1,6 +1,6 @@
 Value VRF (\S+)
 Value RD (\d\S+|<.+>)
-Value List INTERFACES (\w+)
+Value List INTERFACES ([\w\./]+)
 
 Start
   ^\s+V[rR][fF]\s+RD\s+Protocols\s+State\s+Interfaces -> VRF

--- a/tests/arista_eos/show_vrf/arista_eos_show_vrf_3.raw
+++ b/tests/arista_eos/show_vrf/arista_eos_show_vrf_3.raw
@@ -1,0 +1,8 @@
+Maximum number of vrfs allowed: 1023
+   VRF           RD              Protocols       State            Interfaces
+------------- --------------- --------------- ------------------- ------------------------------
+   default       <not set>       ipv4,ipv6       v4:routing,      Ethernet1, Ethernet50/1,
+                                                 v6:no routing    Loopback0, Vlan100, Vlan200,
+                                                                  Vlan300, Vlan400, Vlan500,
+   management    <not set>       ipv4,ipv6       v4:routing,      Ethernet2.10, Ethernet50/1.10,
+                                                 v6:no routing    Loopback1

--- a/tests/arista_eos/show_vrf/arista_eos_show_vrf_3.yml
+++ b/tests/arista_eos/show_vrf/arista_eos_show_vrf_3.yml
@@ -1,0 +1,19 @@
+---
+parsed_sample:
+  - vrf: "default"
+    rd: "<not set>"
+    interfaces:
+      - "Ethernet1"
+      - "Ethernet50/1"
+      - "Loopback0"
+      - "Vlan100"
+      - "Vlan200"
+      - "Vlan300"
+      - "Vlan400"
+      - "Vlan500"
+  - vrf: "management"
+    rd: "<not set>"
+    interfaces:
+      - "Ethernet2.10"
+      - "Ethernet50/1.10"
+      - "Loopback1"


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
arista_eos_show_vrf

##### SUMMARY
Some versions of Arista EOS capitalize the word VRF in the output header of `show vrf`. Additionally, the regex for interface names did not handle cases where the interface belonged to a line card, was a subinterface, or both. This PR updates the template to handle both headers and the mentioned types of interfaces.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Maximum number of vrfs allowed: 1023
   VRF           RD              Protocols       State            Interfaces
------------- --------------- --------------- ------------------- ------------------------------
   default       <not set>       ipv4,ipv6       v4:routing,      Ethernet1, Ethernet50/1,
                                                 v6:no routing    Loopback0, Vlan100, Vlan200,
                                                                  Vlan300, Vlan400, Vlan500,
   management    <not set>       ipv4,ipv6       v4:routing,      Ethernet2.10, Ethernet50/1.10,
                                                 v6:no routing    Loopback1
```
