### PR TITLE
Replace ubuntu-20.04 with 22.04 in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   black:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       INVOKE_LOCAL: "True"
     steps:
@@ -27,7 +27,7 @@ jobs:
       - name: "Linting: black"
         run: "poetry run invoke black"
   bandit:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       INVOKE_LOCAL: "True"
     steps:
@@ -40,7 +40,7 @@ jobs:
     needs:
       - "black"
   pydocstyle:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       INVOKE_LOCAL: "True"
     steps:
@@ -53,7 +53,7 @@ jobs:
     needs:
       - "black"
   flake8:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       INVOKE_LOCAL: "True"
     steps:
@@ -66,7 +66,7 @@ jobs:
     needs:
       - "black"
   yamllint:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       INVOKE_LOCAL: "True"
     steps:
@@ -83,7 +83,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.12"]
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       PYTHON_VER: "${{ matrix.python-version }}"
     steps:
@@ -114,7 +114,7 @@ jobs:
       - "flake8"
       - "yamllint"
   pylint:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     strategy:
       fail-fast: true
       matrix:
@@ -155,7 +155,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.12"]
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       PYTHON_VER: "${{ matrix.python-version }}"
     steps:
@@ -189,7 +189,7 @@ jobs:
       - "pylint"
   publish_gh:
     name: "Publish to GitHub"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
       - name: "Check out repository code"
@@ -218,7 +218,7 @@ jobs:
       - "pytest"
   publish_pypi:
     name: "Push Package to PyPI"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
       - name: "Check out repository code"


### PR DESCRIPTION
:warning: Likely considered a breaking change by ntc-templates.

Ubuntu 20.04 runners are being deprecated and will be removed in April 2025.
Switching to 22.04

ref: https://github.com/actions/runner-images/issues/11101