### PR TITLE
fix: cisco `show ip interface` failing if enabled turbo vector

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_ip_interface.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_ip_interface.textfsm
@@ -42,7 +42,7 @@ Start
   ^\s+Security
   ^\s+Split
   ^\s+ICMP
-  ^\s+IP\s+(?:fast|Flow|CEF|Null|multicast|route|output|access|Clear)
+  ^\s+IP\s+(?:fast|Fast|Flow|Normal|CEF|Null|multicast|route|output|access|Clear)
   ^\s+Downstream
   ^\s+Associated
   ^\s+Topology

--- a/tests/cisco_ios/show_ip_interface/cisco_ios_show_ip_interface8.raw
+++ b/tests/cisco_ios/show_ip_interface/cisco_ios_show_ip_interface8.raw
@@ -1,0 +1,46 @@
+Vlan1 is administratively down, line protocol is down
+  Internet protocol processing disabled
+Vlan2 is up, line protocol is up
+  Internet address is 10.253.11.8/25
+  Broadcast address is 255.255.255.255
+  Address determined by non-volatile memory
+  MTU is 1500 bytes
+  Helper address is not set
+  Directed broadcast forwarding is disabled
+  Outgoing access list is not set
+  Inbound  access list is not set
+  Proxy ARP is enabled
+  Local Proxy ARP is disabled
+  Security level is default
+  Split horizon is enabled
+  ICMP redirects are always sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  IP fast switching is enabled
+  IP fast switching on the same interface is disabled
+  IP Flow switching is disabled
+  IP CEF switching is enabled
+  IP Fast switching turbo vector
+  IP Normal CEF switching turbo vector
+  IP multicast fast switching is enabled
+  IP multicast distributed fast switching is disabled
+  IP route-cache flags are Fast, CEF
+  Router Discovery is disabled
+  IP output packet accounting is disabled
+  IP access violation accounting is disabled
+  TCP/IP header compression is disabled
+  RTP/IP header compression is disabled
+  Probe proxy name replies are disabled
+  Policy routing is disabled
+  Network address translation is disabled
+  WCCP Redirect outbound is disabled
+  WCCP Redirect inbound is disabled
+  WCCP Redirect exclude is disabled
+  BGP Policy Mapping is disabled
+  Sampled Netflow is disabled
+  IP multicast multilayer switching is disabled
+Vlan300 is up, line protocol is up
+  Internet protocol processing disabled
+GigabitEthernet1/1 is up, line protocol is up
+GigabitEthernet1/2 is up, line protocol is up
+  Inbound  access list is not set

--- a/tests/cisco_ios/show_ip_interface/cisco_ios_show_ip_interface8.yml
+++ b/tests/cisco_ios/show_ip_interface/cisco_ios_show_ip_interface8.yml
@@ -1,0 +1,54 @@
+---
+parsed_sample:
+  - inbound_acl: ""
+    interface: "Vlan1"
+    ip_address: []
+    ip_helper: []
+    link_status: "administratively down"
+    mtu: ""
+    outgoing_acl: ""
+    prefix_length: []
+    protocol_status: "down"
+    vrf: ""
+  - inbound_acl: ""
+    interface: "Vlan2"
+    ip_address:
+      - "10.253.11.8"
+    ip_helper: []
+    link_status: "up"
+    mtu: "1500"
+    outgoing_acl: ""
+    prefix_length:
+      - "25"
+    protocol_status: "up"
+    vrf: ""
+  - inbound_acl: ""
+    interface: "Vlan300"
+    ip_address: []
+    ip_helper: []
+    link_status: "up"
+    mtu: ""
+    outgoing_acl: ""
+    prefix_length: []
+    protocol_status: "up"
+    vrf: ""
+  - inbound_acl: ""
+    interface: "GigabitEthernet1/1"
+    ip_address: []
+    ip_helper: []
+    link_status: "up"
+    mtu: ""
+    outgoing_acl: ""
+    prefix_length: []
+    protocol_status: "up"
+    vrf: ""
+  - inbound_acl: ""
+    interface: "GigabitEthernet1/2"
+    ip_address: []
+    ip_helper: []
+    link_status: "up"
+    mtu: ""
+    outgoing_acl: ""
+    prefix_length: []
+    protocol_status: "up"
+    vrf: ""


### PR DESCRIPTION
Addressing issue #1839 for `show ip interface` failing in Cisco IOS