### PR TITLE
add support for bgp summary found on 7124SX

### DIFF
--- a/ntc_templates/templates/arista_eos_show_ip_bgp_summary.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_bgp_summary.textfsm
@@ -16,6 +16,7 @@ Value STATE_PFXACC (\d+)
 Start
   ^BGP.+?VRF\s+${VRF}\s*$$
   ^\s*Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+InQ\s+OutQ\s+Up/Down\s+State/PfxRcd\s*$$
+  ^\s*Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+InQ\s+OutQ\s+Up/Down\s+State\s+PfxRcd\s*$$
   ^\s*Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+InQ\s+OutQ\s+Up/Down\s+State\s+PfxRcd\s+PfxAcc\s*$$
   ^\s*Description\s+Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+InQ\s+OutQ\s+Up/Down\s+State\s+PfxRcd\s+PfxAcc\s*$$
   ^.+\s+${ROUTER_ID},\s+[Ll]ocal\s+[Aa][Ss]\s+[Nn]umber\s+${LOCAL_AS}
@@ -23,6 +24,7 @@ Start
   ^\s+${DESCRIPTION}\s+${BGP_NEIGH}\s+\d+\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE}\s+${STATE_PFXRCD}\s+${STATE_PFXACC} -> Record
   ^\s+${BGP_NEIGH}\s+\d+\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE}\s+ -> Record
   ^\s+${BGP_NEIGH}\s+\d+\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE}\s* -> Record
+  ^${BGP_NEIGH}\s+\d+\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE}\s+${STATE_PFXRCD} -> Record
   ^${BGP_NEIGH}\s+\d+\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE_PFXRCD} -> Record
   ^Neighbor\s+Status\s+Codes:
   ^\s*$$

--- a/tests/arista_eos/show_ip_bgp_summary/arista_eos_show_ip_bgp_summary4.raw
+++ b/tests/arista_eos/show_ip_bgp_summary/arista_eos_show_ip_bgp_summary4.raw
@@ -1,0 +1,3 @@
+BGP router identifier 10.26.0.22, local AS number 65533
+Neighbor         V  AS      MsgRcvd   MsgSent  InQ OutQ  Up/Down State  PfxRcd
+10.17.254.78     4  65534       187       191    0    0  123d12h Estab  1

--- a/tests/arista_eos/show_ip_bgp_summary/arista_eos_show_ip_bgp_summary4.yml
+++ b/tests/arista_eos/show_ip_bgp_summary/arista_eos_show_ip_bgp_summary4.yml
@@ -1,0 +1,16 @@
+---
+parsed_sample:
+  - router_id: "10.26.0.22"
+    local_as: "65533"
+    vrf: ""
+    description: ""
+    bgp_neigh: "10.17.254.78"
+    neigh_as: "65534"
+    msg_rcvd: "187"
+    msg_sent: "191"
+    in_queue: "0"
+    out_queue: "0"
+    up_down: "123d12h"
+    state: "Estab"
+    state_pfxrcd: "1"
+    state_pfxacc: ""


### PR DESCRIPTION
The output in the raw sample here was collected from an Arista DCS-7124SX-R switch running EOS version 4.9.5.2.