### PR TITLE
cisco_asa_dir: Improvement - Catch all unmatched lines

### DIFF
--- a/ntc_templates/templates/cisco_asa_dir.textfsm
+++ b/ntc_templates/templates/cisco_asa_dir.textfsm
@@ -10,6 +10,7 @@ Value NAME (\S+)
 
 Start
   ^Directory of\s+${FILE_SYSTEM} -> DIR
+  ^. -> Error
 
 DIR
   ^Directory of\s+${FILE_SYSTEM} -> DIR
@@ -19,6 +20,7 @@ DIR
   ^\d+\s+\S+\s+\S+\s+\d+\s+\S+
   ^${TOTAL_SIZE} bytes total \(${TOTAL_FREE} bytes free/${TOTAL_PERCENT_FREE}\% free\)
   ^.*$$
+  ^. -> Error DIR
 
 #
 EOF


### PR DESCRIPTION
To bring the template up to standard, throw an error on unmatched lines.