### PR TITLE
cisco_ios_show_vlans: Fix support for q-in-q

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_vlans.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_vlans.textfsm
@@ -15,7 +15,7 @@ Data
   ^VLAN\s+ID:\s+\d+ -> Continue.Record
   ^VLAN\s+ID:\s+${VLAN_ID}
   ^\s+This\s+is\s+configured\s+as\s+native\s+Vlan\s+for\s+the\s+following\s+interface\(s\)\s+:\s*$$
-  ^\S+\s+Native-vlan\s+Tx-type:\s+\S+\s*$$
+  ^\S+(\s+Native-vlan\s+Tx-type:\s+\S+)?\s*$$
   ^\s+Protocols\s+Configured
   ^\s+IP\s+\d+\s+\d+
   ^\s+MPLS\s+\d+\s+\d+

--- a/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_06.raw
+++ b/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_06.raw
@@ -1,7 +1,7 @@
 VLAN ID: 1 (IEEE 802.1Q Encapsulation)
 
  This is configured as native Vlan for the following interface(s) :
-Port-channel14 Native-vlan Tx-type: none
+Port-channel14
 
    Protocols Configured:          Received:        Transmitted:
 


### PR DESCRIPTION
This makes the `Native-vlan Tx-Type: ...` part optional in the rule, because my device doesn't emit this line for the port channels.