### PR TITLE
Modified cisco_xr_show_ipv4_interface

### DIFF
--- a/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface5.raw
+++ b/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface5.raw
@@ -1,0 +1,66 @@
+Wed Oct 23 10:55:50.916 BRA
+Loopback0 is Up, ipv4 protocol is Up
+  Vrf is default (vrfid 0x60000000)
+  Internet address is 10.24.29.18/32
+  MTU is 1500 (1500 is available to IP)
+  Helper address is not set
+  Multicast reserved groups joined: 224.0.0.13 224.0.0.22 224.0.1.40
+  Directed broadcast forwarding is disabled
+  Outgoing access list is not set
+  Inbound  access list is not set
+  Proxy ARP is disabled
+  ICMP redirects are never sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  Table Id is 0xe0000000
+Loopback7 is Up, ipv4 protocol is Up
+  Vrf is default (vrfid 0x60000000)
+  Internet address is 10.44.7.60/32
+  MTU is 1500 (1500 is available to IP)
+  Helper address is not set
+  Multicast reserved groups joined:
+  Directed broadcast forwarding is disabled
+  Outgoing access list is not set
+  Inbound  access list is not set
+  Proxy ARP is disabled
+  ICMP redirects are never sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  Table Id is 0xe0000000
+MgmtEth0/RSP0/CPU0/0 is Down, ipv4 protocol is Down
+  Vrf is default (vrfid 0x60000000)
+  Internet address is 10.0.0.1/24
+  MTU is 1514 (1500 is available to IP)
+  Helper address is not set
+  Directed broadcast forwarding is disabled
+  Outgoing access list is not set
+  Inbound  access list is not set
+  Proxy ARP is disabled
+  ICMP redirects are never sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  Table Id is 0xe0000000
+TenGigE0/5/0/0 is Up, ipv4 protocol is Up
+  Vrf is default (vrfid 0x60000000)
+  Internet address is 10.24.14.12/31
+  MTU is 9208 (9180 is available to IP)
+  Helper address is not set
+  Multicast reserved groups joined: 224.0.0.2 224.0.0.1 224.0.0.5
+      224.0.0.6 224.0.0.13 224.0.0.22
+  Directed broadcast forwarding is disabled
+  Outgoing access list is not set
+  Inbound  access list is not set
+  Proxy ARP is disabled
+  ICMP redirects are never sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  Table Id is 0xe0000000
+TenGigE0/5/0/1 is Shutdown, ipv4 protocol is Down
+  Vrf is default (vrfid 0x60000000)
+  Internet protocol processing disabled
+TenGigE0/5/0/2 is Shutdown, ipv4 protocol is Down
+  Vrf is default (vrfid 0x60000000)
+  Internet protocol processing disabled
+TenGigE0/5/0/3 is Shutdown, ipv4 protocol is Down
+  Vrf is default (vrfid 0x60000000)
+  Internet protocol processing disabled


### PR DESCRIPTION
An empty "Multicast reserved groups joined:" field would cause an error, since the template would expect an empty space that does not exist.

Added test files for this case.