### PR TITLE
Bugfix cisco_asa_show_inventory - catch space in PID value Issue #1692

### DIFF
--- a/ntc_templates/templates/cisco_asa_show_inventory.textfsm
+++ b/ntc_templates/templates/cisco_asa_show_inventory.textfsm
@@ -1,6 +1,6 @@
 Value NAME (.*)
 Value DESCR (.*)
-Value PID (\S+)
+Value PID ([\w\d\s/-]+)
 Value VID (\S+)
 Value SN (\S+)
 

--- a/ntc_templates/templates/cisco_asa_show_inventory.textfsm
+++ b/ntc_templates/templates/cisco_asa_show_inventory.textfsm
@@ -1,6 +1,6 @@
 Value NAME (.*)
 Value DESCR (.*)
-Value PID ([\w\d\s/-]+)
+Value PID ([\w\d\s/-]+[\S]+)
 Value VID (\S+)
 Value SN (\S+)
 

--- a/tests/cisco_asa/show_inventory/cisco_asa_show_inventory_pid_spaces.raw
+++ b/tests/cisco_asa/show_inventory/cisco_asa_show_inventory_pid_spaces.raw
@@ -1,0 +1,5 @@
+Name: "GigabitEthernet1/0", DESCR: ""
+PID: SFCT-739SMZ-CS1 G3, VID: G3.1, SN: JMX8318372GB     
+
+Name: "GigabitEthernet1/1", DESCR: ""
+PID: SFCT-739SMZ-CS1 G3, VID: G3.1, SN: MSA1917883N

--- a/tests/cisco_asa/show_inventory/cisco_asa_show_inventory_pid_spaces.yml
+++ b/tests/cisco_asa/show_inventory/cisco_asa_show_inventory_pid_spaces.yml
@@ -1,0 +1,12 @@
+---
+parsed_sample:
+  - descr: ""
+    name: "GigabitEthernet1/0"
+    pid: "SFCT-739SMZ-CS1 G3"
+    sn: "JMX8318372GB"
+    vid: "G3.1"
+  - descr: ""
+    name: "GigabitEthernet1/1"
+    pid: "SFCT-739SMZ-CS1 G3"
+    sn: "MSA1917883N"
+    vid: "G3.1"


### PR DESCRIPTION
Modified "cisco_asa_show_inventory.textfsm" changing the Regex expression to accept spaces in PID Value to resolve Issue #1692 

Worked alongside navarrj37