### PR TITLE
cisco_ios_show_interfaces_switchport: Edge case addition

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_interfaces_switchport.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_interfaces_switchport.textfsm
@@ -34,7 +34,7 @@ Start
   ^\s*App\s+Interface
   ^\s*Appliance\s+trust
   ^\s*Operational\s+Dot1q\s+Ethertype
-  ^\s*Priority\s+for\s+untagged\s+frames
+  ^\s*Priority\s+for\s+untagged\s+frame
   ^\s*Override\s+vlan\s+tag\s+priority
   ^\s*$$
   # Capture time-stamp if vty line has command time-stamping turned on

--- a/tests/cisco_ios/show_interfaces_switchport/cisco_ios_show_interfaces_switchport4.raw
+++ b/tests/cisco_ios/show_interfaces_switchport/cisco_ios_show_interfaces_switchport4.raw
@@ -1,0 +1,62 @@
+Name: Gi0/1/3
+Switchport: Enabled
+Administrative Mode: dynamic auto
+Operational Mode: down
+Administrative Trunking Encapsulation: dot1q
+Negotiation of Trunking: On
+Access Mode VLAN: 1 (default)
+Trunking Native Mode VLAN: 1 (default)
+Administrative Native VLAN tagging: disabled
+Voice VLAN: none
+Administrative private-vlan host-association: none
+Administrative private-vlan mapping: none
+Administrative private-vlan trunk native VLAN: none
+Administrative private-vlan trunk Native VLAN tagging: enabled
+Administrative private-vlan trunk encapsulation: dot1q
+Administrative private-vlan trunk normal VLANs: none
+Administrative private-vlan trunk associations: none
+Administrative private-vlan trunk mappings: none
+Operational private-vlan: none
+Trunking VLANs Enabled: ALL
+Pruning VLANs Enabled: 2-1001
+Capture Mode Disabled
+Capture VLANs Allowed: ALL
+
+Protected: false
+Unknown unicast blocked: disabled
+Unknown multicast blocked: disabled
+Priority for untagged frame: 0
+Override vlan tag priority: FALSE
+Appliance trust: none
+
+Name: Wl0/1/4
+Switchport: Enabled
+Administrative Mode: dynamic auto
+Operational Mode: static access
+Administrative Trunking Encapsulation: dot1q
+Operational Trunking Encapsulation: native
+Negotiation of Trunking: On
+Access Mode VLAN: 41 (wirelessmgmt)
+Trunking Native Mode VLAN: 1 (default)
+Administrative Native VLAN tagging: disabled
+Voice VLAN: none
+Administrative private-vlan host-association: none
+Administrative private-vlan mapping: none
+Administrative private-vlan trunk native VLAN: none
+Administrative private-vlan trunk Native VLAN tagging: enabled
+Administrative private-vlan trunk encapsulation: dot1q
+Administrative private-vlan trunk normal VLANs: none
+Administrative private-vlan trunk associations: none
+Administrative private-vlan trunk mappings: none
+Operational private-vlan: none
+Trunking VLANs Enabled: ALL
+Pruning VLANs Enabled: 2-1001
+Capture Mode Disabled
+Capture VLANs Allowed: ALL
+
+Protected: false
+Unknown unicast blocked: disabled
+Unknown multicast blocked: disabled
+Priority for untagged frame: 0
+Override vlan tag priority: FALSE
+Appliance trust: none

--- a/tests/cisco_ios/show_interfaces_switchport/cisco_ios_show_interfaces_switchport4.yml
+++ b/tests/cisco_ios/show_interfaces_switchport/cisco_ios_show_interfaces_switchport4.yml
@@ -1,0 +1,24 @@
+---
+parsed_sample:
+  - access_vlan: "1"
+    admin_mode: "dynamic auto"
+    interface: "Gi0/1/3"
+    mode: "down"
+    native_vlan: "1"
+    switchport: "Enabled"
+    switchport_monitor: ""
+    switchport_negotiation: "On"
+    trunking_vlans:
+      - "ALL"
+    voice_vlan: "none"
+  - access_vlan: "41"
+    admin_mode: "dynamic auto"
+    interface: "Wl0/1/4"
+    mode: "static access"
+    native_vlan: "1"
+    switchport: "Enabled"
+    switchport_monitor: ""
+    switchport_negotiation: "On"
+    trunking_vlans:
+      - "ALL"
+    voice_vlan: "none"


### PR DESCRIPTION
Had some failures because of the line 'Priority for untagged frame: 0'.

Fixed and added an appropriate test.