### PR TITLE
Fix 'cisco_ios_show_logging' template with unnecessary '*'

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_logging.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_logging.textfsm
@@ -10,90 +10,90 @@ Value List MESSAGE (.+)
 
 Start
   ^Log\s+Buffer
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
   # 022701: Jun 19 03:02:31: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet2/0/3, changed state to down
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
   # 000024: Dec  2 12:09:21.207: CEF-HWIDB: EDSP0 LES switching vector set to Null
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
-  ^${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> DateLogs
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> DateLogs
   # Jan 30 14:11:11.354: %ILPOWER-7-DETECT: Interface Gi4/3: Power Device detected: IEEE PD
-  ^${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> DateLogs
-  ^${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> DateLogs
-  ^${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> DateLogs
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> DateLogs
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> DateLogs
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> DateLogs
   # 7:04: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet2/0/3, changed state to up
-  ^${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> TimeLogs
-  ^${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> TimeLogs
+  ^(\*)?${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> TimeLogs
+  ^(\*)?${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> TimeLogs
 
 
 NumberLogs
-  ^(\d{6}):\s+(\D\D\D)\s+(\d{1,2})\s+((\d+:\d+:\d+\.\d+)|(\d+:\d+:\d+)) -> Continue.Record
-  ^(\D\D\D)\s+(\d{1,2})\s+((\d+:\d+:\d+\.\d+)|(\d+:\d+:\d+)) -> Continue.Record
-  ^\d{1,2}:\d{1,2}: -> Continue.Record
+  ^(\*)?(\d{6}):\s+(\D\D\D)\s+(\d{1,2})\s+((\d+:\d+:\d+\.\d+)|(\d+:\d+:\d+)) -> Continue.Record
+  ^(\*)?(\D\D\D)\s+(\d{1,2})\s+((\d+:\d+:\d+\.\d+)|(\d+:\d+:\d+)) -> Continue.Record
+  ^(\*)?\d{1,2}:\d{1,2}: -> Continue.Record
   # NUMBER LOGS
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$
   # NUMBER LOGS NO SEVERITY
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$
   # DATE LOGS
-  ^${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
-  ^${MONTH}\s+${DAY}\s+${TIME}:\s%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}:\s%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
   # DATE LOGS NO SEVERITY
-  ^${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
-  ^${MONTH}\s+${DAY}\s+${TIME}:\s${FACILITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}:\s${FACILITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
   # TIME LOGS
-  ^${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> TimeLogs
+  ^(\*)?${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> TimeLogs
   # TIME LOGS NO SEVERITY
-  ^${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> TimeLogs
+  ^(\*)?${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> TimeLogs
   ^${MESSAGE}$$
   ^\s*$$
   ^. -> Error
 
 DateLogs
-  ^(\D\D\D)\s+(\d{1,2})\s+((\d+:\d+:\d+\.\d+)|(\d+:\d+:\d+)) -> Continue.Record
-  ^(\d{6}):\s+(\D\D\D)\s+(\d{1,2})\s+((\d+:\d+:\d+\.\d+)|(\d+:\d+:\d+)) -> Continue.Record
-  ^\d{1,2}:\d{1,2}: -> Continue.Record
+  ^(\*)?(\D\D\D)\s+(\d{1,2})\s+((\d+:\d+:\d+\.\d+)|(\d+:\d+:\d+)) -> Continue.Record
+  ^(\*)?(\d{6}):\s+(\D\D\D)\s+(\d{1,2})\s+((\d+:\d+:\d+\.\d+)|(\d+:\d+:\d+)) -> Continue.Record
+  ^(\*)?\d{1,2}:\d{1,2}: -> Continue.Record
   # DATE LOGS
-  ^${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}
-  ^${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}
   # DATE LOGS NO SEVERITY
-  ^${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}
-  ^${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}
   # NUMBER LOGS
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
   # NUMBER LOGS NO SEVERITY
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
   # TIME LOGS
-  ^${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> TimeLogs
+  ^(\*)?${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> TimeLogs
   # TIME LOGS NO SEVERITY
-  ^${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> TimeLogs
+  ^(\*)?${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> TimeLogs
   ^${MESSAGE}$$
   ^\s*$$
   ^. -> Error
 
 TimeLogs
-  ^\d{1,2}:\d{1,2}: -> Continue.Record
-  ^(\D\D\D)\s+(\d{1,2})\s+((\d+:\d+:\d+\.\d+)|(\d+:\d+:\d+)) -> Continue.Record
-  ^\d+:\s+\S+ -> Continue.Record
+  ^(\*)?\d{1,2}:\d{1,2}: -> Continue.Record
+  ^(\*)?(\D\D\D)\s+(\d{1,2})\s+((\d+:\d+:\d+\.\d+)|(\d+:\d+:\d+)) -> Continue.Record
+  ^(\*)?\d+:\s+\S+ -> Continue.Record
   # TIME LOGS
-  ^${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$
+  ^(\*)?${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$
   # TIME LOGS NO SEVERITY
-  ^${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$
+  ^(\*)?${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$
   # DATE LOGS
-  ^${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
-  ^${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
   # DATE LOGS NO SEVERITY
-  ^${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
-  ^${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
+  ^(\*)?${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE} -> DateLogs
   # NUMBER LOGS
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+%${FACILITY}-${SEVERITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
   # NUMBER LOGS NO SEVERITY
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
-  ^${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}\s+${TIMEZONE}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
+  ^(\*)?${NUMBER}:\s+${MONTH}\s+${DAY}\s+${TIME}:\s+${FACILITY}-${MNEMONIC}:\s+${MESSAGE}$$ -> NumberLogs
   ^${MESSAGE}$$
   ^\s*$$
   ^. -> Error

--- a/tests/cisco_ios/show_logging/cisco_ios_show_logging_5.raw
+++ b/tests/cisco_ios/show_logging/cisco_ios_show_logging_5.raw
@@ -1,0 +1,45 @@
+Syslog logging: enabled (0 messages dropped, 21 messages rate-limited, 0 flushes, 0 overruns, xml disabled, filtering disabled)
+
+No Active Message Discriminator.
+
+
+
+No Inactive Message Discriminator.
+
+
+    Console logging: level debugging, 10027 messages logged, xml disabled,
+                     filtering disabled
+    Monitor logging: level debugging, 0 messages logged, xml disabled,
+                     filtering disabled
+    Buffer logging:  level informational, 10048 messages logged, xml disabled,
+                    filtering disabled
+    Exception Logging: size (8192 bytes)
+    Count and timestamp logging messages: disabled
+    Persistent logging: disabled
+
+No active filter modules.
+
+    Trap logging: level debugging, 10180 message lines logged
+        Logging to 81.95.32.138  (udp port 514, audit disabled,
+              link up),
+              10179 message lines logged,
+              0 message lines rate-limited,
+              0 message lines dropped-by-MD,
+              xml disabled, sequence number disabled
+              filtering disabled
+        Logging to 192.168.214.143  (udp port 514, audit disabled,
+              link up),
+              10180 message lines logged,
+              0 message lines rate-limited,
+              0 message lines dropped-by-MD,
+              xml disabled, sequence number disabled
+              filtering disabled
+        Logging Source-Interface:       VRF Name:
+
+Log Buffer (100000 bytes):
+rtual-PPP2, changed state to down
+*Sep 14 05:59:54.113: %LINEPROTO-5-UPDOWN: Line protocol on Interface Virtual-PPP2, changed state to up
+*Sep 14 06:00:45.693: %CRYPTO-4-PKT_REPLAY_ERR: decrypt: replay check failed
+        connection id=29, sequence number=219
+
+*Sep 14 06:07:26.245: %LINEPROTO-5-UPDOWN: Line protocol on Interface Virtual-PPP2, changed state to down

--- a/tests/cisco_ios/show_logging/cisco_ios_show_logging_5.yml
+++ b/tests/cisco_ios/show_logging/cisco_ios_show_logging_5.yml
@@ -1,0 +1,33 @@
+---
+parsed_sample:
+  - number: ""
+    month: "Sep"
+    day: "14"
+    time: "05:59:54.113"
+    timezone: ""
+    facility: "LINEPROTO"
+    severity: "5"
+    mnemonic: "UPDOWN"
+    message:
+      - "Line protocol on Interface Virtual-PPP2, changed state to up"
+  - number: ""
+    month: "Sep"
+    day: "14"
+    time: "06:00:45.693"
+    timezone: ""
+    facility: "CRYPTO"
+    severity: "4"
+    mnemonic: "PKT_REPLAY_ERR"
+    message:
+      - "decrypt: replay check failed"
+      - "        connection id=29, sequence number=219"
+  - number: ""
+    month: "Sep"
+    day: "14"
+    time: "06:07:26.245"
+    timezone: ""
+    facility: "LINEPROTO"
+    severity: "5"
+    mnemonic: "UPDOWN"
+    message:
+      - "Line protocol on Interface Virtual-PPP2, changed state to down"


### PR DESCRIPTION
On Cisco C881-K9 (for example) there is '*' before log line. I`ve fixed that