### PR TITLE
Update Cisco AireOS WLC show inventory

### DIFF
--- a/ntc_templates/templates/cisco_wlc_ssh_show_inventory.textfsm
+++ b/ntc_templates/templates/cisco_wlc_ssh_show_inventory.textfsm
@@ -8,6 +8,7 @@ Value SN (\w+)
 
 Start
   ^Burned-in\s+MAC\s+Address\.+\s+${BIA_MAC}
+  ^Power\sSupply\s\d\.*\s(Present|Absent)
   ^Maximum\s+number\s+of\s+APs\s+supported\.+\s+${MAX_AP_NUM}
   ^NAME:\s+"${NAME}"\s+,\s*DESCR:\s+"${DESCRIPTION}"
   ^PID:\s+${PID},\s*VID:\s+${VID},\s*SN:\s+${SN} -> Record

--- a/tests/cisco_wlc_ssh/show_inventory/cisco_wlc_ssh_show_inventory2.raw
+++ b/tests/cisco_wlc_ssh/show_inventory/cisco_wlc_ssh_show_inventory2.raw
@@ -1,0 +1,6 @@
+Burned-in MAC Address............................ 18:B7:38:F4:CE:40
+Power Supply 1................................... Present, OK
+Power Supply 2................................... Absent
+Maximum number of APs supported.................. 500
+NAME: "Chassis"    , DESCR: "Cisco 5500 Series Wireless LAN Controller"
+PID: AIR-CT5508-K9,  VID: V03,  SN: FCW1234L25Y

--- a/tests/cisco_wlc_ssh/show_inventory/cisco_wlc_ssh_show_inventory2.yml
+++ b/tests/cisco_wlc_ssh/show_inventory/cisco_wlc_ssh_show_inventory2.yml
@@ -1,0 +1,9 @@
+---
+parsed_sample:
+  - bia_mac: "18:B7:38:F4:CE:40"
+    max_ap_num: "500"
+    name: "Chassis"
+    description: "Cisco 5500 Series Wireless LAN Controller"
+    pid: "AIR-CT5508-K9"
+    vid: "V03"
+    sn: "FCW1234L25Y"


### PR DESCRIPTION
Some devices have the following lines present
`Power Supply 1................................... Present, OK
Power Supply 2................................... Absent`

And that's where it broke for me. This change doesn't record that information but at least it runs.