### PR TITLE
Fix HP Comware displ inteface

### DIFF
--- a/ntc_templates/templates/hp_comware_display_interface.textfsm
+++ b/ntc_templates/templates/hp_comware_display_interface.textfsm
@@ -23,8 +23,8 @@ Start
   ^Bandwidth:\s+${BANDWIDTH}
   ^Maximum\s+transmission\s+unit:\s+${MTU}
   ^Maximum\s+frame\s+length:\s+${L2MTU}
-  ^Internet\s+address:\s+${IP_ADDRESS}\s+\(Primary\)
-  ^Internet\s+address:\s+${IP_ADDRESS}\s+\(Sub\)
+  ^Internet\s+[Aa]ddress:\s+${IP_ADDRESS}\s+\([Pp]rimary\)
+  ^Internet\s+[Aa]ddress:\s+${IP_ADDRESS}\s+\([Ss]ub\)
   ^IP\s+packet\s+frame\s+type:\s+Ethernet\s+II,\s+hardware\s+address:\s+${HW_ADDRESS}
   ^IPv6\s+packet\s+frame\s+type:\s+Ethernet\s+II,\s+hardware\s+address:\s+${HW_ADDRESS}
   ^${SPEED}\s+mode,\s+${DUPLEX}\s+mode
@@ -144,13 +144,21 @@ Start
   ^\s*IPv4\s+traffic
   ^\s*IPv6\s+traffic
   ^\s+Tagged\s+VLAN
-  ^\s+UnTagged\s+VLAN
-  ^\s*Input
-  ^\s*Output
+  ^\s+Un[tT]agged\s+VLAN
+  ^\s*[Ii]nput
+  ^\s*[Oo]utput
+  ^\s*Physical
+  ^\s*Internet\s+protocol
+  ^\s*Port\s+hardware
   ^\s{6,}\d+\s+unicasts
   ^\s{6,}\d+\s+CRC
   ^\s{6,}\d+\s+aborts
   ^\s{6,}\d+\s+lost
-  ^\s{6,}.*ignored
+  ^\s{6,}\d+\s+broadcasts
+  ^\s{6,}\d+\s+ignored
+  ^\s{6,}-\s+ignored
+  ^\s{6,}-\s+frame
+  ^\s{6,}-\s+aborts
+  ^\s{6,}-\s+lost\s+carrier
   ^. -> Error
   ^\s*$$ ^. -> Error

--- a/tests/hp_comware/display_interface/hp_comware_display_interface2.raw
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface2.raw
@@ -1,0 +1,79 @@
+FortyGigE1/0/49
+Current state: DOWN
+Line protocol state: DOWN
+IP packet frame type: Ethernet II, hardware address: bcea-fa19-5f8c
+Description: FortyGigE1/0/49 Interface
+Bandwidth: 40000000 kbps
+Loopback is not set
+Media type is not sure, port hardware type is No connector
+Unknown-speed mode, unknown-duplex mode
+Link speed type is autonegotiation, link duplex type is autonegotiation
+Flow-control is not enabled
+Maximum frame length: 10000
+Allow jumbo frames to pass
+Broadcast max-ratio: 100%
+Multicast max-ratio: 100%
+Unicast max-ratio: 100%
+PVID: 1
+MDI type: Automdix
+Port link-type: Access
+ Tagged VLANs:   None
+ Untagged VLANs: 1
+Port priority: 0
+Last link flapping: Never
+Last clearing of counters: Never
+ Peak input rate: 0 bytes/sec, at 2011-01-01 03:03:20 
+ Peak output rate: 0 bytes/sec, at 2011-01-01 03:03:20 
+ Last 300 second input: 0 packets/sec 0 bytes/sec -%
+ Last 300 second output: 0 packets/sec 0 bytes/sec -%
+ Input (total):  0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Input (normal):  0 packets, - bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, - overruns, 0 aborts
+         - ignored, - parity errors
+ Output (total): 0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Output (normal): 0 packets, - bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Output: 0 output errors, - underruns, - buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, - no carrier
+
+InLoopBack0
+Current state: UP
+Line protocol state: UP(spoofing)
+Description: InLoopBack0 Interface
+Bandwidth: 0 kbps
+Maximum transmission unit: 1536
+Physical: InLoopBack
+Last 300 seconds input rate: 0 bytes/sec, 0 bits/sec, 0 packets/sec
+Last 300 seconds output rate: 0 bytes/sec, 0 bits/sec, 0 packets/sec
+Input: 0 packets, 0 bytes, 0 drops
+Output: 5 packets, 420 bytes, 0 drops
+
+M-GigabitEthernet0/0/0
+Current state: DOWN
+Line protocol state: DOWN
+Description: M-GigabitEthernet0/0/0 Interface
+Bandwidth: 1000000 kbps
+Maximum transmission unit: 1500
+Internet protocol processing: Disabled
+IP packet frame type: Ethernet II, hardware address: bcea-fa19-8bec
+IPv6 packet frame type: Ethernet II, hardware address: bcea-fa19-8bec
+Last link flapping: Never
+Last clearing of counters: Never
+Media type is twisted pair, loopback not set
+Port hardware type is 1000_BASE_T
+Unknown-speed mode, unknown-duplex mode
+Link speed type is autonegotiation , Link duplex type is autonegotiation
+input:   0 packets, 0 bytes
+         0 broadcasts,0 multicasts
+input:   - input errors,- runts,- giants,- throttles,0 CRC
+         - frame,- overruns,- aborts,- ignored,- parity errors
+output:  0 packets, 0 bytes
+         0 broadcasts,0 multicasts
+output:  - output errors,- underruns,- buffer failures
+         - aborts,- deferred,0 collisions,0 late collisions
+         - lost carrier,- no carrier

--- a/tests/hp_comware/display_interface/hp_comware_display_interface2.yml
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface2.yml
@@ -1,0 +1,50 @@
+---
+parsed_sample:
+  - intf: "FortyGigE1/0/49"
+    line_status: "DOWN"
+    protocol_status: "DOWN"
+    hw_address:
+      - "bcea-fa19-5f8c"
+    description: "FortyGigE1/0/49 Interface"
+    bandwidth: "40000000 kbps"
+    speed: "Unknown-speed"
+    duplex: "unknown-duplex"
+    mtu: ""
+    l2mtu: "10000"
+    vlan_native: "1"
+    ip_address: []
+    port_link_type: "Access"
+    vlan_passing: []
+    vlan_permitted: []
+  - intf: "InLoopBack0"
+    line_status: "UP"
+    protocol_status: "UP(spoofing)"
+    hw_address: []
+    description: "InLoopBack0 Interface"
+    bandwidth: "0 kbps"
+    speed: ""
+    duplex: ""
+    mtu: "1536"
+    l2mtu: ""
+    vlan_native: ""
+    ip_address: []
+    port_link_type: ""
+    vlan_passing: []
+    vlan_permitted: []
+  - intf: "M-GigabitEthernet0/0/0"
+    line_status: "DOWN"
+    protocol_status: "DOWN"
+    hw_address:
+      - "bcea-fa19-8bec"
+      - "bcea-fa19-8bec"
+    description: "M-GigabitEthernet0/0/0 Interface"
+    bandwidth: "1000000 kbps"
+    speed: "Unknown-speed"
+    duplex: "unknown-duplex"
+    mtu: "1500"
+    l2mtu: ""
+    vlan_native: ""
+    ip_address: []
+    port_link_type: ""
+    vlan_passing: []
+    vlan_permitted: []


### PR DESCRIPTION
Adjust template with data coming from production switches (case insensitive, additional output dropped.
Fix:  ntc_templates/templates/hp_comware_display_interface.textfsm
Add: new tests