### PR TITLE
Add additional nonmatching line to EOS show ip mroute vrf all detail template

### DIFF
--- a/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_mroute_vrf_all_detail.textfsm
@@ -21,6 +21,7 @@ Start
   ^\s+M\s+-\s+From
   ^Flags
   ^\s+[RWIHZANTVF]\s+-
+  ^\*\s-
   ^${MULTICAST_GROUP}
   ^\s+?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) -> Continue.Record
   ^\s+${RPF_SOURCE},\s+${UPTIME},\s+(RP\s+${RP},\s+)?flags:\s+${FLAGS}

--- a/tests/arista_eos/show_ip_mroute_vrf_all_detail/arista_eos_show_ip_mroute_vrf_all.raw
+++ b/tests/arista_eos/show_ip_mroute_vrf_all_detail/arista_eos_show_ip_mroute_vrf_all.raw
@@ -16,6 +16,7 @@ Flags: E - Entry forwarding on the RPT, J - Joining to the SPT
     F - Learned via MVPN
 RPF route: U - From unicast routing table
            M - From multicast routing table
+* - Interface has EVPN information available in the 'detail' command output
 224.0.1.129
   169.254.132.172, 118d18h, flags: PE
     Incoming interface: Null


### PR DESCRIPTION
I found an additional non-matching line in the wild that is breaking at the wildcard `-> Error` line:
```
* - Interface has EVPN information available in the 'detail' command output
```

This change introduces a fix for this pattern