### PR TITLE
Standardize huawei capture group to all uppercase and insert underscore

### DIFF
--- a/ntc_templates/templates/avaya_ers_show_vlan.textfsm
+++ b/ntc_templates/templates/avaya_ers_show_vlan.textfsm
@@ -9,7 +9,7 @@ Value VLAN_MGMT (\S+)
 Value List VLAN_PORT_MEMBERS (\S+)
 
 Start
-  ^Total\s+VLAN_s: -> Done
+  ^Total\s+VLANs: -> Done
   ^\d+ -> Continue.Record
   ^${VLAN_ID}\s+${VLAN_NAME}\s+${VLAN_TYPE}\s+${VLAN_PROTOCOL}\s+${VLAN_PID}\s+${VLAN_ACTIVE}\s+${VLAN_IVL_SVL}\s+${VLAN_MGMT}$$
   ^\t+Port Members:\s+${VLAN_PORT_MEMBERS}$$

--- a/ntc_templates/templates/avaya_ers_show_vlan.textfsm
+++ b/ntc_templates/templates/avaya_ers_show_vlan.textfsm
@@ -9,7 +9,7 @@ Value VLAN_MGMT (\S+)
 Value List VLAN_PORT_MEMBERS (\S+)
 
 Start
-  ^Total\s+VLANs: -> Done
+  ^Total\s+VLAN_s: -> Done
   ^\d+ -> Continue.Record
   ^${VLAN_ID}\s+${VLAN_NAME}\s+${VLAN_TYPE}\s+${VLAN_PROTOCOL}\s+${VLAN_PID}\s+${VLAN_ACTIVE}\s+${VLAN_IVL_SVL}\s+${VLAN_MGMT}$$
   ^\t+Port Members:\s+${VLAN_PORT_MEMBERS}$$

--- a/ntc_templates/templates/huawei_vrp_display_ipv6_neighbors.textfsm
+++ b/ntc_templates/templates/huawei_vrp_display_ipv6_neighbors.textfsm
@@ -1,10 +1,10 @@
 Value IP_ADDRESS (\S+)
-Value LINK_lAYER (([\d\w]{4}-){2}[\d\w]{4})
+Value LINK_LAYER (([\d\w]{4}-){2}[\d\w]{4})
 Value STATE (INCMP|REACH|STALE|DELAY|PROBE)
 Value INTERFACE (\S+)
 Value AGE (\S+)
 Value VLAN_ID ([-\d]+)
-Value CEVLAN ([-\d]+)
+Value CE_VLAN ([-\d]+)
 Value VPN_NAME (\S+|\s{0})
 Value IS_ROUTER (TRUE|FALSE)
 Value SECURE_FLAG (SECURE|UNSECURE|UN-SECURE)
@@ -15,9 +15,9 @@ Start
   ^\s*-+\s*$$
   ^\s*IPv6\sAddress\s*:\s*\S+\s*$$ -> Continue.Record
   ^\s*IPv6\sAddress\s*:\s*${IP_ADDRESS}\s*$$
-  ^\s*Link-layer\s*:\s*${LINK_lAYER}\s+State\s*:\s*${STATE}\s*$$
+  ^\s*Link-layer\s*:\s*${LINK_LAYER}\s+State\s*:\s*${STATE}\s*$$
   ^\s*Interface\s*:\s*${INTERFACE}\s+Age\s*:\s*${AGE}\s*$$
-  ^\s*VLAN\s*:\s*${VLAN_ID}\s+CEVLAN\s*:\s*${CEVLAN}\s*$$
+  ^\s*VLAN\s*:\s*${VLAN_ID}\s+CEVLAN\s*:\s*${CE_VLAN}\s*$$
   ^\s*(VPN\sname\s*:\s*${VPN_NAME}\s+)?Is\sRouter\s*:\s*${IS_ROUTER}\s*$$
   ^\s*Secure FLAG\s*:\s*${SECURE_FLAG}\s*(Nickname\s*:\s*${NICKNAME}\s*)?$$
   ^\s*Total:\s+\d+\s+Dynamic:\s+\d+\s+Static:\s+\d+\s*$$

--- a/tests/huawei_vrp/display_ipv6_neighbors/huawei_vrp_display_ipv6_neighbors_description1.yml
+++ b/tests/huawei_vrp/display_ipv6_neighbors/huawei_vrp_display_ipv6_neighbors_description1.yml
@@ -1,7 +1,7 @@
 ---
 parsed_sample:
   - age: "00h05m12s"
-    cevlan: "-"
+    ce_vlan: "-"
     interface: "GE0/0/0"
     ip_address: "2::1"
     is_router: "TRUE"
@@ -12,7 +12,7 @@ parsed_sample:
     vlan_id: "200"
     vpn_name: ""
   - age: "00h03m02s"
-    cevlan: "-"
+    ce_vlan: "-"
     interface: "GE0/0/1"
     ip_address: "FE80::727B:E8FF:FEE9:D329"
     is_router: "TRUE"

--- a/tests/huawei_vrp/display_ipv6_neighbors/huawei_vrp_display_ipv6_neighbors_description2.yml
+++ b/tests/huawei_vrp/display_ipv6_neighbors/huawei_vrp_display_ipv6_neighbors_description2.yml
@@ -1,7 +1,7 @@
 ---
 parsed_sample:
   - age: "75"
-    cevlan: "-"
+    ce_vlan: "-"
     interface: "10GE4/17/6"
     ip_address: "FC00:1::2"
     is_router: "TRUE"
@@ -12,7 +12,7 @@ parsed_sample:
     vlan_id: "35"
     vpn_name: "-"
   - age: "38"
-    cevlan: "-"
+    ce_vlan: "-"
     interface: "10GE4/17/6"
     ip_address: "FE80::225:9EFF:FE01:20A"
     is_router: "TRUE"
@@ -23,7 +23,7 @@ parsed_sample:
     vlan_id: "35"
     vpn_name: "-"
   - age: "-"
-    cevlan: "-"
+    ce_vlan: "-"
     interface: "10GE4/17/3"
     ip_address: "FC00:2::1"
     is_router: "TRUE"


### PR DESCRIPTION
Fix a lowercase "L" in a capture group that was not capitalized like the rest of the letters.
Insert an underscore between CE and VLAN to make things more readable and align with naming conventions.

Breaking change on account of the capture group changes
(second of 8/2023 PRs)