### PR TITLE
Fixed TYPE regex to include non-dynamic addresses

### DIFF
--- a/ntc_templates/templates/aruba_aoscx_show_mac-address-table.textfsm
+++ b/ntc_templates/templates/aruba_aoscx_show_mac-address-table.textfsm
@@ -1,6 +1,6 @@
 Value MAC (\S+)
 Value VLAN (\d+)
-Value TYPE ([a-z]+)
+Value TYPE ([a-z-]+)
 Value PORT (\S+)
 
 Start


### PR DESCRIPTION
Found a small error with MAC addresses that had type **port-access-security**.  They weren't being processed properly by the regex.

Without the fix parsing would fail on line 5

MAC age-time            : 300 seconds
Number of MAC addresses : 104

MAC Address          VLAN     Type                      Port
--------------------------------------------------------------
00:01:00:00:00:01     1000     dynamic                   lag1
00:01:00:00:00:01     1000     dynamic                   lag1
00:01:00:00:00:01     1000     dynamic                   lag1
00:01:00:00:00:01     1000     dynamic                   lag1
00:01:00:00:00:01     2015     port-access-security      1/1/30
00:01:00:00:00:01      2015     port-access-security      1/1/27
00:01:00:00:00:01    2015     dynamic                   lag1