### PR TITLE
fix: `show_vlans` not returning packets

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_vlans.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_vlans.textfsm
@@ -26,7 +26,6 @@ Data
   ^[\w\./]+\s*$$
   ^${INTERFACES}\s+\(\d+\)\s*$$
   ^\s+IP:\s+${IP_ADDRESSES}\s*$$
-  ^\s+IP\s+${IP_ADDRESSES}\s+\d+\s+\d+
   ^\s+IP\s+${IP_ADDRESSES}\s+
   ^\s+IPv6:\s+${IPV6_ADDRESSES}\s*$$
   ^\s+IPv6\s+${IPV6_ADDRESSES}\s+\d+\s+\d+

--- a/ntc_templates/templates/cisco_ios_show_vlans.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_vlans.textfsm
@@ -29,7 +29,6 @@ Data
   ^\s+IP\s+${IP_ADDRESSES}\s+
   ^\s+IPv6:\s+${IPV6_ADDRESSES}\s*$$
   ^\s+IPv6\s+${IPV6_ADDRESSES}\s+\d+\s+\d+
-  ^\s+Other\s+\d+\s+\d+
   ^\s+Other\s+
   ^\s+IPv6\s+\d+\s+\d+
   ^\s+Total\s\d+

--- a/ntc_templates/templates/cisco_ios_show_vlans.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_vlans.textfsm
@@ -27,9 +27,11 @@ Data
   ^${INTERFACES}\s+\(\d+\)\s*$$
   ^\s+IP:\s+${IP_ADDRESSES}\s*$$
   ^\s+IP\s+${IP_ADDRESSES}\s+\d+\s+\d+
+  ^\s+IP\s+${IP_ADDRESSES}\s+
   ^\s+IPv6:\s+${IPV6_ADDRESSES}\s*$$
   ^\s+IPv6\s+${IPV6_ADDRESSES}\s+\d+\s+\d+
   ^\s+Other\s+\d+\s+\d+
+  ^\s+Other\s+
   ^\s+IPv6\s+\d+\s+\d+
   ^\s+Total\s\d+
   ^\s+\d+\s+packets,

--- a/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_08.raw
+++ b/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_08.raw
@@ -1,0 +1,50 @@
+Virtual LAN ID:  1 (IEEE 802.1Q Encapsulation)
+
+   vLAN Trunk Interfaces:  GigabitEthernet8
+GigabitEthernet9
+
+ This is configured as native Vlan for the following interface(s) :
+GigabitEthernet8    Native-vlan Tx-type: Untagged
+GigabitEthernet9    Native-vlan Tx-type: Untagged
+
+   Protocols Configured:   Address:              Received:        Transmitted:
+
+GigabitEthernet8 (1)
+           IP              10.249.2.6           903996720           917275590
+        Other                                           0             6689172
+
+   861876081 packets, 104351032620 bytes input
+   886447918 packets, 315385944437 bytes output
+
+GigabitEthernet9 (1)
+           IP              10.252.202.197 
+        Other                                           0             6689172
+
+   43228243 packets, 8882119957 bytes input
+   37516844 packets, 4952240355 bytes output
+
+Virtual LAN ID:  2 (IEEE 802.1Q Encapsulation)
+
+   vLAN Trunk Interface:   GigabitEthernet9.2
+
+   Protocols Configured:   Address:              Received:        Transmitted:
+
+GigabitEthernet9.2 (2)
+           IP              10.253.60.65          66096377            63057013
+        Other                                           0              268232
+
+   66096377 packets, 17476917909 bytes input
+   63325245 packets, 11174981744 bytes output
+
+Virtual LAN ID:  1280 (IEEE 802.1Q Encapsulation)
+
+   vLAN Trunk Interface:   GigabitEthernet9.1280
+
+   Protocols Configured:   Address:              Received:        Transmitted:
+
+GigabitEthernet9.1280 (1280)
+           IP              10.49.14.129                 0                   0
+        Other                                           0                   2
+
+   0 packets, 0 bytes input
+   2 packets, 92 bytes output

--- a/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_08.yml
+++ b/tests/cisco_ios/show_vlans/cisco_ios_show_vlans_08.yml
@@ -1,0 +1,26 @@
+---
+parsed_sample:
+  - interfaces:
+      - "GigabitEthernet8"
+      - "GigabitEthernet9"
+      - "GigabitEthernet8"
+      - "GigabitEthernet9"
+    ip_addresses:
+      - "10.249.2.6"
+      - "10.252.202.197"
+    ipv6_addresses: []
+    vlan_id: "1"
+  - interfaces:
+      - "GigabitEthernet9.2"
+      - "GigabitEthernet9.2"
+    ip_addresses:
+      - "10.253.60.65"
+    ipv6_addresses: []
+    vlan_id: "2"
+  - interfaces:
+      - "GigabitEthernet9.1280"
+      - "GigabitEthernet9.1280"
+    ip_addresses:
+      - "10.49.14.129"
+    ipv6_addresses: []
+    vlan_id: "1280"


### PR DESCRIPTION
Some Cisco IOS devices `show vlans` output return nothing under packets. Similar to the below example: 
```
Virtual LAN ID:  1 (IEEE 802.1Q Encapsulation)

   vLAN Trunk Interfaces:  GigabitEthernet8
GigabitEthernet9

 This is configured as native Vlan for the following interface(s) :
GigabitEthernet8    Native-vlan Tx-type: Untagged
GigabitEthernet9    Native-vlan Tx-type: Untagged

   Protocols Configured:   Address:              Received:        Transmitted:

GigabitEthernet8 (1)
           IP              10.249.2.6           903996720           917275590
        Other                                           0             6689172

   861876081 packets, 104351032620 bytes input
   886447918 packets, 315385944437 bytes output

GigabitEthernet9 (1)
           IP              10.252.202.197 
        Other                                           0             6689172

   43228243 packets, 8882119957 bytes input
   37516844 packets, 4952240355 bytes output

```
This causes the parsing to fail. 
This PR tries to address that issue #1827 