### PR TITLE
Hp comware display ip interface update

### DIFF
--- a/ntc_templates/templates/hp_comware_display_ip_interface.textfsm
+++ b/ntc_templates/templates/hp_comware_display_ip_interface.textfsm
@@ -15,7 +15,7 @@ Interface
   ^\S+\s+current\s+state -> Continue.Record
   ^${INTERFACE}\s+current\s+state\s*:\s*${LINE_STATUS}
   ^Line\s+protocol\s+current\s+state\s*:\s*${PROTOCOL_STATUS}
-  ^Internet\s+Address\s+is\s+${IP_ADDRESS}\s+Primary
+  ^Internet\s+Address\s+is\s+${IP_ADDRESS}\s+(Primary|CELLULAR-Allocated)
   ^Internet\s+Address\s+is\s+${IP_ADDRESS}\s+Sub
   ^Broadcast\s+address\s*:\s*\S+
   ^The\s+Maximum\s+Transmit\s+Unit\s*:\s*${MTU}\s+bytes

--- a/ntc_templates/templates/hp_comware_display_ip_interface.textfsm
+++ b/ntc_templates/templates/hp_comware_display_ip_interface.textfsm
@@ -15,8 +15,7 @@ Interface
   ^\S+\s+current\s+state -> Continue.Record
   ^${INTERFACE}\s+current\s+state\s*:\s*${LINE_STATUS}
   ^Line\s+protocol\s+current\s+state\s*:\s*${PROTOCOL_STATUS}
-  ^Internet\s+Address\s+is\s+${IP_ADDRESS}\s+(Primary|CELLULAR-Allocated)
-  ^Internet\s+Address\s+is\s+${IP_ADDRESS}\s+Sub
+  ^Internet\s+Address\s+is\s+${IP_ADDRESS}\s+(Primary|Sub|CELLULAR-Allocated)
   ^Broadcast\s+address\s*:\s*\S+
   ^The\s+Maximum\s+Transmit\s+Unit\s*:\s*${MTU}\s+bytes
   ^Policy\s+routing\s+is\s+enabled,\s+using\s+route\s+map\s+${ROUTE_MAP}

--- a/tests/hp_comware/display_ip_interface/hp_comware_display_ip_interface_release_0615P16.raw
+++ b/tests/hp_comware/display_ip_interface/hp_comware_display_ip_interface_release_0615P16.raw
@@ -1,0 +1,86 @@
+Aux0 current state: UP
+Line protocol current state: DOWN
+
+Eth-channel2/0:0 current state: UP
+Line protocol current state: UP
+Internet Address is 1.2.3.4/32 CELLULAR-Allocated
+The Maximum Transmit Unit: 1500 bytes
+input packets : 23367835, bytes : 1413874673, multicasts : 0
+output packets : 34966062, bytes : 2316469473, multicasts : 0
+TTL invalid packet number:         0
+ICMP packet input number:     823870
+  Echo reply:                     70
+  Unreachable:                  6335
+  Source quench:                   0
+  Routing redirect:                0
+  Echo request:               491210
+  Router advert:                   0
+  Router solicit:                  0
+  Time exceed:                326252
+  IP header bad:                   0
+  Timestamp request:               0
+  Timestamp reply:                 0
+  Information request:             0
+  Information reply:               0
+  Netmask request:                 0
+  Netmask reply:                   0
+  Unknown type:                    3
+
+GigabitEthernet0/0 current state: Administratively DOWN
+Line protocol current state: DOWN
+
+GigabitEthernet0/1 current state: UP
+Line protocol current state: UP
+Internet Address is 5.6.7.10/30 Primary
+Broadcast address: 5.6.7.11
+The Maximum Transmit Unit: 1500 bytes
+input packets : 4195331629, bytes : 3133177734, multicasts : 0
+output packets : 918509741, bytes : 2093433955, multicasts : 0
+TTL invalid packet number:      3716
+ICMP packet input number:    2449183
+  Echo reply:                    165
+  Unreachable:                 18290
+  Source quench:                   0
+  Routing redirect:                0
+  Echo request:              2430380
+  Router advert:                   0
+  Router solicit:                  0
+  Time exceed:                   342
+  IP header bad:                   0
+  Timestamp request:               0
+  Timestamp reply:                 0
+  Information request:             0
+  Information reply:               0
+  Netmask request:                 0
+  Netmask reply:                   0
+  Unknown type:                    6
+
+GigabitEthernet0/2 current state: Administratively DOWN
+Line protocol current state: DOWN
+
+Vlan-interface1 current state: UP
+Line protocol current state: UP
+Internet Address is 1.2.3.65/29 Primary
+Broadcast address: 1.2.3.71
+The Maximum Transmit Unit: 1500 bytes
+input packets : 882770572, bytes : 3680182010, multicasts : 1
+output packets : 4143569939, bytes : 491084805, multicasts : 0
+TTL invalid packet number:       263
+ICMP packet input number:          0
+  Echo reply:                      0
+  Unreachable:                     0
+  Source quench:                   0
+  Routing redirect:                0
+  Echo request:                    0
+  Router advert:                   0
+  Router solicit:                  0
+  Time exceed:                     0
+  IP header bad:                   0
+  Timestamp request:               0
+  Timestamp reply:                 0
+  Information request:             0
+  Information reply:               0
+  Netmask request:                 0
+  Netmask reply:                   0
+  Unknown type:                    0
+

--- a/tests/hp_comware/display_ip_interface/hp_comware_display_ip_interface_release_0615P16.yml
+++ b/tests/hp_comware/display_ip_interface/hp_comware_display_ip_interface_release_0615P16.yml
@@ -1,0 +1,41 @@
+---
+parsed_sample:
+  - interface: "Aux0"
+    ip_address: []
+    line_status: "UP"
+    mtu: ""
+    protocol_status: "DOWN"
+    route_map: ""
+  - interface: "Eth-channel2/0:0"
+    ip_address:
+      - "1.2.3.4/32"
+    line_status: "UP"
+    mtu: "1500"
+    protocol_status: "UP"
+    route_map: ""
+  - interface: "GigabitEthernet0/0"
+    ip_address: []
+    line_status: "Administratively DOWN"
+    mtu: ""
+    protocol_status: "DOWN"
+    route_map: ""
+  - interface: "GigabitEthernet0/1"
+    ip_address:
+      - "5.6.7.10/30"
+    line_status: "UP"
+    mtu: "1500"
+    protocol_status: "UP"
+    route_map: ""
+  - interface: "GigabitEthernet0/2"
+    ip_address: []
+    line_status: "Administratively DOWN"
+    mtu: ""
+    protocol_status: "DOWN"
+    route_map: ""
+  - interface: "Vlan-interface1"
+    ip_address:
+      - "1.2.3.65/29"
+    line_status: "UP"
+    mtu: "1500"
+    protocol_status: "UP"
+    route_map: ""

--- a/tests/hp_comware/display_ip_interface/hp_comware_display_ip_interface_sub.raw
+++ b/tests/hp_comware/display_ip_interface/hp_comware_display_ip_interface_sub.raw
@@ -1,0 +1,59 @@
+Aux0 current state: UP
+Line protocol current state: DOWN
+
+GigabitEthernet0/0 current state: UP
+Line protocol current state: UP
+Internet Address is 1.2.3.218/30 Primary
+Broadcast address: 1.2.3.219
+The Maximum Transmit Unit: 1500 bytes
+input packets : 3630628677, bytes : 3530327189888, multicasts : 0
+output packets : 2789163179, bytes : 1952895304430, multicasts : 0
+TTL invalid packet number:      1304
+ICMP packet input number:    1112080
+  Echo reply:                     58
+  Unreachable:                  1518
+  Source quench:                   0
+  Routing redirect:                0
+  Echo request:              1110479
+  Router advert:                   0
+  Router solicit:                  0
+  Time exceed:                    25
+  IP header bad:                   0
+  Timestamp request:               0
+  Timestamp reply:                 0
+  Information request:             0
+  Information reply:               0
+  Netmask request:                 0
+  Netmask reply:                   0
+  Unknown type:                    0
+
+GigabitEthernet0/1 current state: Administratively DOWN
+Line protocol current state: DOWN
+
+Vlan-interface1 current state: UP
+Line protocol current state: UP
+Internet Address is 5.6.7.194/29 Primary
+Internet Address is 5.6.7.179/29 Sub
+Internet Address is 8.9.10.221/27 Sub
+Broadcast address: 5.6.7.199
+The Maximum Transmit Unit: 1500 bytes
+input packets : 2788236164, bytes : 1952740685995, multicasts : 3451747
+output packets : 3629098304, bytes : 3530157189482, multicasts : 6913848
+TTL invalid packet number:      8280
+ICMP packet input number:     197889
+  Echo reply:                      7
+  Unreachable:                   248
+  Source quench:                   0
+  Routing redirect:                0
+  Echo request:               197628
+  Router advert:                   0
+  Router solicit:                  0
+  Time exceed:                     6
+  IP header bad:                   0
+  Timestamp request:               0
+  Timestamp reply:                 0
+  Information request:             0
+  Information reply:               0
+  Netmask request:                 0
+  Netmask reply:                   0
+  Unknown type:                    0

--- a/tests/hp_comware/display_ip_interface/hp_comware_display_ip_interface_sub.yml
+++ b/tests/hp_comware/display_ip_interface/hp_comware_display_ip_interface_sub.yml
@@ -1,0 +1,30 @@
+---
+parsed_sample:
+  - interface: "Aux0"
+    ip_address: []
+    line_status: "UP"
+    mtu: ""
+    protocol_status: "DOWN"
+    route_map: ""
+  - interface: "GigabitEthernet0/0"
+    ip_address:
+      - "1.2.3.218/30"
+    line_status: "UP"
+    mtu: "1500"
+    protocol_status: "UP"
+    route_map: ""
+  - interface: "GigabitEthernet0/1"
+    ip_address: []
+    line_status: "Administratively DOWN"
+    mtu: ""
+    protocol_status: "DOWN"
+    route_map: ""
+  - interface: "Vlan-interface1"
+    ip_address:
+      - "5.6.7.194/29"
+      - "5.6.7.179/29"
+      - "8.9.10.221/27"
+    line_status: "UP"
+    mtu: "1500"
+    protocol_status: "UP"
+    route_map: ""


### PR DESCRIPTION
Updated the template to also allow CELLULAR-Allocated instead of Primary when handling an eth-channel interface on a router, this is not possible on the MSR958X and MSR2003X, so no test file for release 9119P17