### PR TITLE
cisco_asa_show_route: Improvement - Catch all unmatched lines

### DIFF
--- a/ntc_templates/templates/cisco_asa_show_route.textfsm
+++ b/ntc_templates/templates/cisco_asa_show_route.textfsm
@@ -9,7 +9,12 @@ Value NEXTHOPIF (\S+)
 Value UPTIME (\d\S+?)
 
 Start
+  # Skips over the code line that explains what each code means
+  ^Codes:
+  # Skips over the definitions for the codes
+  ^\s{6,}\S*\s-\s\S.*
   ^Gateway -> ROUTES
+  ^. -> Error
 
 ROUTES
   # Match regular routes with all data in same line
@@ -34,5 +39,6 @@ ROUTES
   #^${TYPE} -> Continue.Record
   #^${TYPE}\s+${NETWORK}\s+${NETMASK}\s+\[\d+\/\d+\]\s+via\s+${GATEWAY}\,\s+${UPTIME},\s+${INTFC}\s*$$ -> Record
   #^\s+\[\d+\/\d+\]\s+via\s+${GATEWAY}\,\s+${UPTIME},\s+${INTFC}\s*$$ -> Record
+  ^. -> Error
 
 EOF


### PR DESCRIPTION
To bring the template up to standard, throw an error on unmatched lines.