### PR TITLE
XR show ipv4 int fails on Int prot proc disabled

### DIFF
--- a/ntc_templates/templates/cisco_xr_show_ipv4_interface.textfsm
+++ b/ntc_templates/templates/cisco_xr_show_ipv4_interface.textfsm
@@ -17,6 +17,7 @@ Start
   ^\s+Helper.*$$
   ^\s+Multicast.*$$
   ^\s+2(?:2[4-9]|3\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d?|0)){3}$$
+  ^\s+Internet\s+protocol.*$$
   ^\s+Directed.*$$
   ^\s+Outgoing.*$$
   ^\s+Inbound.*$$

--- a/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface1.raw
+++ b/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface1.raw
@@ -1,0 +1,18 @@
+Mon Feb 13 17:30:47.464 UTC
+MgmtEth0/0/CPU0/0 is Up, ipv4 protocol is Up
+  Vrf is default (vrfid 0x60000000)
+  Internet address is 172.25.82.44/24
+  MTU is 1514 (1500 is available to IP)
+  Helper address is not set
+  Multicast reserved groups joined: 224.0.0.2 224.0.0.1
+  Directed broadcast forwarding is disabled
+  Outgoing access list is not set
+  Inbound  common access list is not set, access list is not set
+  Proxy ARP is disabled
+  ICMP redirects are never sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  Table Id is 0xe0000000
+GigabitEthernet0/0/0/0 is Shutdown, ipv4 protocol is Down
+  Vrf is default (vrfid 0x60000000)
+  Internet protocol processing disabled

--- a/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface1.yml
+++ b/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface1.yml
@@ -1,0 +1,16 @@
+---
+parsed_sample:
+  - interface: "MgmtEth0/0/CPU0/0"
+    ip_address: "172.25.82.44/24"
+    link_status: "Up"
+    mtu: "1514"
+    protocol: "ipv4"
+    protocol_status: "Up"
+    vrf: "default"
+  - interface: "GigabitEthernet0/0/0/0"
+    ip_address: ""
+    link_status: "Shutdown"
+    mtu: ""
+    protocol: "ipv4"
+    protocol_status: "Down"
+    vrf: "default"


### PR DESCRIPTION
When Cisco XR interfaces are in shutdown state, the following line must be dropped:

~~~
Internet protocol processing disabled
~~~
