### PR TITLE
Update Huawei VRP display version template

### DIFF
--- a/ntc_templates/templates/huawei_vrp_display_version.textfsm
+++ b/ntc_templates/templates/huawei_vrp_display_version.textfsm
@@ -1,11 +1,11 @@
 Value VRP_VERSION (\S+)
 Value PRODUCT_VERSION (.+)
-Value MODEL (.+)
+Value MODEL (((?!\sRouter).)+)
 Value UPTIME (.+)
 Value PATCH_VERSION (\S+)
 
 
 Start
   ^.*software,\s+Version\s+${VRP_VERSION}\s+\(${PRODUCT_VERSION}\)
-  ^(HUAWEI|Huawei)\s+${MODEL}\s+uptime\s+is\s+${UPTIME}$$
+  ^H(UAWEI|uawei)\s+${MODEL}\s+(Router\s+)?uptime\s+is\s+${UPTIME}$$
   ^Patch\s+[Vv]ersion\s*:\s+${PATCH_VERSION}

--- a/tests/huawei_vrp/display_version/huawei_vrp_display_version3.yml
+++ b/tests/huawei_vrp/display_version/huawei_vrp_display_version3.yml
@@ -2,6 +2,6 @@
 parsed_sample:
   - vrp_version: "5.170"
     product_version: "AR6280 V300R019C10SPC300"
-    model: "AR6280 Router"
+    model: "AR6280"
     uptime: "60 weeks, 4 days, 11 hours, 20 minutes"
     patch_version: ""

--- a/tests/huawei_vrp/display_version/huawei_vrp_display_version4.raw
+++ b/tests/huawei_vrp/display_version/huawei_vrp_display_version4.raw
@@ -1,0 +1,13 @@
+Huawei Versatile Routing Platform Software
+VRP (R) software, Version 5.170 (AR610 V300R019C13SPC200)
+Copyright (C) 2011-2021 HUAWEI TECH CO., LTD
+Huawei AR617VW-LTE4EA Router uptime is 0 week, 0 day, 15 hours, 16 minutes
+
+MPU 0(Master) : uptime is 0 week, 0 day, 15 hours, 15 minutes
+SDRAM Memory Size    : 1024    M bytes
+Flash 0 Memory Size  : 1024    M bytes
+MPU version information : 
+1. PCB      Version  : AR-SRU617 VER.C
+2. MAB      Version  : 0
+3. Board    Type     : AR617VW-LTE4EA
+4. BootROM  Version  : 1

--- a/tests/huawei_vrp/display_version/huawei_vrp_display_version4.yml
+++ b/tests/huawei_vrp/display_version/huawei_vrp_display_version4.yml
@@ -1,0 +1,7 @@
+---
+parsed_sample:
+  - vrp_version: "5.170"
+    product_version: "AR610 V300R019C13SPC200"
+    model: "AR617VW-LTE4EA"
+    uptime: "0 week, 0 day, 15 hours, 16 minutes"
+    patch_version: ""


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
huawei, VRP, display version

##### SUMMARY
Display version command for Huawei router is little bit different.
Huawei is not uppercase and there is "Router" text append in response.

https://support.huawei.com/enterprise/en/doc/EDOC1100064353/b2944170/display-version
