### PR TITLE
Update docs wording

### DIFF
--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -1,8 +1,8 @@
 # Contributing
 
-Pull requests are welcomed and automatically built and tested against multiple versions of Python through GitHub Actions. 
+Pull requests are welcomed and automatically built and tested against Python version(s) through GitHub Actions. 
 
-Except for unit tests, testing is only supported on Python 3.9.
+Except for unit tests, testing is supported on Python 3.12.
 
 The project is packaged with a light development environment based on `Docker` to help with the local development of the project and to run tests within  GitHub Actions.
 

--- a/docs/dev/dev_parser.md
+++ b/docs/dev/dev_parser.md
@@ -227,7 +227,7 @@ tests/cisco_ios/show_mac-address-table/cisco_ios_show_mac-address-table9.yml
 $ 
 ```
 
-Additionally, each of these commands are available via invoke commands to better support a docker environment. The arguement names match up, e.g. `python cli.py clean-yaml-file` has an equivalant `invoke clean-yaml-file`.
+Additionally, each of these commands are available via invoke commands to better support a docker environment. The argument names match up, e.g. `python cli.py clean-yaml-file` has an equivalant `invoke clean-yaml-file`.
 
 # Updating/Fixing Existing Templates
 When either fixing a bug within a template or adding additional **Values** to be captured, additional test files should be added to ensure backwards compatibility and that the new data is being parsed correctly.

--- a/docs/dev/extending.md
+++ b/docs/dev/extending.md
@@ -1,5 +1,5 @@
 # Extending the Library
 
-Extending the library is welcome, however it is best to open an issue first, to ensure that a PR would be accepted and makes sense in terms of features and design.
+Extending the library is welcome and in most instances PRs are merged after review. If there is a large quantity of changes or are not backwards compatible, it would be advised to open an issue first to ensure that a PR would be accepted and makes sense in terms of features and design.
 
 Requesting for others to create templates is not currently supported. Please review the [faq](../user/faq.md#does-the-project-support-requests-for-additional-templates-or-additional-data-in-an-existing-template) for more details.

--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions
 
-From an outsiders view, some design choices, requirements, and testing procedures can seem arbitrary. The following list of FAQ is intended to help provide context and better guide users and contributors of ntc-templates.
+From an outsider's view, some design choices, requirements, and testing procedures can seem arbitrary. The following list of FAQ is intended to help provide context and better guide users and contributors of ntc-templates.
 
 ## How do I test my templates?
 


### PR DESCRIPTION
Following https://github.com/networktocode/ntc-templates/issues/1968#issuecomment-2588039413, I figured the docs verbiage could be updated. ~~(Unfortunately I haven't found that section/mention yet.)~~ Bruno pointed me to the section. :grinning:

> Extending the library is welcome, however it is best to open an issue first, to ensure that a PR would be accepted and makes sense in terms of features and design.
> 
> per https://ntc-templates.readthedocs.io/en/latest/dev/extending/

* Make outsider's view possessive in faq.md
   * outsiders view -> outsider's view
* Change Python version testing verbiage in contributing.md
* Updated extending verbiage since it has been said that not all contributions necessarily need an issue before a PR