### PR TITLE
[fixed]: arista includes "/" in the port number on some models.

### DIFF
--- a/ntc_templates/templates/arista_eos_show_inventory.textfsm
+++ b/ntc_templates/templates/arista_eos_show_inventory.textfsm
@@ -1,4 +1,4 @@
-Value PORT (\d+)
+Value PORT ([0-9\/]+)
 Value NAME (\S+)
 Value SN (\S+)
 Value DESCR (.+)


### PR DESCRIPTION
Arista includes "/" in the port number on some models like the 7500R3 series.
Could you update the templates?