### PR TITLE
fix: `show vlans` for cisco-ios to get IPv6 ip addresses

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_vlans.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_vlans.textfsm
@@ -1,6 +1,7 @@
 Value Required VLAN_ID (\d+)
 Value List INTERFACES ([\w\./-]+)
 Value List IP_ADDRESSES (\S+)
+Value List IPV6_ADDRESSES (\S+)
 
 Start
   ^VLAN\s+ID:\s+${VLAN_ID} -> Data
@@ -26,7 +27,10 @@ Data
   ^${INTERFACES}\s+\(\d+\)\s*$$
   ^\s+IP:\s+${IP_ADDRESSES}\s*$$
   ^\s+IP\s+${IP_ADDRESSES}\s+\d+\s+\d+
+  ^\s+IPv6:\s+${IPV6_ADDRESSES}\s*$$
+  ^\s+IPv6\s+${IPV6_ADDRESSES}\s+\d+\s+\d+
   ^\s+Other\s+\d+\s+\d+
+  ^\s+IPv6\s+\d+\s+\d+
   ^\s+Total\s\d+
   ^\s+\d+\s+packets,
   ^\s*$$
@@ -37,6 +41,7 @@ Interface
   ^\s*\S+\s+\(\S+\)$$
   ^\s+Total\s+\d+\s+
   ^\s+IP\:\s+${IP_ADDRESSES}
+  ^\s+IPv6\:\s+${IPV6_ADDRESSES}
   ^\s+MPLS\:\s+
   ^\s+Protocols\s+Configured\: -> Data
   ^\s+This\s+is\s+configured\s+as\s+native\s+Vlan -> Data

--- a/tests/cisco_ios/show_vlans/cisco_ios_show_vlans.yml
+++ b/tests/cisco_ios/show_vlans/cisco_ios_show_vlans.yml
@@ -9,6 +9,7 @@ parsed_sample:
       - "10.0.2.86"
       - "10.0.2.225"
       - "10.252.212.189"
+    ipv6_addresses: []
   - vlan_id: "3141"
     interfaces:
       - "GigabitEthernet0/0/0.3141"
@@ -16,31 +17,37 @@ parsed_sample:
     ip_addresses:
       - "10.0.2.94"
       - "10.0.2.233"
+    ipv6_addresses: []
   - vlan_id: "100"
     interfaces:
       - "TenGigabitEthernet0/1/0.100"
     ip_addresses:
       - "10.0.2.149"
+    ipv6_addresses: []
   - vlan_id: "101"
     interfaces:
       - "TenGigabitEthernet0/1/0.101"
     ip_addresses:
       - "10.0.2.145"
+    ipv6_addresses: []
   - vlan_id: "102"
     interfaces:
       - "TenGigabitEthernet0/1/0.102"
     ip_addresses:
       - "10.0.2.153"
+    ipv6_addresses: []
   - vlan_id: "103"
     interfaces:
       - "TenGigabitEthernet0/1/0.103"
     ip_addresses:
       - "10.0.2.157"
+    ipv6_addresses: []
   - vlan_id: "104"
     interfaces:
       - "TenGigabitEthernet0/1/0.104"
     ip_addresses:
       - "10.0.231.229"
+    ipv6_addresses: []
   - vlan_id: "3228"
     interfaces:
       - "GigabitEthernet0/0/0.3228"
@@ -48,6 +55,7 @@ parsed_sample:
     ip_addresses:
       - "10.0.231.242"
       - "10.0.231.233"
+    ipv6_addresses: []
   - vlan_id: "3000"
     interfaces:
       - "GigabitEthernet0/0/0.3000"
@@ -55,6 +63,7 @@ parsed_sample:
     ip_addresses:
       - "10.0.2.90"
       - "10.0.2.229"
+    ipv6_addresses: []
   - vlan_id: "3017"
     interfaces:
       - "GigabitEthernet0/0/0.3017"
@@ -62,6 +71,7 @@ parsed_sample:
     ip_addresses:
       - "10.0.2.98"
       - "10.0.2.237"
+    ipv6_addresses: []
   - vlan_id: "3062"
     interfaces:
       - "GigabitEthernet0/0/0.3062"
@@ -69,3 +79,4 @@ parsed_sample:
     ip_addresses:
       - "10.0.2.102"
       - "10.0.2.241"
+    ipv6_addresses: []

--- a/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_01.yml
+++ b/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_01.yml
@@ -3,9 +3,11 @@ parsed_sample:
   - interfaces:
       - "GigabitEthernet0/0"
     ip_addresses: []
+    ipv6_addresses: []
     vlan_id: "1"
   - interfaces:
       - "GigabitEthernet0/0.36"
     ip_addresses:
       - "10.1.0.1"
+    ipv6_addresses: []
     vlan_id: "36"

--- a/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_02.yml
+++ b/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_02.yml
@@ -5,9 +5,11 @@ parsed_sample:
       - "GigabitEthernet0/2"
     ip_addresses:
       - "172.16.16.65"
+    ipv6_addresses: []
     vlan_id: "1"
   - interfaces:
       - "GigabitEthernet0/1.106"
     ip_addresses:
       - "10.10.10.1"
+    ipv6_addresses: []
     vlan_id: "106"

--- a/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_03.yml
+++ b/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_03.yml
@@ -4,9 +4,11 @@ parsed_sample:
       - "TenGigabitEthernet3/20.1"
     ip_addresses:
       - "172.16.16.54"
+    ipv6_addresses: []
     vlan_id: "10"
   - interfaces:
       - "TenGigabitEthernet3/20.22"
     ip_addresses:
       - "172.16.16.8"
+    ipv6_addresses: []
     vlan_id: "22"

--- a/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_04.yml
+++ b/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_04.yml
@@ -3,9 +3,11 @@ parsed_sample:
   - interfaces:
       - "GigabitEthernet0/0/1"
     ip_addresses: []
+    ipv6_addresses: []
     vlan_id: "1"
   - interfaces:
       - "GigabitEthernet0/0/1.103"
     ip_addresses:
       - "10.16.16.129"
+    ipv6_addresses: []
     vlan_id: "103"

--- a/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_05.yml
+++ b/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_05.yml
@@ -4,16 +4,19 @@ parsed_sample:
       - "Port-channel10"
       - "Port-channel11"
     ip_addresses: []
+    ipv6_addresses: []
     vlan_id: "1"
   - interfaces:
       - "Port-channel10.3101"
       - "Port-channel11.3101"
     ip_addresses:
       - "172.16.16.54"
+    ipv6_addresses: []
     vlan_id: "3101"
   - interfaces:
       - "Port-channel10.3102"
       - "Port-channel11.3102"
     ip_addresses:
       - "172.17.17.58"
+    ipv6_addresses: []
     vlan_id: "3102"

--- a/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_06.yml
+++ b/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_06.yml
@@ -3,11 +3,13 @@ parsed_sample:
   - interfaces:
       - "Port-channel14"
     ip_addresses: []
+    ipv6_addresses: []
     vlan_id: "1"
   - interfaces:
       - "Port-channel14.2"
     ip_addresses:
       - "192.0.2.1"
+    ipv6_addresses: []
     vlan_id: "2"
   - interfaces:
       - "Port-channel14.501"
@@ -17,4 +19,5 @@ parsed_sample:
       - "192.0.2.2"
       - "192.0.2.3"
       - "192.0.2.4"
+    ipv6_addresses: []
     vlan_id: "501"

--- a/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_07.raw
+++ b/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_07.raw
@@ -1,0 +1,158 @@
+VLAN ID: 3084 (IEEE 802.1Q Encapsulation)
+
+   Protocols Configured:          Received:        Transmitted:
+                     IP         1379273851          1393511050
+
+VLAN trunk interfaces for VLAN ID 3084:
+HundredGigE2/0/0.3084
+
+HundredGigE2/0/0.3084 (3084)
+
+                     IP: 10.247.62.37
+
+      Total 1379277713 packets, 120663875433 bytes input
+      Total 1393518607 packets, 188818944216 bytes output
+      Total 0 oversubscription packet drops
+
+VLAN ID: 1 (IEEE 802.1Q Encapsulation)
+
+ This is configured as native Vlan for the following interface(s) :
+HundredGigE2/0/0    Native-vlan Tx-type: Untagged
+TenGigabitEthernet2/1/8    Native-vlan Tx-type: Untagged
+TenGigabitEthernet2/1/9    Native-vlan Tx-type: Untagged
+Port-channel10    Native-vlan Tx-type: Untagged
+Port-channel30    Native-vlan Tx-type: Untagged
+
+   Protocols Configured:          Received:        Transmitted:
+                     IP      6541368380841       6472616296020
+                   IPv6         8274039002         30233393091
+
+VLAN trunk interfaces for VLAN ID 1:
+HundredGigE2/0/0
+
+HundredGigE2/0/0 (1)
+
+                     IP: 10.247.53.229
+
+      Total 1115482 packets, 416350865 bytes input
+      Total 1115506 packets, 416321434 bytes output
+      Total 0 oversubscription packet drops
+TenGigabitEthernet2/1/8
+
+TenGigabitEthernet2/1/8 (1)
+
+                     IP: 10.247.52.197
+
+      Total 1022659290 packets, 56136462971 bytes input
+      Total 879480 packets, 333859004 bytes output
+      Total 0 oversubscription packet drops
+TenGigabitEthernet2/1/9
+
+TenGigabitEthernet2/1/9 (1)
+
+
+      Total 9 packets, 6477 bytes input
+      Total 89558 packets, 6895966 bytes output
+      Total 0 oversubscription packet drops
+Port-channel10
+
+Port-channel10 (1)
+
+
+      Total 201486441 packets, 25752365485 bytes input
+      Total 91564 packets, 7050428 bytes output
+Port-channel30
+
+Port-channel30 (1)
+
+                     IP: 10.247.58.138
+                   IPv6: FE80::4
+
+      Total 120827408 packets, 15556961031 bytes input
+      Total 811792 packets, 67689708 bytes output
+
+VLAN ID: 2 (IEEE 802.1Q Encapsulation)
+
+   Protocols Configured:          Received:        Transmitted:
+                     IP           29074846            25968697
+
+VLAN trunk interfaces for VLAN ID 2:
+Port-channel10.2
+
+Port-channel10.2 (2)
+
+                     IP: 10.252.218.109
+
+      Total 29078127 packets, 8615015870 bytes input
+      Total 25976050 packets, 6163071365 bytes output
+
+
+VLAN ID: 3013 (IEEE 802.1Q Encapsulation)
+
+   Protocols Configured:          Received:        Transmitted:
+                     IP         1573635970          1591959627
+
+VLAN trunk interfaces for VLAN ID 3013:
+HundredGigE2/0/0.3013
+
+HundredGigE2/0/0.3013 (3013)
+
+                     IP: 10.247.59.65
+
+      Total 1319146066 packets, 92480624537 bytes input
+      Total 1319243308 packets, 97679149017 bytes output
+      Total 0 oversubscription packet drops
+TenGigabitEthernet2/1/8.3013
+
+TenGigabitEthernet2/1/8.3013 (3013)
+
+                     IP: 10.247.44.13
+
+      Total 254494199 packets, 17822122501 bytes input
+      Total 272725599 packets, 20198540106 bytes output
+      Total 0 oversubscription packet drops
+
+
+VLAN ID: 3039 (IEEE 802.1Q Encapsulation)
+
+   Protocols Configured:          Received:        Transmitted:
+                     IP         1339885034          1344016315
+
+VLAN trunk interfaces for VLAN ID 3039:
+HundredGigE2/0/0.3039
+
+HundredGigE2/0/0.3039 (3039)
+
+                     IP: 10.247.37.253
+
+      Total 1339888657 packets, 104375311608 bytes input
+      Total 1344023630 packets, 120551040721 bytes output
+      Total 0 oversubscription packet drops
+
+
+VLAN ID: 3041 (IEEE 802.1Q Encapsulation)
+
+   Protocols Configured:          Received:        Transmitted:
+                     IP     19330790405514      20425659306056
+                   IPv6       108710041805         76514210281
+
+VLAN trunk interfaces for VLAN ID 3041:
+HundredGigE2/0/0.3041
+
+HundredGigE2/0/0.3041 (3041)
+
+                     IP: 10.247.28.69
+                   IPv6: FE80::1
+
+      Total 19401785065329 packets, 15931092255882505 bytes input
+      Total 20470771799948 packets, 14337966338477780 bytes output
+      Total 0 oversubscription packet drops
+TenGigabitEthernet2/1/8.3041
+
+TenGigabitEthernet2/1/8.3041 (3041)
+
+                     IP: 10.247.52.201
+
+      Total 37711502876 packets, 24910543920510 bytes input
+      Total 31397101637 packets, 14774938204031 bytes output
+      Total 0 oversubscription packet drops

--- a/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_07.yml
+++ b/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_07.yml
@@ -1,0 +1,50 @@
+---
+parsed_sample:
+  - interfaces:
+      - "HundredGigE2/0/0.3084"
+    ip_addresses:
+      - "10.247.62.37"
+    ipv6_addresses: []
+    vlan_id: "3084"
+  - interfaces:
+      - "HundredGigE2/0/0"
+      - "TenGigabitEthernet2/1/8"
+      - "TenGigabitEthernet2/1/9"
+      - "Port-channel10"
+      - "Port-channel30"
+    ip_addresses:
+      - "10.247.53.229"
+      - "10.247.52.197"
+      - "10.247.58.138"
+    ipv6_addresses:
+      - "FE80::4"
+    vlan_id: "1"
+  - interfaces:
+      - "Port-channel10.2"
+    ip_addresses:
+      - "10.252.218.109"
+    ipv6_addresses: []
+    vlan_id: "2"
+  - interfaces:
+      - "HundredGigE2/0/0.3013"
+      - "TenGigabitEthernet2/1/8.3013"
+    ip_addresses:
+      - "10.247.59.65"
+      - "10.247.44.13"
+    ipv6_addresses: []
+    vlan_id: "3013"
+  - interfaces:
+      - "HundredGigE2/0/0.3039"
+    ip_addresses:
+      - "10.247.37.253"
+    ipv6_addresses: []
+    vlan_id: "3039"
+  - interfaces:
+      - "HundredGigE2/0/0.3041"
+      - "TenGigabitEthernet2/1/8.3041"
+    ip_addresses:
+      - "10.247.28.69"
+      - "10.247.52.201"
+    ipv6_addresses:
+      - "FE80::1"
+    vlan_id: "3041"


### PR DESCRIPTION
If IPv6 is configured in Cisco IOS-XE devices the parsing of the command `show vlans` returns error because cannot parse the outputs regarding IPv6. This tries to fix this issue and close #1747 