### PR TITLE
cisco_show_ip_route: Remove vrf regex in index file.

### DIFF
--- a/ntc_templates/templates/index
+++ b/ntc_templates/templates/index
@@ -294,7 +294,7 @@ cisco_ios_show_ip_mroute.textfsm, .*, cisco_ios, sh[[ow]] ip mr[[oute]]
 cisco_ios_show_nve_peers.textfsm, .*, cisco_ios, sh[[ow]] nv[[e]] p[[eers]]
 cisco_ios_show_route-map.textfsm, .*, cisco_ios, sh[[ow]] route-m[[ap]]
 cisco_ios_show_snmp_user.textfsm, .*, cisco_ios, sh[[ow]] sn[[mp]] u[[ser]]
-cisco_ios_show_ip_route.textfsm, .*, cisco_ios, sh[[ow]] ip r[[oute]](?: vrf \S+)?\s*$
+cisco_ios_show_ip_route.textfsm, .*, cisco_ios, sh[[ow]] ip r[[oute]]
 cisco_ios_show_vrrp_all.textfsm, .*, cisco_ios, sh[[ow]] vrr[[p]] a[[ll]]
 cisco_ios_show_aliases.textfsm,  .*, cisco_ios, sh[[ow]] alia[[ses]]
 cisco_ios_show_archive.textfsm,  .*, cisco_ios, sh[[ow]] arc[[hive]]


### PR DESCRIPTION
The current line in the index file is stopping some usage of the command, such as:
- show ip route static
- show ip route 0.0.0.0/0 

Basically anything other than specifying a vrf.

This PR would now make it the same as other platforms (like nx-os).