### PR TITLE
Docs: add invoke local usage example to docs

### DIFF
--- a/docs/dev/dev_environment.md
+++ b/docs/dev/dev_environment.md
@@ -13,7 +13,7 @@ This is a quick reference guide if you're already familiar with the development 
 
 The [Invoke](http://www.pyinvoke.org/) library is used to provide some helper commands based on the environment. There are a few configuration parameters which can be passed to Invoke to override the default configuration:
 
-- `local`: a boolean flag indicating if invoke tasks should be run on the host or inside the docker containers (default: False, commands will be run in docker containers)
+- `--local`: a boolean flag indicating if invoke tasks should be run on the host or inside the docker containers (default: False, when ommitting `--local` tasks will be run in docker containers) [Local testing example](dev_parser.md#local-testing)
 
 Using **Invoke** these configuration options can be overridden using [several methods](https://docs.pyinvoke.org/en/stable/concepts/configuration.html). Perhaps the simplest is setting an environment variable `INVOKE_NETUTILS_VARIABLE_NAME` where `VARIABLE_NAME` is the variable you are trying to override. There is an example `invoke.yml` (`invoke.example.yml`) in this directory which can be used as a starting point.
 

--- a/docs/dev/dev_parser.md
+++ b/docs/dev/dev_parser.md
@@ -239,6 +239,8 @@ To add additional raw/parsed tests for a command:
 
 You can test your changes locally within your Git branch before submitting a PR.
 
+### Dockerized Testing
+
 ```bash
 % invoke tests
 DOCKER - Running command: black --check --diff . container: ntc_templates:3.1.0-py3.7
@@ -255,3 +257,23 @@ DOCKER - Running command: yamllint . container: ntc_templates:3.1.0-py3.7
 ```
 
 > Note: Omitted for brevity.
+
+### Local Testing
+
+```bash
+% poetry shell
+% poetry install
+% invoke tests --local
+LOCAL - Running command black --check --diff .
+All done! ✨ 🍰 ✨
+9 files would be left unchanged.
+LOCAL - Running command flake8 . --config .flake8
+LOCAL - Running command find . -name "*.py" | xargs pylint
+
+--------------------------------------------------------------------
+Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
+
+LOCAL - Running command yamllint .
+
+[... skipping remaining output for brevity ...]
+```


### PR DESCRIPTION
Based on a broken link in the poetry section of dev_environment.md (section linked below) it seems that some of the local poetry development documentation may have been pruned back.
https://github.com/networktocode/ntc-templates/blob/master/docs/dev/dev_environment.md#poetry <<< Local Development Environment

Tries to link to https://github.com/mjbear/ntc-templates/blob/docs_invoke_local/docs/dev/dev_environment.md#local-poetry-development-environment

Added an example and changed the invoke local flag docs to be more clear.

Thank you!

*Edit:* added details as to the text of the seemingly broken link within the docs