### PR TITLE
Update cisco_asa_show_running-config_object_network.textfsm

### DIFF
--- a/ntc_templates/templates/cisco_asa_show_access-list.textfsm
+++ b/ntc_templates/templates/cisco_asa_show_access-list.textfsm
@@ -18,6 +18,13 @@ Value SRC_V6NETWORK ([0-9a-f:]+)
 Value SRC_MASK (\d+\.\d+\.\d+\.\d+)
 Value SRC_V6MASK (\d{1,3})
 Value SRC_ANY (any[46]{0,1})
+Value SRC_PORT (\S+)
+Value SRC_PORT_LESS_THAN (\S+)
+Value SRC_PORT_GREATER_THAN (\S+)
+Value SRC_PORT_RANGE_START (\S+)
+Value SRC_PORT_RANGE_END (\S+)
+Value SRC_PORT_GRP (\S+)
+Value SRC_PORT_OBJECT (\S+)
 Value DST_INTFC (\S+)
 Value DST_OBJECT_GRP (\S+)
 Value DST_OBJECT (\S+)
@@ -43,31 +50,38 @@ Value STATE (inactive)
 Value HIT_COUNT (\d+)
 Value LINE_HASH (0x\w+)
 Value ENTRY_PROTOCOL_ICMP (icmp)
-Value ENTRY_PROTOCOL ([a-z\-]+)
+Value ENTRY_PROTOCOL ([a-z\-\d]+)
 Value ENTRY_SRC_FQDN (\S+)
 Value ENTRY_SRC_RANGE_START (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_SRC_RANGE_END (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_SRC_HOST (\d+\.\d+\.\d+\.\d+)
+Value ENTRY_SRC_HOST_FQDN (\S+)
 Value ENTRY_SRC_V6HOST ([0-9a-f:]+)
 Value ENTRY_SRC_NETWORK (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_SRC_V6NETWORK ([0-9a-f:]+)
 Value ENTRY_SRC_MASK (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_SRC_V6MASK (\d{1,3})
 Value ENTRY_SRC_ANY (any[46]{0,1})
-Value ENTRY_SRC_FQDN_STATE (unresolved)
+Value ENTRY_SRC_FQDN_STATE (resolved|unresolved)
 Value ENTRY_DST_FQDN (\S+)
 Value ENTRY_DST_RANGE_START (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_DST_RANGE_END (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_DST_HOST (\S+)
+Value ENTRY_DST_HOST_FQDN (\S+)
 Value ENTRY_DST_V6HOST ([0-9a-f:]+)
 Value ENTRY_DST_NETWORK (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_DST_V6NETWORK ([0-9a-f:]+)
 Value ENTRY_DST_MASK (\d+\.\d+\.\d+\.\d+)
 Value ENTRY_DST_V6MASK (\d{1,3})
 Value ENTRY_DST_ANY (any[46]{0,1})
-Value ENTRY_DST_FQDN_STATE (unresolved)
+Value ENTRY_DST_FQDN_STATE (resolved|unresolved)
 Value ENTRY_ICMP_TYPE (alternate-address|conversion-error|echo|echo-reply|information-reply|information-request|mask-reply|mask-request|mobile-redirect|parameter-problem|redirect|router-advertisement|router-solicitation|source-quench|time-exceeded|timestamp-reply|timestamp-request|traceroute|unreachable|\d{1,3})
 Value ENTRY_ICMP_CODE (\d+)
+Value ENTRY_SRC_PORT ([a-z\-]+\s+\d+|[\w\-]+)
+Value ENTRY_SRC_PORT_LESS_THAN ([a-z\-]+\s+\d+|\S+)
+Value ENTRY_SRC_PORT_GREATER_THAN ([a-z\-]+\s+\d+|\S+)
+Value ENTRY_SRC_PORT_RANGE_START ([a-z\-]+\s+\d+|\S+)
+Value ENTRY_SRC_PORT_RANGE_END ([a-z\-]+\s+\d+|\S+)
 Value ENTRY_PORT ([a-z\-]+\s+\d+|[\w\-]+)
 Value ENTRY_PORT_LESS_THAN ([a-z\-]+\s+\d+|\S+)
 Value ENTRY_PORT_GREATER_THAN ([a-z\-]+\s+\d+|\S+)
@@ -83,9 +97,9 @@ Start
   ^access\-list\s+cached\s+ACL\s+log\s+flows.* -> NoRecord
   ^\s+alert-interval\s+\d+ -> NoRecord
   ^access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+remark\s+${REMARK}\s*$$ -> Record
-  ^access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+${TYPE}\s+${ACTION}\s+(object\-group\s+${SVC_OBJECT_GRP}|object\s+${SVC_OBJECT}|${PROTOCOL})\s+(interface\s+${SRC_INTFC}|object\-group\s+${SRC_OBJECT_GRP}|object\s+${SRC_OBJECT}|host\s+(${SRC_HOST}|${SRC_V6HOST})|${SRC_NETWORK}\s+${SRC_MASK}|${SRC_V6NETWORK}\/${SRC_V6MASK}|${SRC_ANY})\s+(interface\s+${DST_INTFC}|object\-group\s+${DST_OBJECT_GRP}|object\s+${DST_OBJECT}|host\s+(${DST_HOST}|${DST_V6HOST})|${DST_NETWORK}\s+${DST_MASK}|${DST_V6NETWORK}\/${DST_V6MASK}|${DST_ANY})\s+((eq\s+${DST_PORT}|lt\s+${DST_PORT_LESS_THAN}|gt\s+${DST_PORT_GREATER_THAN}|range\s+${DST_PORT_RANGE_START}\s+${DST_PORT_RANGE_END}|object\-group\s+${DST_PORT_GRP}|object\s+${DST_PORT_OBJECT})\s+){0,1}(${ENTRY_ICMP_TYPE}(\s+${ENTRY_ICMP_CODE}){0,1}\s+){0,1}((log\s+(${LOG_LEVEL}\s+interval\s+${LOG_INTERVAL}|disable|default))\s+){0,1}(time-range\s+${TIME_RANGE}\s+){0,1}(${STATE}\s+){0,1}\(hitcnt=${HIT_COUNT}\)\s+(\(inactive\)\s+){0,1}${LINE_HASH}\s* -> Record
-  ^\s+access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+${TYPE}\s+${ACTION}\s+${ENTRY_PROTOCOL_ICMP}\s+(fqdn\s+${ENTRY_SRC_FQDN}|range\s+${ENTRY_SRC_RANGE_START}\s+${ENTRY_SRC_RANGE_END}|host\s+(${ENTRY_SRC_HOST}|${ENTRY_SRC_V6HOST})|${ENTRY_SRC_NETWORK}\s+${ENTRY_SRC_MASK}|${ENTRY_SRC_V6NETWORK}\/${ENTRY_SRC_V6MASK}|${ENTRY_SRC_ANY})\s+(\(${ENTRY_SRC_FQDN_STATE}\)\s+){0,1}(fqdn\s+${ENTRY_DST_FQDN}|range\s+${ENTRY_DST_RANGE_START}\s+${ENTRY_DST_RANGE_END}|host\s+(${ENTRY_DST_HOST}|${ENTRY_DST_V6HOST})|${ENTRY_DST_NETWORK}\s+${ENTRY_DST_MASK}|${ENTRY_DST_V6NETWORK}\/${ENTRY_DST_V6MASK}|${ENTRY_DST_ANY})\s+(\(${ENTRY_DST_FQDN_STATE}\)\s+){0,1}(${ENTRY_ICMP_TYPE}(\s+${ENTRY_ICMP_CODE}){0,1}\s+){0,1}(log\s+(${LOG_LEVEL}\s+interval\s+${LOG_INTERVAL}|disable|default)\s+){0,1}(time-range\s+${TIME_RANGE}\s+){0,1}(inactive){0,1}\s*(\(hitcnt=${ENTRY_HIT_COUNT}\)){0,1}\s*(\(${ENTRY_STATE}\)){0,1}\s+${ENTRY_HASH}\s* -> Record
-  ^\s+access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+${TYPE}\s+${ACTION}\s+(${ENTRY_PROTOCOL}\s+){0,1}(fqdn\s+${ENTRY_SRC_FQDN}|range\s+${ENTRY_SRC_RANGE_START}\s+${ENTRY_SRC_RANGE_END}|host\s+(${ENTRY_SRC_HOST}|${ENTRY_SRC_V6HOST})|${ENTRY_SRC_NETWORK}\s+${ENTRY_SRC_MASK}|${ENTRY_SRC_V6NETWORK}\/${ENTRY_SRC_V6MASK}|${ENTRY_SRC_ANY})\s+(\(${ENTRY_SRC_FQDN_STATE}\)\s+){0,1}((fqdn\s+${ENTRY_DST_FQDN}|range\s+${ENTRY_DST_RANGE_START}\s+${ENTRY_DST_RANGE_END}|host\s+(${ENTRY_DST_HOST}|${ENTRY_DST_V6HOST})|${ENTRY_DST_NETWORK}\s+${ENTRY_DST_MASK}|${ENTRY_DST_V6NETWORK}\/${ENTRY_DST_V6MASK}|${ENTRY_DST_ANY})\s+){0,1}(\(${ENTRY_DST_FQDN_STATE}\)\s+){0,1}((eq\s+${ENTRY_PORT}|lt\s+${ENTRY_PORT_LESS_THAN}|gt\s+${ENTRY_PORT_GREATER_THAN}|range\s+${ENTRY_PORT_RANGE_START}\s+${ENTRY_PORT_RANGE_END})\s+){0,1}(log\s+([a-z0-9]+\s+interval\s+\d+|disable|default)\s+){0,1}(time-range\s+${TIME_RANGE}\s+){0,1}(inactive){0,1}\s*(\(hitcnt=${ENTRY_HIT_COUNT}\)){0,1}\s*(\(${ENTRY_STATE}\)){0,1}\s+${ENTRY_HASH}\s* -> Record
+  ^access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+${TYPE}\s+${ACTION}\s+(object\-group\s+${SVC_OBJECT_GRP}|object\s+${SVC_OBJECT}|${PROTOCOL})\s+(interface\s+${SRC_INTFC}|object\-group\s+${SRC_OBJECT_GRP}|object\s+${SRC_OBJECT}|host\s+(${SRC_HOST}|${SRC_V6HOST})|${SRC_NETWORK}\s+${SRC_MASK}|${SRC_V6NETWORK}\/${SRC_V6MASK}|${SRC_ANY})\s+((eq\s+${SRC_PORT}|lt\s+${SRC_PORT_LESS_THAN}|gt\s+${SRC_PORT_GREATER_THAN}|range\s+${SRC_PORT_RANGE_START}\s+${SRC_PORT_RANGE_END}|object\-group\s+${SRC_PORT_GRP}|object\s+${SRC_PORT_OBJECT})\s+){0,1}(interface\s+${DST_INTFC}|object\-group\s+${DST_OBJECT_GRP}|object\s+${DST_OBJECT}|host\s+(${DST_HOST}|${DST_V6HOST})|${DST_NETWORK}\s+${DST_MASK}|${DST_V6NETWORK}\/${DST_V6MASK}|${DST_ANY})\s+((eq\s+${DST_PORT}|lt\s+${DST_PORT_LESS_THAN}|gt\s+${DST_PORT_GREATER_THAN}|range\s+${DST_PORT_RANGE_START}\s+${DST_PORT_RANGE_END}|object\-group\s+${DST_PORT_GRP}|object\s+${DST_PORT_OBJECT})\s+){0,1}(${ENTRY_ICMP_TYPE}(\s+${ENTRY_ICMP_CODE}){0,1}\s+){0,1}((log\s+(${LOG_LEVEL}\s+interval\s+${LOG_INTERVAL}|disable|default))\s+){0,1}(time-range\s+${TIME_RANGE}\s+){0,1}(${STATE}\s+){0,1}\(hitcnt=${HIT_COUNT}\)\s+(\(inactive\)\s+){0,1}${LINE_HASH}\s* -> Record
+  ^\s+access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+${TYPE}\s+${ACTION}\s+${ENTRY_PROTOCOL_ICMP}\s+(fqdn\s+${ENTRY_SRC_FQDN}|range\s+${ENTRY_SRC_RANGE_START}\s+${ENTRY_SRC_RANGE_END}|host\s+(${ENTRY_SRC_HOST}(\s+\(${ENTRY_SRC_HOST_FQDN}\)){0,1}|${ENTRY_SRC_V6HOST})|${ENTRY_SRC_NETWORK}\s+${ENTRY_SRC_MASK}|${ENTRY_SRC_V6NETWORK}\/${ENTRY_SRC_V6MASK}|${ENTRY_SRC_ANY})\s+(\(${ENTRY_SRC_FQDN_STATE}\)\s+){0,1}(fqdn\s+${ENTRY_DST_FQDN}|range\s+${ENTRY_DST_RANGE_START}\s+${ENTRY_DST_RANGE_END}|host\s+(${ENTRY_DST_HOST}(\s+\(${ENTRY_DST_HOST_FQDN}\)){0,1}|${ENTRY_DST_V6HOST})|${ENTRY_DST_NETWORK}\s+${ENTRY_DST_MASK}|${ENTRY_DST_V6NETWORK}\/${ENTRY_DST_V6MASK}|${ENTRY_DST_ANY})\s+(\(${ENTRY_DST_FQDN_STATE}\)\s+){0,1}(${ENTRY_ICMP_TYPE}(\s+${ENTRY_ICMP_CODE}){0,1}\s+){0,1}(log\s+(${LOG_LEVEL}\s+interval\s+${LOG_INTERVAL}|disable|default)\s+){0,1}(time-range\s+${TIME_RANGE}\s+){0,1}(inactive){0,1}\s*(\(hitcnt=${ENTRY_HIT_COUNT}\)){0,1}\s*(\(${ENTRY_STATE}\)){0,1}\s*${ENTRY_HASH}\s* -> Record
+  ^\s*access\-list\s+${ACL_NAME}\s+line\s+${LINE_NUM}\s+${TYPE}\s+${ACTION}\s+(${ENTRY_PROTOCOL}\s+){0,1}(fqdn\s+${ENTRY_SRC_FQDN}|range\s+${ENTRY_SRC_RANGE_START}\s+${ENTRY_SRC_RANGE_END}|host\s+(${ENTRY_SRC_HOST}(\s+\(${ENTRY_SRC_HOST_FQDN}\)){0,1}|${ENTRY_SRC_V6HOST})|${ENTRY_SRC_NETWORK}\s+${ENTRY_SRC_MASK}|${ENTRY_SRC_V6NETWORK}\/${ENTRY_SRC_V6MASK}|${ENTRY_SRC_ANY})\s+(\(${ENTRY_SRC_FQDN_STATE}\)\s+){0,1}((eq\s+${ENTRY_SRC_PORT}|lt\s+${ENTRY_SRC_PORT_LESS_THAN}|gt\s+${ENTRY_SRC_PORT_GREATER_THAN}|range\s+${ENTRY_SRC_PORT_RANGE_START}\s+${ENTRY_SRC_PORT_RANGE_END})\s+){0,1}((fqdn\s+${ENTRY_DST_FQDN}|range\s+${ENTRY_DST_RANGE_START}\s+${ENTRY_DST_RANGE_END}|host\s+(${ENTRY_DST_HOST}(\s+\(${ENTRY_DST_HOST_FQDN}\)){0,1}|${ENTRY_DST_V6HOST})|${ENTRY_DST_NETWORK}\s+${ENTRY_DST_MASK}|${ENTRY_DST_V6NETWORK}\/${ENTRY_DST_V6MASK}|${ENTRY_DST_ANY})\s+){0,1}(\(${ENTRY_DST_FQDN_STATE}\)\s+){0,1}((eq\s+${ENTRY_PORT}|lt\s+${ENTRY_PORT_LESS_THAN}|gt\s+${ENTRY_PORT_GREATER_THAN}|range\s+${ENTRY_PORT_RANGE_START}\s+${ENTRY_PORT_RANGE_END})\s+){0,1}(log\s+([a-z0-9]+\s+interval\s+\d+|disable|default)\s+){0,1}(time-range\s+${TIME_RANGE}\s+){0,1}(inactive){0,1}\s*(\(hitcnt=${ENTRY_HIT_COUNT}\)){0,1}\s*(\(${ENTRY_STATE}\)){0,1}\s*${ENTRY_HASH}\s* -> Record
   ^.* -> Error "Did not match any rules"
 
 EOF

--- a/ntc_templates/templates/cisco_asa_show_running-config_object_network.textfsm
+++ b/ntc_templates/templates/cisco_asa_show_running-config_object_network.textfsm
@@ -7,7 +7,7 @@ Value NETMASK (\S+)
 Value PREFIX_LENGTH (\d+)
 Value START_IP (\S+)
 Value END_IP (\S+)
-
+Value FQDN ((v[46]\s+){0,1}\S+)
 
 Start
   ^object\s+network -> Continue.Record
@@ -18,4 +18,5 @@ Start
   ^\s+subnet\s+${NETWORK}\/${PREFIX_LENGTH}\s*
   ^\s+range\s+${START_IP}\s+${END_IP}\s*
   ^\s+host\s+${HOST}\s*
+  ^\s+fqdn\s+${FQDN}\s*
   ^. -> Error


### PR DESCRIPTION
This update includes the case where an object of type network includes an FQDN entry.

It was tested and worked on a Cisco ASA 5545 running version 9.12(4)67