### PR TITLE
bugfix - cisco_xr sh inv whitespace issue1393

### DIFF
--- a/ntc_templates/templates/cisco_xr_admin_show_inventory.textfsm
+++ b/ntc_templates/templates/cisco_xr_admin_show_inventory.textfsm
@@ -1,5 +1,5 @@
 Value Required NAME (.*?)
-Value DESCR (.*)
+Value DESCR (.*?)
 Value PID (\S+)
 Value VID (\S+)
 Value SN (\S*)
@@ -10,6 +10,6 @@ Start
   ^\s*PID:\s+${PID}\s*,\s+VID:\s+${VID}\s*,\s+SN:\s*${SN}$$ -> Record
   ^\s*PID:\s+${PID}\s+(,\s+)?VID:\s+${VID}\s+(,\s+)?SN:\s+${SN}\s*$$ -> Record
   #
-  ^\s*$$ 
+  ^\s*$$
   ^(Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s\S{3}\s+\d
   ^. -> Error

--- a/ntc_templates/templates/cisco_xr_admin_show_inventory.textfsm
+++ b/ntc_templates/templates/cisco_xr_admin_show_inventory.textfsm
@@ -7,7 +7,7 @@ Value SN (\S*)
 Start
   ^NAME:\s+"${NAME}",\s+DESCR:\s+"${DESCR}"\s*$$
   ^\s*Name:\s+${NAME}\s+Descr:\s+${DESCR}\s*$$
-  ^\s*PID:\s+${PID}\s*,\s+VID:\s+${VID}\s*,\s+SN:\s*${SN}$$ -> Record
+  ^\s*PID:\s+${PID}\s*,\s+VID:\s+${VID}\s*,\s+SN:\s*${SN}\s*$$ -> Record
   ^\s*PID:\s+${PID}\s+(,\s+)?VID:\s+${VID}\s+(,\s+)?SN:\s+${SN}\s*$$ -> Record
   #
   ^\s*$$

--- a/tests/cisco_xr/admin_show_inventory/cisco_xr_admin_show_inventory4.raw
+++ b/tests/cisco_xr/admin_show_inventory/cisco_xr_admin_show_inventory4.raw
@@ -1,0 +1,11 @@
+Thu Jul  6 08:36:32.002 UTC
+  
+ Name: Rack 0                Descr: Cisco IOS-XRv 9000 Centralized Virtual Router               
+ PID: R-IOSXRV9000-CC        VID: V01                   SN: FOC1234PA56 
+ 
+ Name: 0/0                   Descr: Cisco IOS-XRv 9000 Centralized Line Card                    
+ PID: R-IOSXRV9000-LC-C      VID: V01                   SN: FOC4321PA6D 
+ 
+ Name: 0/RP0                 Descr: Cisco IOS-XRv 9000 Centralized Route Processor              
+ PID: R-IOSXRV9000-RP-C      VID: V01                   SN: FOC7085NP2K 
+ 

--- a/tests/cisco_xr/admin_show_inventory/cisco_xr_admin_show_inventory4.raw
+++ b/tests/cisco_xr/admin_show_inventory/cisco_xr_admin_show_inventory4.raw
@@ -8,4 +8,3 @@ Thu Jul  6 08:36:32.002 UTC
  
  Name: 0/RP0                 Descr: Cisco IOS-XRv 9000 Centralized Route Processor              
  PID: R-IOSXRV9000-RP-C      VID: V01                   SN: FOC7085NP2K 
- 

--- a/tests/cisco_xr/admin_show_inventory/cisco_xr_admin_show_inventory4.yml
+++ b/tests/cisco_xr/admin_show_inventory/cisco_xr_admin_show_inventory4.yml
@@ -1,0 +1,17 @@
+---
+parsed_sample:
+  - descr: "Cisco IOS-XRv 9000 Centralized Virtual Router"
+    name: "Rack 0"
+    pid: "R-IOSXRV9000-CC"
+    sn: "FOC1234PA56"
+    vid: "V01"
+  - descr: "Cisco IOS-XRv 9000 Centralized Line Card"
+    name: "0/0"
+    pid: "R-IOSXRV9000-LC-C"
+    sn: "FOC4321PA6D"
+    vid: "V01"
+  - descr: "Cisco IOS-XRv 9000 Centralized Route Processor"
+    name: "0/RP0"
+    pid: "R-IOSXRV9000-RP-C"
+    sn: "FOC7085NP2K"
+    vid: "V01"

--- a/tests/cisco_xr/admin_show_inventory/cisco_xr_admin_show_inventory5.raw
+++ b/tests/cisco_xr/admin_show_inventory/cisco_xr_admin_show_inventory5.raw
@@ -1,0 +1,4 @@
+Sat Jul 27 15:34:02.678 UTC
+NAME: "Chassis", DESCR: "IOS XRv Chassis"
+PID: IOSXRV, VID: V01, SN: 9S3NLRASCAL
+

--- a/tests/cisco_xr/admin_show_inventory/cisco_xr_admin_show_inventory5.yml
+++ b/tests/cisco_xr/admin_show_inventory/cisco_xr_admin_show_inventory5.yml
@@ -1,0 +1,7 @@
+---
+parsed_sample:
+  - descr: "IOS XRv Chassis"
+    name: "Chassis"
+    pid: "IOSXRV"
+    sn: "9S3NLRASCAL"
+    vid: "V01"


### PR DESCRIPTION
resolves #1393
supersedes #1396 (closed for inactivity)

bugfix - Virtual XR (ex: XR 9000v) have a bunch of trailing whitespace for the Description in `admin show inventory` raw output.

Thanks to @muhammad-rafi for bringing this up.

Process:
- added muhammad's fork as a remote of my fork
- fetched muhammad's branch
- rebased against current state of ntc-templates/master branch
- resolved merge conflicts
- added XRv (non-9000v) raw output and parsed output
- ran test cases via invoke
- submit this PR
- :grinning: 