### PR TITLE
Fix template to properly handle hyphens in 'show lldp neighbors' for arista eos

### DIFF
--- a/ntc_templates/templates/arista_eos_show_lldp_neighbors.textfsm
+++ b/ntc_templates/templates/arista_eos_show_lldp_neighbors.textfsm
@@ -6,7 +6,7 @@ Start
   ^Port.*TTL -> LLDP
 
 LLDP
-  ^${LOCAL_INTERFACE}\s+${NEIGHBOR_NAME}\s+${NEIGHBOR_INTERFACE}\s+\d+ -> Record
+  ^${LOCAL_INTERFACE}\s+${NEIGHBOR_NAME}\s+${NEIGHBOR_INTERFACE}\s+\d+.* -> Record
   # Skip the hyphen header line
   ^--------.*$$
   ^\s*$$

--- a/ntc_templates/templates/arista_eos_show_lldp_neighbors.textfsm
+++ b/ntc_templates/templates/arista_eos_show_lldp_neighbors.textfsm
@@ -6,5 +6,8 @@ Start
   ^Port.*TTL -> LLDP
 
 LLDP
-  ^${LOCAL_INTERFACE}\s+${NEIGHBOR_NAME}\s+${NEIGHBOR_INTERFACE}\s+.* -> Record
-
+  ^${LOCAL_INTERFACE}\s+${NEIGHBOR_NAME}\s+${NEIGHBOR_INTERFACE}\s+\d+ -> Record
+  # Skip the hyphen header line
+  ^--------.*$$
+  ^\s*$$
+  ^. -> Error

--- a/ntc_templates/templates/arista_eos_show_lldp_neighbors.textfsm
+++ b/ntc_templates/templates/arista_eos_show_lldp_neighbors.textfsm
@@ -6,8 +6,8 @@ Start
   ^Port.*TTL -> LLDP
 
 LLDP
-  ^${LOCAL_INTERFACE}\s+${NEIGHBOR_NAME}\s+${NEIGHBOR_INTERFACE}\s+\d+.* -> Record
   # Skip the hyphen header line
   ^--------.*$$
+  ^${LOCAL_INTERFACE}\s+${NEIGHBOR_NAME}\s+${NEIGHBOR_INTERFACE}\s+.* -> Record
   ^\s*$$
   ^. -> Error

--- a/tests/arista_eos/show_lldp_neighbors/arista_eos_show_lldp_neighbors2.raw
+++ b/tests/arista_eos/show_lldp_neighbors/arista_eos_show_lldp_neighbors2.raw
@@ -1,0 +1,13 @@
+Last table change time   : 5 days, 8:24:38 ago
+Number of table inserts  : 9
+Number of table deletes  : 3
+Number of table drops    : 0
+Number of table age-outs : 3
+Port          Neighbor Device ID       Neighbor Port ID    TTL
+---------- ------------------------ ---------------------- ---
+Et2           arista2                  Ethernet2           120
+Et3           arista2                  Ethernet3           120
+Et4           arista2                  Ethernet4           120
+Et5           arista2                  Ethernet5           120
+Et6           arista2                  Ethernet6           120
+Et7           arista2                  Ethernet7           120

--- a/tests/arista_eos/show_lldp_neighbors/arista_eos_show_lldp_neighbors2.yml
+++ b/tests/arista_eos/show_lldp_neighbors/arista_eos_show_lldp_neighbors2.yml
@@ -1,0 +1,20 @@
+---
+parsed_sample:
+  - neighbor_name: arista2
+    local_interface: Et2
+    neighbor_interface: Ethernet2
+  - neighbor_name: arista2
+    local_interface: Et3
+    neighbor_interface: Ethernet3
+  - neighbor_name: arista2
+    local_interface: Et4
+    neighbor_interface: Ethernet4
+  - neighbor_name: arista2
+    local_interface: Et5
+    neighbor_interface: Ethernet5
+  - neighbor_name: arista2
+    local_interface: Et6
+    neighbor_interface: Ethernet6
+  - neighbor_name: arista2
+    local_interface: Et7
+    neighbor_interface: Ethernet7

--- a/tests/arista_eos/show_lldp_neighbors/arista_eos_show_lldp_neighbors2.yml
+++ b/tests/arista_eos/show_lldp_neighbors/arista_eos_show_lldp_neighbors2.yml
@@ -1,20 +1,20 @@
 ---
 parsed_sample:
-  - neighbor_name: arista2
-    local_interface: Et2
-    neighbor_interface: Ethernet2
-  - neighbor_name: arista2
-    local_interface: Et3
-    neighbor_interface: Ethernet3
-  - neighbor_name: arista2
-    local_interface: Et4
-    neighbor_interface: Ethernet4
-  - neighbor_name: arista2
-    local_interface: Et5
-    neighbor_interface: Ethernet5
-  - neighbor_name: arista2
-    local_interface: Et6
-    neighbor_interface: Ethernet6
-  - neighbor_name: arista2
-    local_interface: Et7
-    neighbor_interface: Ethernet7
+  - neighbor_name: "arista2"
+    local_interface: "Et2"
+    neighbor_interface: "Ethernet2"
+  - neighbor_name: "arista2"
+    local_interface: "Et3"
+    neighbor_interface: "Ethernet3"
+  - neighbor_name: "arista2"
+    local_interface: "Et4"
+    neighbor_interface: "Ethernet4"
+  - neighbor_name: "arista2"
+    local_interface: "Et5"
+    neighbor_interface: "Ethernet5"
+  - neighbor_name: "arista2"
+    local_interface: "Et6"
+    neighbor_interface: "Ethernet6"
+  - neighbor_name: "arista2"
+    local_interface: "Et7"
+    neighbor_interface: "Ethernet7"


### PR DESCRIPTION
The hyphens in this following output:

```
netmiko-show --cmd "show lldp neighbors" arista1
Last table change time   : 5 days, 8:50:53 ago
Number of table inserts  : 9
Number of table deletes  : 3
Number of table drops    : 0
Number of table age-outs : 3
Port          Neighbor Device ID       Neighbor Port ID    TTL
---------- ------------------------ ---------------------- ---
Et2           arista2                  Ethernet2           120
Et3           arista2                  Ethernet3           120
Et4           arista2                  Ethernet4           120
Et5           arista2                  Ethernet5           120
Et6           arista2                  Ethernet6           120
Et7           arista2                  Ethernet7           120
```

Was showing up as an entry in the parsed LLDP output table.

This fix causes that hyphen line to be skipped over.
