### PR TITLE
[fix] hp_procurve_show_interfaces_brief.textfsm

### DIFF
--- a/ntc_templates/templates/hp_procurve_show_interfaces_brief.textfsm
+++ b/ntc_templates/templates/hp_procurve_show_interfaces_brief.textfsm
@@ -9,7 +9,7 @@ Value FLOW_CTRL (on|off)
 Value BCAST_LIMIT (\d+)
 
 Start
-  ^\s+Status.*Status\s*
+  ^\s+Status.*Status\s*$$
   ^\s*$$
   ^\s+\|\s+Intrusion\s+MDI\s+Flow(?:\s+Bcast)?\s*$$
   ^\s+Port\s+Type\s+\|\s+Alert\s+Enabled\s+Status\s+Mode\s+Mode\s+Ctrl\s*$$ -> showintbrief1
@@ -20,11 +20,12 @@ showintbrief1
   ^\s+${PORT}\s+${TYPE}\s+\|\s+${INTRUSION_ALERT}\s+${ENABLED}\s+${STATUS}\s+${MODE}\s+(?:${MDI_MODE}\s+)?${FLOW_CTRL}\s*$$ -> Record
   ^\s*-+(?:\s|-|\+)+$$
   ^\s*$$
+  ^\s+\*.*$$
   ^. -> Error
 
 showintbrief2
   ^\s+${PORT}\s+${TYPE}\s+\|\s+${INTRUSION_ALERT}\s+${ENABLED}\s+${STATUS}\s+${MODE}\s+(?:${MDI_MODE}\s+)?${FLOW_CTRL}\s+${BCAST_LIMIT}\s*$$ -> Record
   ^\s*-+(?:\s|-|\+)+$$
   ^\s*$$
+  ^\s+\*.*$$
   ^. -> Error
-

--- a/tests/hp_procurve/show_interfaces_brief/show_interfaces_brief.raw
+++ b/tests/hp_procurve/show_interfaces_brief/show_interfaces_brief.raw
@@ -55,3 +55,4 @@
   50    100/1000T  | No        Yes     Down   1000FDx    MDI  off
   51               | No        Yes     Down   .               off
   52               | No        Yes     Down   .               off
+ * third-party transceiver

--- a/tests/hp_procurve/show_interfaces_brief/show_interfaces_brief_bcast.raw
+++ b/tests/hp_procurve/show_interfaces_brief/show_interfaces_brief_bcast.raw
@@ -27,3 +27,4 @@
   22           100/1000T  | No        Yes     Down   1000FDx    Auto off  0
   23           100/1000T  | No        Yes     Down   1000FDx    Auto off  0
   24           100/1000T  | No        Yes     Up     100FDx     MDI  off  0
+ * third-party transceiver


### PR DESCRIPTION
[fix] hp_procurve_show_interfaces_brief.textfsm, support "* third-party transceiver"
------------------------------------------------------------------------------------------

If the switch has a plugged-in third-party transceiver
and the appropriate "allow-unsupported-transceiver" command is configured,
then a line "* third-party transceiver" appears at the end of the output and raises a TextFSMError.

.. code:: text

	 Status and Counters - Port Status
	
	                   | Intrusion                           MDI  Flow
	  Port  Type       | Alert     Enabled Status Mode       Mode Ctrl
	  ----- ---------- + --------- ------- ------ ---------- ---- ----
	  1     10/100TX   | No        Yes     Up     100FDx     MDIX off
	  2     10/100TX   | No        Yes     Down   10FDx      MDI  off
	  3     10/100TX   | Yes       Yes     Down   10FDx      MDI  off
	  ...
	  50    100/1000T  | No        Yes     Down   1000FDx    MDI  off
	  51               | No        Yes     Down   .               off
	  52               | No        Yes     Down   .               off
	 * third-party transceiver
