### PR TITLE
Cisco NXOS "show port-channel summary" fix

### DIFF
--- a/ntc_templates/templates/cisco_nxos_show_port-channel_summary.textfsm
+++ b/ntc_templates/templates/cisco_nxos_show_port-channel_summary.textfsm
@@ -2,7 +2,7 @@ Value Required,Filldown BUNDLE_IFACE (Po\d+)
 Value Filldown BUNDLE_STATUS (\(\w+\))
 Value Filldown BUNDLE_PROTO (\w+)
 Value Filldown BUNDLE_PROTO_STATE (\(\w+\))
-Value List PHYS_IFACE (Et.+?)
+Value List PHYS_IFACE ([\w\/]+|\-\-)
 Value List PHYS_IFACE_STATUS (\(.+?\))
 
 
@@ -43,3 +43,4 @@ CASE2_RTE
   ^\s{37}Et.+?\s+${PHYS_IFACE}${PHYS_IFACE_STATUS}(\s|$$) -> Continue
   ^\s{37}Et.+?\s+Et.+?\s+${PHYS_IFACE}${PHYS_IFACE_STATUS}(\s|$$) -> Continue
   ^\s{37}Et.+?\s+Et.+?\s+Et.+?\s+${PHYS_IFACE}${PHYS_IFACE_STATUS}(\s|$$) -> Continue
+  ^\d+\s+${BUNDLE_IFACE}${BUNDLE_STATUS}\s+\w+\s+${BUNDLE_PROTO}\s+${PHYS_IFACE}($$) -> Next

--- a/tests/cisco_nxos/show_port-channel_summary/cisco_nxos_show_port-channel_summary3.raw
+++ b/tests/cisco_nxos/show_port-channel_summary/cisco_nxos_show_port-channel_summary3.raw
@@ -1,0 +1,30 @@
+Flags:  D - Down        P - Up in port-channel (members)
+        I - Individual  H - Hot-standby (LACP only)
+        s - Suspended   r - Module-removed
+        S - Switched    R - Routed
+        U - Up (port-channel)
+        M - Not in use. Min-links not met
+--------------------------------------------------------------------------------
+Group Port-       Type     Protocol  Member Ports
+      Channel
+--------------------------------------------------------------------------------
+131   Po131(SU)   Eth      LACP      Eth1/1(P)    
+132   Po132(SU)   Eth      LACP      Eth1/2(P)    
+133   Po133(SU)   Eth      LACP      Eth1/3(P)    
+134   Po134(SU)   Eth      LACP      Eth1/4(P)    
+135   Po135(SD)   Eth      NONE      --
+136   Po136(SD)   Eth      LACP      Eth1/6(D)    
+137   Po137(SD)   Eth      NONE      --
+138   Po138(SD)   Eth      LACP      Eth1/24(D)   
+141   Po141(SD)   Eth      NONE      --
+142   Po142(SD)   Eth      NONE      --
+151   Po151(SD)   Eth      NONE      --
+171   Po171(SU)   Eth      LACP      Eth1/14(P)   
+172   Po172(SU)   Eth      LACP      Eth1/15(P)   
+173   Po173(SU)   Eth      LACP      Eth1/16(P)   
+174   Po174(SU)   Eth      LACP      Eth1/17(P)   
+175   Po175(SD)   Eth      LACP      Eth1/25(D)   
+176   Po176(SD)   Eth      LACP      Eth1/27(D)   
+177   Po177(SD)   Eth      LACP      Eth1/28(D)   
+178   Po178(SD)   Eth      NONE      --
+200   Po200(SU)   Eth      LACP      Eth1/21(P)   Eth1/22(P)  

--- a/tests/cisco_nxos/show_port-channel_summary/cisco_nxos_show_port-channel_summary3.yml
+++ b/tests/cisco_nxos/show_port-channel_summary/cisco_nxos_show_port-channel_summary3.yml
@@ -1,0 +1,158 @@
+---
+parsed_sample:
+  - bundle_iface: "Po131"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SU)"
+    phys_iface:
+      - "Eth1/1"
+    phys_iface_status:
+      - "(P)"
+  - bundle_iface: "Po132"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SU)"
+    phys_iface:
+      - "Eth1/2"
+    phys_iface_status:
+      - "(P)"
+  - bundle_iface: "Po133"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SU)"
+    phys_iface:
+      - "Eth1/3"
+    phys_iface_status:
+      - "(P)"
+  - bundle_iface: "Po134"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SU)"
+    phys_iface:
+      - "Eth1/4"
+    phys_iface_status:
+      - "(P)"
+  - bundle_iface: "Po135"
+    bundle_proto: "NONE"
+    bundle_proto_state: ""
+    bundle_status: "(SD)"
+    phys_iface:
+      - "--"
+    phys_iface_status: []
+  - bundle_iface: "Po136"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SD)"
+    phys_iface:
+      - "Eth1/6"
+    phys_iface_status:
+      - "(D)"
+  - bundle_iface: "Po137"
+    bundle_proto: "NONE"
+    bundle_proto_state: ""
+    bundle_status: "(SD)"
+    phys_iface:
+      - "--"
+    phys_iface_status: []
+  - bundle_iface: "Po138"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SD)"
+    phys_iface:
+      - "Eth1/24"
+    phys_iface_status:
+      - "(D)"
+  - bundle_iface: "Po141"
+    bundle_proto: "NONE"
+    bundle_proto_state: ""
+    bundle_status: "(SD)"
+    phys_iface:
+      - "--"
+    phys_iface_status: []
+  - bundle_iface: "Po142"
+    bundle_proto: "NONE"
+    bundle_proto_state: ""
+    bundle_status: "(SD)"
+    phys_iface:
+      - "--"
+    phys_iface_status: []
+  - bundle_iface: "Po151"
+    bundle_proto: "NONE"
+    bundle_proto_state: ""
+    bundle_status: "(SD)"
+    phys_iface:
+      - "--"
+    phys_iface_status: []
+  - bundle_iface: "Po171"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SU)"
+    phys_iface:
+      - "Eth1/14"
+    phys_iface_status:
+      - "(P)"
+  - bundle_iface: "Po172"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SU)"
+    phys_iface:
+      - "Eth1/15"
+    phys_iface_status:
+      - "(P)"
+  - bundle_iface: "Po173"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SU)"
+    phys_iface:
+      - "Eth1/16"
+    phys_iface_status:
+      - "(P)"
+  - bundle_iface: "Po174"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SU)"
+    phys_iface:
+      - "Eth1/17"
+    phys_iface_status:
+      - "(P)"
+  - bundle_iface: "Po175"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SD)"
+    phys_iface:
+      - "Eth1/25"
+    phys_iface_status:
+      - "(D)"
+  - bundle_iface: "Po176"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SD)"
+    phys_iface:
+      - "Eth1/27"
+    phys_iface_status:
+      - "(D)"
+  - bundle_iface: "Po177"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SD)"
+    phys_iface:
+      - "Eth1/28"
+    phys_iface_status:
+      - "(D)"
+  - bundle_iface: "Po178"
+    bundle_proto: "NONE"
+    bundle_proto_state: ""
+    bundle_status: "(SD)"
+    phys_iface:
+      - "--"
+    phys_iface_status: []
+  - bundle_iface: "Po200"
+    bundle_proto: "LACP"
+    bundle_proto_state: ""
+    bundle_status: "(SU)"
+    phys_iface:
+      - "Eth1/21"
+      - "Eth1/22"
+    phys_iface_status:
+      - "(P)"
+      - "(P)"


### PR DESCRIPTION
Cisco NXOS "show port-channel summary" fix,

This can catch port-channels with no members.