### PR TITLE
ios show mac addr: fix match of legend

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_mac-address-table.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_mac-address-table.textfsm
@@ -23,7 +23,7 @@ TYPE1
 
 TYPE2
   # Order of the group in brackets here matters
-  ^\s*(\*\s+R|\*|R|\s)\s*(\d+|-+|[Nn]/[Aa]) -> Continue.Record
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*(\d+|-+|[Nn]/[Aa]) -> Continue.Record
   # using 20 spaces should ensure that lines only match destination port flowing to next line
   ^\s{20}\s+${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
   ^\s{20}\s+${DESTINATION_PORT},*\s*$$
@@ -37,19 +37,19 @@ TYPE2
   ^\s{20}\s+([^,\s]+(\s+|,\s*)){4}${DESTINATION_PORT},*\s*$$
   ^\s{20}\s+([^,\s]+(\s+|,\s*)){5}${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
   ^\s{20}\s+([^,\s]+(\s+|,\s*)){5}${DESTINATION_PORT},*\s*$$
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s*$$
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+${DESTINATION_PORT},*\s*$$
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+[^,\s]+(\s+|,\s*)${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+[^,\s]+?(\s+|,\s*)${DESTINATION_PORT},*\s*$$
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){2}${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){2}${DESTINATION_PORT},*\s*$$
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){3}${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){3}${DESTINATION_PORT},*\s*$$
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){4}${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){4}${DESTINATION_PORT},*\s*$$
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){5}${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
-  ^\s*(\*\s+R|\*|R|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){5}${DESTINATION_PORT},*\s*$$
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s*$$
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+${DESTINATION_PORT},*\s*$$
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+[^,\s]+(\s+|,\s*)${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+[^,\s]+?(\s+|,\s*)${DESTINATION_PORT},*\s*$$
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){2}${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){2}${DESTINATION_PORT},*\s*$$
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){3}${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){3}${DESTINATION_PORT},*\s*$$
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){4}${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){4}${DESTINATION_PORT},*\s*$$
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){5}${DESTINATION_PORT}(\s+|,\s*)\S -> Continue
+  ^\s*(\*\s+[R,S,D]|\*|[R,S,D]|\s)\s*${VLAN_ID}\s+${DESTINATION_ADDRESS}\s+${TYPE}\s+\S+\s+\S+\s+([^,\s]+(\s+|,\s*)){5}${DESTINATION_PORT},*\s*$$
   ^-+\+-+
   ^Displaying\s+entries
   ^\s+vlan\s+mac address\s+type\s+learn\s+age\s+ports

--- a/tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table9.raw
+++ b/tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table9.raw
@@ -40,3 +40,6 @@ Displaying entries from active supervisor::
         361 0000.0000.0ca6  dynamic  Yes      105     Po4
    R    451 0000.0000.0e00   static   No       -      Router
         401 0000.0000.1fcb  dynamic  Yes        5     Po4
+   S     67 0000.0000.0004   static   No       -      Te1/5/11
+ *      728 0000.0000.0003   static  Yes       -    
+ 

--- a/tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table9.yml
+++ b/tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table9.yml
@@ -145,3 +145,12 @@ parsed_sample:
       - "Po4"
     type: "dynamic"
     vlan_id: "401"
+  - destination_address: "0000.0000.0004"
+    destination_port:
+      - "Te1/5/11"
+    type: "static"
+    vlan_id: "67"
+  - destination_address: "0000.0000.0003"
+    destination_port: []
+    type: "static"
+    vlan_id: "728"


### PR DESCRIPTION
This comes from @jacdavi where show mac address table was only matching the "R" field, but the legend shows "S" and "D" are also options. This replaces #943 which is out of sync with the default branch.