### PR TITLE
address bug 1225

### DIFF
--- a/ntc_templates/templates/arista_eos_show_ip_route.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_route.textfsm
@@ -17,6 +17,9 @@ Start
   # Match for codes
   ^\s+.+-.+
   ^\s*$$ -> Routes
+  # Ignore IP routing not enabled
+  ^\! IP routing not enabled
+  # Error on everything else
   ^. -> Error
 
 Routes
@@ -27,4 +30,7 @@ Routes
   ^\s*$$ -> Record
   ^VRF(\s+name)?:\s+${VRF}\s*$$ -> Start
   ^Gateway\s+of\s+last
+  # Ignore IP routing not enabled
+  ^\! IP routing not enabled
+  # Error on everything else
   ^. -> Error

--- a/tests/arista_eos/show_ip_route/arista_eos_show_ip_route6.raw
+++ b/tests/arista_eos/show_ip_route/arista_eos_show_ip_route6.raw
@@ -1,0 +1,19 @@
+VRF: MGMT
+Codes: C - connected, S - static, K - kernel,
+       O - OSPF, IA - OSPF inter area, E1 - OSPF external type 1,
+       E2 - OSPF external type 2, N1 - OSPF NSSA external type 1,
+       N2 - OSPF NSSA external type2, B - Other BGP Routes,
+       B I - iBGP, B E - eBGP, R - RIP, I L1 - IS-IS level 1,
+       I L2 - IS-IS level 2, O3 - OSPFv3, A B - BGP Aggregate,
+       A O - OSPF Summary, NG - Nexthop Group Static Route,
+       V - VXLAN Control Service, M - Martian,
+       DH - DHCP client installed default route,
+       DP - Dynamic Policy Route, L - VRF Leaked,
+       G  - gRIBI, RC - Route Cache Route
+
+Gateway of last resort:
+ S        0.0.0.0/0 [1/0] via 172.20.20.1, Management0
+
+ C        172.20.20.0/24 is directly connected, Management0
+
+! IP routing not enabled

--- a/tests/arista_eos/show_ip_route/arista_eos_show_ip_route6.yml
+++ b/tests/arista_eos/show_ip_route/arista_eos_show_ip_route6.yml
@@ -1,23 +1,24 @@
 ---
-- DIRECT: ""
-  DISTANCE: "1"
-  INTERFACE:
-    - "Management0"
-  MASK: "0"
-  METRIC: "0"
-  NETWORK: "0.0.0.0"
-  NEXT_HOP:
-    - "172.20.20.1"
-  PROTOCOL: "S"
-  VRF: "MGMT"
-- DIRECT: "directly"
-  DISTANCE: ""
-  INTERFACE:
-    - "Management0"
-  MASK: "24"
-  METRIC: ""
-  NETWORK: "172.20.20.0"
-  NEXT_HOP:
-    - "connected"
-  PROTOCOL: "C"
-  VRF: "MGMT"
+parsed_sample:
+  - DIRECT: ""
+    DISTANCE: "1"
+    INTERFACE:
+      - "Management0"
+    MASK: "0"
+    METRIC: "0"
+    NETWORK: "0.0.0.0"
+    NEXT_HOP:
+      - "172.20.20.1"
+    PROTOCOL: "S"
+    VRF: "MGMT"
+  - DIRECT: "directly"
+    DISTANCE: ""
+    INTERFACE:
+      - "Management0"
+    MASK: "24"
+    METRIC: ""
+    NETWORK: "172.20.20.0"
+    NEXT_HOP:
+      - "connected"
+    PROTOCOL: "C"
+    VRF: "MGMT"

--- a/tests/arista_eos/show_ip_route/arista_eos_show_ip_route6.yml
+++ b/tests/arista_eos/show_ip_route/arista_eos_show_ip_route6.yml
@@ -1,3 +1,4 @@
+---
 - DIRECT: ""
   DISTANCE: "1"
   INTERFACE:
@@ -7,7 +8,7 @@
   NETWORK: "0.0.0.0"
   NEXT_HOP:
     - "172.20.20.1"
-  PROTOCOL: S
+  PROTOCOL: "S"
   VRF: "MGMT"
 - DIRECT: "directly"
   DISTANCE: ""

--- a/tests/arista_eos/show_ip_route/arista_eos_show_ip_route6.yml
+++ b/tests/arista_eos/show_ip_route/arista_eos_show_ip_route6.yml
@@ -1,24 +1,24 @@
 ---
 parsed_sample:
-  - DIRECT: ""
-    DISTANCE: "1"
-    INTERFACE:
+  - direct: ""
+    distance: "1"
+    interface:
       - "Management0"
-    MASK: "0"
-    METRIC: "0"
-    NETWORK: "0.0.0.0"
-    NEXT_HOP:
+    mask: "0"
+    metric: "0"
+    network: "0.0.0.0"
+    next_hop:
       - "172.20.20.1"
-    PROTOCOL: "S"
-    VRF: "MGMT"
-  - DIRECT: "directly"
-    DISTANCE: ""
-    INTERFACE:
+    protocol: "S"
+    vrf: "MGMT"
+  - direct: "directly"
+    distance: ""
+    interface:
       - "Management0"
-    MASK: "24"
-    METRIC: ""
-    NETWORK: "172.20.20.0"
-    NEXT_HOP:
+    mask: "24"
+    metric: ""
+    network: "172.20.20.0"
+    next_hop:
       - "connected"
-    PROTOCOL: "C"
-    VRF: "MGMT"
+    protocol: "C"
+    vrf: "MGMT"

--- a/tests/arista_eos/show_ip_route/arista_eos_show_ip_route6.yml
+++ b/tests/arista_eos/show_ip_route/arista_eos_show_ip_route6.yml
@@ -1,0 +1,22 @@
+- DIRECT: ""
+  DISTANCE: "1"
+  INTERFACE:
+    - "Management0"
+  MASK: "0"
+  METRIC: "0"
+  NETWORK: "0.0.0.0"
+  NEXT_HOP:
+    - "172.20.20.1"
+  PROTOCOL: S
+  VRF: "MGMT"
+- DIRECT: "directly"
+  DISTANCE: ""
+  INTERFACE:
+    - "Management0"
+  MASK: "24"
+  METRIC: ""
+  NETWORK: "172.20.20.0"
+  NEXT_HOP:
+    - "connected"
+  PROTOCOL: "C"
+  VRF: "MGMT"


### PR DESCRIPTION
closes #1225 

Updates arista_eos_show_ip_route.textfsm to handle vrfs where no ip routing is enabled.