### PR TITLE
Create template for Cisco AireOS WLC `show boot` command

### DIFF
--- a/ntc_templates/templates/cisco_wlc_ssh_show_boot.textfsm
+++ b/ntc_templates/templates/cisco_wlc_ssh_show_boot.textfsm
@@ -1,9 +1,9 @@
-Value IMAGE (\S+\s+\S+\s+[A-z]+)
-Value VERSION (\S+)
-Value STATUS ((?:\(\S+\))\s*(?:\(\S+\))?)
+Value IMAGE_TYPE (\S+\s+\S+\s+[A-z]+)
+Value IMAGE_VERSION (\S+)
+Value IMAGE_STATUS ((?:\(\S+\))\s*(?:\(\S+\))?)
 
 
 Start
-  ^${IMAGE}\.+\s+${VERSION}\s*(${STATUS})?$$ -> Record
+  ^${IMAGE_TYPE}\.+\s+${IMAGE_VERSION}\s*(${IMAGE_STATUS})?$$ -> Record
   ^\s*$$
   ^. -> Error

--- a/ntc_templates/templates/cisco_wlc_ssh_show_boot.textfsm
+++ b/ntc_templates/templates/cisco_wlc_ssh_show_boot.textfsm
@@ -1,0 +1,9 @@
+Value IMAGE (\S+\s+\S+\s+[A-z]+)
+Value VERSION (\S+)
+Value STATUS ((?:\(\S+\))\s*(?:\(\S+\))?)
+
+
+Start
+  ^${IMAGE}\.+\s+${VERSION}\s*(${STATUS})?$$ -> Record
+  ^\s*$$
+  ^. -> Error

--- a/ntc_templates/templates/index
+++ b/ntc_templates/templates/index
@@ -439,6 +439,7 @@ cisco_wlc_ssh_show_inventory.textfsm, .*, cisco_wlc_ssh, sh[[ow]] inve[[ntory]]
 cisco_wlc_ssh_show_wlan_sum.textfsm, .*, cisco_wlc_ssh, sh[[ow]] wl[[an]] s[[ummary]]
 cisco_wlc_ssh_show_802.11a.textfsm, .*, cisco_wlc_ssh, show 802\.11[ab]
 cisco_wlc_ssh_show_sysinfo.textfsm, .*, cisco_wlc_ssh, sh[[ow]] sysi[[nfo]]
+cisco_wlc_ssh_show_boot.textfsm, .*, cisco_wlc_ssh, sh[[ow]] bo[[ot]]
 cisco_wlc_ssh_show_time.textfsm, .*, cisco_wlc_ssh, sh[[ow]] ti[[me]]
 
 cisco_xr_show_controllers_fabric_fia_errors_ingress_location.textfsm, .*, cisco_xr, sh[[ow]] contr[[ollers]] fabric fi[[a]] err[[ors]] in[[gress]] loc[[ation]]

--- a/tests/cisco_wlc_ssh/show_boot/cisco_wlc_ssh_show_boot.raw
+++ b/tests/cisco_wlc_ssh/show_boot/cisco_wlc_ssh_show_boot.raw
@@ -1,0 +1,2 @@
+Primary Boot Image............................... 8.10.183.0 (default) (active)
+Backup Boot Image................................ 8.8.125.0

--- a/tests/cisco_wlc_ssh/show_boot/cisco_wlc_ssh_show_boot.yml
+++ b/tests/cisco_wlc_ssh/show_boot/cisco_wlc_ssh_show_boot.yml
@@ -1,0 +1,8 @@
+---
+parsed_sample:
+  - image: "Primary Boot Image"
+    status: "(default) (active)"
+    version: "8.10.183.0"
+  - image: "Backup Boot Image"
+    status: ""
+    version: "8.8.125.0"

--- a/tests/cisco_wlc_ssh/show_boot/cisco_wlc_ssh_show_boot.yml
+++ b/tests/cisco_wlc_ssh/show_boot/cisco_wlc_ssh_show_boot.yml
@@ -1,8 +1,8 @@
 ---
 parsed_sample:
-  - image: "Primary Boot Image"
-    status: "(default) (active)"
-    version: "8.10.183.0"
-  - image: "Backup Boot Image"
-    status: ""
-    version: "8.8.125.0"
+  - image_status: "(default) (active)"
+    image_type: "Primary Boot Image"
+    image_version: "8.10.183.0"
+  - image_status: ""
+    image_type: "Backup Boot Image"
+    image_version: "8.8.125.0"

--- a/tests/cisco_wlc_ssh/show_boot/cisco_wlc_ssh_show_boot2.raw
+++ b/tests/cisco_wlc_ssh/show_boot/cisco_wlc_ssh_show_boot2.raw
@@ -1,0 +1,2 @@
+Primary Boot Image............................... 8.10.183.0 (default)
+Backup Boot Image................................ 8.8.125.0 (active)

--- a/tests/cisco_wlc_ssh/show_boot/cisco_wlc_ssh_show_boot2.yml
+++ b/tests/cisco_wlc_ssh/show_boot/cisco_wlc_ssh_show_boot2.yml
@@ -1,0 +1,8 @@
+---
+parsed_sample:
+  - image: "Primary Boot Image"
+    status: "(default)"
+    version: "8.10.183.0"
+  - image: "Backup Boot Image"
+    status: "(active)"
+    version: "8.8.125.0"

--- a/tests/cisco_wlc_ssh/show_boot/cisco_wlc_ssh_show_boot2.yml
+++ b/tests/cisco_wlc_ssh/show_boot/cisco_wlc_ssh_show_boot2.yml
@@ -1,8 +1,8 @@
 ---
 parsed_sample:
-  - image: "Primary Boot Image"
-    status: "(default)"
-    version: "8.10.183.0"
-  - image: "Backup Boot Image"
-    status: "(active)"
-    version: "8.8.125.0"
+  - image_status: "(default)"
+    image_type: "Primary Boot Image"
+    image_version: "8.10.183.0"
+  - image_status: "(active)"
+    image_type: "Backup Boot Image"
+    image_version: "8.8.125.0"


### PR DESCRIPTION
Enhancement: Add support for `show boot` Cisco AireOS WLC command (cisco_wlc_ssh)

Note: Had to anchor the `IMAGE` capture group by including `[A-z]+` since `\S+` would have included the string of periods.