### PR TITLE
Handle trailing space after mode in HP Comware display interface

### DIFF
--- a/ntc_templates/templates/hp_comware_display_interface.textfsm
+++ b/ntc_templates/templates/hp_comware_display_interface.textfsm
@@ -34,7 +34,7 @@ Start
   ^\s*Internet\s+[Aa]ddress:\s+${IP_ADDRESS}\s+\([Ss]ub\)
   ^\s*IP\s+[Pp]acket\s+[Ff]rame\s+[Tt]ype\s*:\s*[^,]+,\s+[Hh]ardware\s+[Aa]ddress:\s+${HW_ADDRESS}
   ^\s*IPv6\s+[Pp]acket\s+[Ff]rame\s+[Tt]ype\s*:\s*[^,]+,\s+[Hh]ardware\s+[Aa]ddress:\s+${HW_ADDRESS}
-  ^\s*${SPEED}\s+mode,\s+${DUPLEX}\s+mode
+  ^\s*${SPEED}\s+mode\s*,\s+${DUPLEX}\s+mode
   ^\s*${SPEED},\s+${DUPLEX},\s+link\s+type
   ^\s*PVID:\s+${VLAN_NATIVE}
   ^\s*Port\s+link-type:\s+${PORT_LINK_TYPE}

--- a/ntc_templates/templates/hp_comware_display_interface.textfsm
+++ b/ntc_templates/templates/hp_comware_display_interface.textfsm
@@ -83,7 +83,7 @@ Start
   ^\s{14,}(?:\s+[^,]+,){18}\s+${VLAN_PASSING},* -> Continue
   ^\s{14,}(?:\s+[^,]+,){19}\s+${VLAN_PASSING},* -> Continue
   ^\s{14,}(?:\s+[^,]+,){20}\s+${VLAN_PASSING},* -> Continue
-  # End od VLAN Passing
+  # End of VLAN Passing
   ^\s+VLAN\s+[Pp]assing\s*:
   ^\s{14,}
   # Trunk - Permitted VLANs (parsing multiple times with Continue)
@@ -130,7 +130,7 @@ Start
   ^\s{14,}(?:\s+[^,]+,){18}\s+${VLAN_PERMITTED},* -> Continue
   ^\s{14,}(?:\s+[^,]+,){19}\s+${VLAN_PERMITTED},* -> Continue
   ^\s{14,}(?:\s+[^,]+,){20}\s+${VLAN_PERMITTED},* -> Continue
-  # End od VLAN Passing
+  # End of VLAN Passing
   ^\s+VLAN\s+permitted:
   ^\s{14,}
   # Next

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_mgmt.raw
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_mgmt.raw
@@ -1,0 +1,27 @@
+M-GigabitEthernet0/0/0
+Current state: UP
+Line protocol state: UP
+Description: SanitizedDescription
+Bandwidth: 1000000 kbps
+Maximum transmission unit: 1500
+Internet address: A.B.C.D/XY (Primary)
+IP packet frame type: Ethernet II, hardware address: 5477-8aee-2818
+IPv6 packet frame type: Ethernet II, hardware address: 5477-8aee-2818
+Last link flapping: 45 weeks 2 days 4 hours 17 minutes
+Last clearing of counters: Never
+Current system time:2024-12-30 13:12:50 EST-05:00:00
+Last time when physical state changed to up:2000-12-31 19:05:41 EST-05:00:00
+Last time when physical state changed to down:2001-01-01 00:05:02 EST-05:00:00
+Media type is twisted pair, loopback not set
+Port hardware type is 1000_BASE_T
+1000Mbps-speed mode , full-duplex mode 
+Link speed type is autonegotiation , Link duplex type is autonegotiation
+input:   57670968 packets, 348067745 bytes
+         22020401 broadcasts,18647198 multicasts
+input:   - input errors,- runts,- giants,- throttles,0 CRC
+         - frame,- overruns,- aborts,- ignored,- parity errors
+output:  21389206 packets, 3225503833 bytes
+         18 broadcasts,913477 multicasts
+output:  - output errors,- underruns,- buffer failures
+         - aborts,- deferred,0 collisions,0 late collisions
+         - lost carrier,- no carrier

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_mgmt.yml
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_mgmt.yml
@@ -1,0 +1,21 @@
+---
+parsed_sample:
+  - bandwidth: "1000000 kbps"
+    description: "SanitizedDescription"
+    duplex: "full-duplex"
+    hw_address:
+      - "5477-8aee-2818"
+      - "5477-8aee-2818"
+    interface: "M-GigabitEthernet0/0/0"
+    ip_address:
+      - "A.B.C.D/XY"
+    l2mtu: ""
+    line_status: "UP"
+    mtu: "1500"
+    port_link_type: ""
+    protocol_status: "UP"
+    speed: "1000Mbps-speed"
+    untagged_vlan_id: ""
+    vlan_native: ""
+    vlan_passing: []
+    vlan_permitted: []


### PR DESCRIPTION
resolves #1953

* Allows for an optional space between mode and comma
* Fixes template comment typo

Thank you goes out to @marcus-cain for pulling all the information together in #1953.