### PR TITLE
Fix template huawei_vrp_display_interface_description

### DIFF
--- a/ntc_templates/templates/huawei_vrp_display_interface_description.textfsm
+++ b/ntc_templates/templates/huawei_vrp_display_interface_description.textfsm
@@ -8,7 +8,7 @@ Start
   ^Interface\s+PHY\s+Protocol\s+Description\s*$$ -> Begin
   ^\s*$$
   ^PHY:\s+Physical
-  ^(?:\*|\^|\#)down:
+  ^(?:\*|\^|\#|\-)down:
   ^\(\w+\):\s+\S+
   ^. -> Error
 

--- a/tests/huawei_vrp/display_interface_description/huawei_vrp_display_interface_description.raw
+++ b/tests/huawei_vrp/display_interface_description/huawei_vrp_display_interface_description.raw
@@ -1,6 +1,7 @@
 PHY: Physical
 *down: administratively down
 #down: LBDT down
+-down: link flap down
 (l): loopback
 (s): spoofing
 (E): E-Trunk down


### PR DESCRIPTION
On some Huawei VRP switches (first noticed on `S6730-H24X6C` running `V200R022C00SPC500`) the output of the command `display interface description` includes one additional line `-down: link flap down`. 

This breaks the current template with the following error, which this PR attempts to fix:

```json
[
	"State Error raised. Rule Line: 13. Input Line: -down: link flap down"
]
``` 