### PR TITLE
Update extreme_exos_show_iparp to support output format change

### DIFF
--- a/ntc_templates/templates/extreme_exos_show_iparp.textfsm
+++ b/ntc_templates/templates/extreme_exos_show_iparp.textfsm
@@ -14,6 +14,19 @@ Start
 Start_record
   ^\s*---
   ^${VR}\s+${DESTINATION}\s+\(*${MAC_ADDRESS}\)*\s+${AGE}\s+${STATIC}\s+${VLAN}\s+${VID}(\s+${PORT})?\s*$$ -> Record
-  ^(\S+\s*){1,4}:
+  ^\s*(Dynamic|Pending)\s+Entries\s*:
+  ^\s*(In|Out|Failed)\s+Requests?\s*:
+  ^\s*Proxy\s+Answered\s*:
+  ^\s*Rx\s+Error\s*:
+  ^\s*Rejected\s+(Count|Port)\s*:
+  ^\s*Max\s+((ARP|Pending|Proxy)\s+)?[Ee]ntries\s*:
+  ^\s*ARP\s+address\s+check\s*:
+  ^\s*Timeout\s*:
+  ^\s*Distributed\s+mode\s*:
+  ^\s*ARP\s+Sender-Mac\s+Learning\s*:
+  ^\s*Locktime\s*:
+  ^\s*(Retransmit|Reachable)\s+Time\s*:
+  ^\s*Fast\s+Convergence\s*:
+  ^\s*ARP\s+Global\s+Settings\s*$$
   ^\s*$$
   ^. -> Error

--- a/tests/extreme_exos/show_iparp/extreme_exos_show_iparp.raw
+++ b/tests/extreme_exos/show_iparp/extreme_exos_show_iparp.raw
@@ -1,0 +1,18 @@
+VR            Destination      Mac                Age  Static  VLAN          VID   Port
+VR-Default    10.128.32.4      00:d0:59:17:74:83   20      NO  bluered       4092  1:25
+VR-Default    10.128.32.8      00:01:30:ba:6a:a0    7      NO  Default       4095
+
+Dynamic Entries  :           4             Static Entries            :          0
+Pending Entries  :           0
+
+ARP address check:    Enabled              ARP refresh               :    Enabled
+Timeout          :          20 minutes     ARP Sender-Mac Learning   :   Disabled
+Locktime         :        1000 milliseconds
+Retransmit Time  :        1000 milliseconds
+Reachable Time   :      900000 milliseconds (Auto)
+Fast Convergence :         Off 
+
+ARP Global Settings
+Max Entries         :    12288 
+Max Pending Entries :      256 
+Max Proxy Entries   :      256

--- a/tests/extreme_exos/show_iparp/extreme_exos_show_iparp.yml
+++ b/tests/extreme_exos/show_iparp/extreme_exos_show_iparp.yml
@@ -1,0 +1,18 @@
+---
+parsed_sample:
+  - age: "20"
+    destination: "10.128.32.4"
+    mac_address: "00:d0:59:17:74:83"
+    port: "1:25"
+    static: "NO"
+    vid: "4092"
+    vlan: "bluered"
+    vr: "VR-Default"
+  - age: "7"
+    destination: "10.128.32.8"
+    mac_address: "00:01:30:ba:6a:a0"
+    port: ""
+    static: "NO"
+    vid: "4095"
+    vlan: "Default"
+    vr: "VR-Default"


### PR DESCRIPTION
Command output format was changed in ExtremeXOS 30.1, updates template to support new & old format. Additional test files added.