### PR TITLE
Fix CDP neighbors if interfaces are in single line

### DIFF
--- a/ntc_templates/templates/cisco_xr_show_cdp_neighbors_detail.textfsm
+++ b/ntc_templates/templates/cisco_xr_show_cdp_neighbors_detail.textfsm
@@ -3,17 +3,18 @@ Value SYSNAME (.*)
 Value MGMT_IP (.*)
 Value PLATFORM (.*)
 Value REMOTE_PORT (.*)
-Value LOCAL_PORT (.*)
+Value LOCAL_PORT ([^,]+)
 Value VERSION (.*)
-Value CAPABILITIES (.*)
+Value CAPABILITIES (.+?)
 
 Start
   ^Device ID: ${DEST_HOST}
   ^SysName : ${SYSNAME}
   ^Entry address\(es\): -> GetIP
-  ^Platform: ${PLATFORM},  Capabilities: ${CAPABILITIES}
-  ^Interface: ${LOCAL_PORT}
+  ^Platform: ${PLATFORM},  Capabilities: ${CAPABILITIES}\s*$$
+  ^Interface: ${LOCAL_PORT}$$
   ^Port ID \(outgoing port\): ${REMOTE_PORT}
+  ^Interface: ${LOCAL_PORT},\s+Port ID \(outgoing port\): ${REMOTE_PORT}
   ^Version : -> GetVersion
 
 GetIP

--- a/tests/cisco_xr/show_cdp_neighbors_detail/cisco_xr_show_cdp_neighbors_detail1.raw
+++ b/tests/cisco_xr/show_cdp_neighbors_detail/cisco_xr_show_cdp_neighbors_detail1.raw
@@ -1,0 +1,15 @@
+-------------------------
+Device ID: SW1
+SysName : SW1
+Entry address(es): 
+  IPv4 address: 3.1.1.1
+Platform: cisco ASR9K Series,  Capabilities: Router 
+Interface: TenGigabitEthernet0/2,  Port ID (outgoing port): GigabitEthernet0/2/0/15
+Holdtime : 168 sec
+
+Version :
+Cisco IOS XR Software, Version 4.3.1[Default]
+Copyright (c) 2014 by Cisco Systems, Inc.
+
+advertisement version: 2
+Duplex: full

--- a/tests/cisco_xr/show_cdp_neighbors_detail/cisco_xr_show_cdp_neighbors_detail1.yml
+++ b/tests/cisco_xr/show_cdp_neighbors_detail/cisco_xr_show_cdp_neighbors_detail1.yml
@@ -1,0 +1,10 @@
+---
+parsed_sample:
+  - dest_host: "SW1"
+    local_port: "TenGigabitEthernet0/2"
+    mgmt_ip: "3.1.1.1"
+    platform: "cisco ASR9K Series"
+    remote_port: "GigabitEthernet0/2/0/15"
+    sysname: "SW1"
+    version: "Cisco IOS XR Software, Version 4.3.1[Default]"
+    capabilities: "Router"


### PR DESCRIPTION
On Cisco XR -> show cdp neighbors detail local and remote interfaces can be in the same line.
The PR implement this behavior.