### PR TITLE
fix(mikrotik): system routerboard print - fix corner case where warning messages are added

### DIFF
--- a/ntc_templates/templates/mikrotik_routeros_system_routerboard_print.textfsm
+++ b/ntc_templates/templates/mikrotik_routeros_system_routerboard_print.textfsm
@@ -1,5 +1,5 @@
 Value routerboard (\S+)
-Value board_name (\S+)
+Value board_name (.+)
 Value hardware_model (\S+)
 Value revision (\S+)
 Value serial_number (\S+)
@@ -9,6 +9,7 @@ Value current_firmware ([\d.]+)
 Value upgrade_firmware ([\d.]+)
 
 Start
+  ^\s*;;;.* -> Next
   ^\s*routerboard:\s${routerboard}
   ^\s*board-name:\s${board_name}
   ^\s*model:\s${hardware_model}

--- a/tests/mikrotik_routeros/system_routerboard_print/mikrotik_routeros_system_routerboard_print2.raw
+++ b/tests/mikrotik_routeros/system_routerboard_print/mikrotik_routeros_system_routerboard_print2.raw
@@ -1,0 +1,9 @@
+;;; Firmware upgraded successfully, please reboot for changes to take effect!
+       routerboard: yes
+        board-name: hAP ac^3
+             model: RBD53iG-5HacD2HnD
+     serial-number: HCQ08FX50J7
+     firmware-type: ipq4000
+  factory-firmware: 7.2.3
+  current-firmware: 7.2.3
+  upgrade-firmware: 7.5

--- a/tests/mikrotik_routeros/system_routerboard_print/mikrotik_routeros_system_routerboard_print2.yml
+++ b/tests/mikrotik_routeros/system_routerboard_print/mikrotik_routeros_system_routerboard_print2.yml
@@ -1,0 +1,11 @@
+---
+parsed_sample:
+  - routerboard: "yes"
+    board_name: "hAP ac^3"
+    hardware_model: "RBD53iG-5HacD2HnD"
+    revision: ""
+    serial_number: "HCQ08FX50J7"
+    firmware_type: "ipq4000"
+    factory_firmware: "7.2.3"
+    current_firmware: "7.2.3"
+    upgrade_firmware: "7.5"


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug fix in template

##### COMPONENT
Mikrotik
routeros
system routerboard print

##### SUMMARY
Some warning messages could be added by Mikrotik on the command.
I added a second test with an example (Mikrotik asks to reboot the router because of an upgrade, then print the information of the command)