### PR TITLE
cisco_ios_show_vrf_details: New CLI and Old CLI format lines

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_vrf_detail.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_vrf_detail.textfsm
@@ -24,6 +24,8 @@ Start
   ^\s*No\sglobal.*\s*$$
   ^\s*VRF\slabel.*\s*$$
   ^\s*Address\sfamily.*\s*$$
+  ^\s*New\sCLI\sformat.*\s*$$
+  ^\s*Old\sCLI\sformat.*\s*$$
   ^. -> Error
 
 Interfaces


### PR DESCRIPTION
Allow existing template to work with the new CLI format, still only parses ipv4 format

"Old CLI Format" and "New CLI Format" lines in show vrf details output on:

Cisco IOS XE Software, Version 17.03.04
Cisco IOS Software [Amsterdam], Catalyst L3 Switch Software (CAT9K_IOSXE), Version 17.3.4, RELEASE SOFTWARE (fc3)

![image](https://github.com/networktocode/ntc-templates/assets/4852099/6aa19101-097f-42f0-b031-bcac64205aae)
