### PR TITLE
added cisco ios power consumption templates

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_power_used.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_power_used.textfsm
@@ -1,6 +1,8 @@
-Value USED_WATTS (\d+\.\d+)
+Value WATTS (\d+\.\d+)
+Value AMPS (\d+\.\d+)
+Value VOLTS (\d+)
 
 Start
-  ^system\s+power\s+used\s+=\s+${USED_WATTS} -> Record
+  ^system\s+power\s+used\s+=\s+${WATTS}\s+Watts\s+\(${AMPS}\s+Amps\s+@\s+${VOLTS}V\)\s*$$ -> Record
   ^\s*$$
   ^. -> Error

--- a/ntc_templates/templates/cisco_ios_show_power_used.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_power_used.textfsm
@@ -1,0 +1,6 @@
+Value USED_WATTS (\d+\.\d+)
+
+Start
+  ^system\s+power\s+used\s+=\s+${USED_WATTS} -> Record
+  ^\s*$$
+  ^. -> Error

--- a/ntc_templates/templates/cisco_ios_show_stack-power.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_stack-power.textfsm
@@ -1,0 +1,21 @@
+Value POWER_STACK_NAME (\S+)
+Value STACK_MODE (\S+)
+Value STACK_TOPOLOGY (\w+)
+Value TOTAL_POWER (\d+)
+Value RESERVED_POWER (\d+)
+Value ALLOCATED_POWER (\d+)
+Value SWITCH_AVAILABLE_POWER (\d+)
+Value STACK_NUMBER (\d+)
+Value POWER_SUPPLY_NUMBERS (\d+)
+
+Start
+  ^\s*Power\s+Stack
+  ^\s*Name\s*Mode
+  ^\s*-+ -> Power
+  ^\s*$$
+  ^. -> Error
+
+Power
+  ^\s*${POWER_STACK_NAME}\s+${STACK_MODE}\s+${STACK_TOPOLOGY}\s+${TOTAL_POWER}\s+${RESERVED_POWER}\s+${ALLOCATED_POWER}\s+${SWITCH_AVAILABLE_POWER}\s+${STACK_NUMBER}\s+${POWER_SUPPLY_NUMBERS} -> Record
+  ^\s*$$
+  ^. -> Error

--- a/ntc_templates/templates/cisco_ios_show_stack-power.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_stack-power.textfsm
@@ -10,7 +10,7 @@ Value POWER_SUPPLY_NUMBERS (\d+)
 
 Start
   ^\s*Power\s+Stack
-  ^\s*Name\s*Mode
+  ^\s*Name\s+Mode
   ^\s*-+ -> Power
   ^\s*$$
   ^. -> Error

--- a/ntc_templates/templates/index
+++ b/ntc_templates/templates/index
@@ -248,6 +248,7 @@ cisco_fxos_show_system_firmware.textfsm, .*, cisco_fxos, sh[[ow]] sy[[stem]] fi[
 
 cisco_ios_show_module.textfsm:cisco_ios_show_module_status.textfsm:cisco_ios_show_module_submodule.textfsm:cisco_ios_show_module_online_diag.textfsm, .*, cisco_ios, sh[[ow]] mod[[ule]]
 cisco_ios_show_switch_detail.textfsm:cisco_ios_show_switch_detail_stack_ports.textfsm, .*, cisco_ios, sh[[ow]] sw[[itch]] d[[etail]]
+cisco_ios_show_stack-power.textfsm, .*, cisco_ios, sh[[ow]] stack-[[power]]
 cisco_ios_show_authentication_sessions_method_details.textfsm, .*, cisco_ios, show authen[[tication]] ses[[sions]] met[[hod]](\s+d[[ot1x]]|\s+m[[ab]])? det[[ails]]
 cisco_ios_show_running-config_partition_access-list.textfsm, .*, cisco_ios, sh[[ow]] ru[[nning-config]] p[[artition]] a[[ccess-list]]
 cisco_ios_show_ip_bgp_neighbors_advertised-routes.textfsm, .*, cisco_ios, sh[[ow]] ip bgp nei[[ghbors]](\s+\d+\.\d+\.\d+\.\d+)? adv[[ertised-routes]]
@@ -300,6 +301,7 @@ cisco_ios_show_ip_access-lists.textfsm, .*, cisco_ios, sh[[ow]] ip acce[[ss-list
 cisco_ios_show_ip_dhcp_binding.textfsm, .*, cisco_ios, sh[[ow]] ip dh[[cp]] b[[inding]]
 cisco_ios_show_mpls_interfaces.textfsm, .*, cisco_ios, sh[[ow]] mpls interfa[[ces]]
 cisco_ios_show_power_available.textfsm, .*, cisco_ios, sh[[ow]] pow[[er]] a[[vailable]]
+cisco_ios_show_power_used.textfsm, .*, cisco_ios, sh[[ow]] pow[[er]] u[[sed]]
 cisco_ios_show_access-session.textfsm, .*, cisco_ios, show access-s[[ession]]
 cisco_ios_show_alert_counters.textfsm, .*, cisco_ios, sh[[ow]] alert [[counters]]
 cisco_ios_show_interface_link.textfsm, .*, cisco_ios, sh[[ow]] int[[erfaces]] li[[nk]]

--- a/ntc_templates/templates/index
+++ b/ntc_templates/templates/index
@@ -248,7 +248,6 @@ cisco_fxos_show_system_firmware.textfsm, .*, cisco_fxos, sh[[ow]] sy[[stem]] fi[
 
 cisco_ios_show_module.textfsm:cisco_ios_show_module_status.textfsm:cisco_ios_show_module_submodule.textfsm:cisco_ios_show_module_online_diag.textfsm, .*, cisco_ios, sh[[ow]] mod[[ule]]
 cisco_ios_show_switch_detail.textfsm:cisco_ios_show_switch_detail_stack_ports.textfsm, .*, cisco_ios, sh[[ow]] sw[[itch]] d[[etail]]
-cisco_ios_show_stack-power.textfsm, .*, cisco_ios, sh[[ow]] stack-[[power]]
 cisco_ios_show_authentication_sessions_method_details.textfsm, .*, cisco_ios, show authen[[tication]] ses[[sions]] met[[hod]](\s+d[[ot1x]]|\s+m[[ab]])? det[[ails]]
 cisco_ios_show_running-config_partition_access-list.textfsm, .*, cisco_ios, sh[[ow]] ru[[nning-config]] p[[artition]] a[[ccess-list]]
 cisco_ios_show_ip_bgp_neighbors_advertised-routes.textfsm, .*, cisco_ios, sh[[ow]] ip bgp nei[[ghbors]](\s+\d+\.\d+\.\d+\.\d+)? adv[[ertised-routes]]
@@ -301,7 +300,6 @@ cisco_ios_show_ip_access-lists.textfsm, .*, cisco_ios, sh[[ow]] ip acce[[ss-list
 cisco_ios_show_ip_dhcp_binding.textfsm, .*, cisco_ios, sh[[ow]] ip dh[[cp]] b[[inding]]
 cisco_ios_show_mpls_interfaces.textfsm, .*, cisco_ios, sh[[ow]] mpls interfa[[ces]]
 cisco_ios_show_power_available.textfsm, .*, cisco_ios, sh[[ow]] pow[[er]] a[[vailable]]
-cisco_ios_show_power_used.textfsm, .*, cisco_ios, sh[[ow]] pow[[er]] u[[sed]]
 cisco_ios_show_access-session.textfsm, .*, cisco_ios, show access-s[[ession]]
 cisco_ios_show_alert_counters.textfsm, .*, cisco_ios, sh[[ow]] alert [[counters]]
 cisco_ios_show_interface_link.textfsm, .*, cisco_ios, sh[[ow]] int[[erfaces]] li[[nk]]
@@ -329,11 +327,13 @@ cisco_ios_show_power_status.textfsm, .*, cisco_ios, sh[[ow]] pow[[er]] st[[atus]
 cisco_ios_show_rep_topology.textfsm, .*, cisco_ios, sh[[ow]] rep topology
 cisco_ios_show_access-list.textfsm, .*, cisco_ios, sh[[ow]] acc[[ess-list]]
 cisco_ios_show_isdn_status.textfsm, .*, cisco_ios, sh[[ow]] isd[[n]] st[[atus]]
+cisco_ios_show_stack-power.textfsm, .*, cisco_ios, sh[[ow]] stack-[[power]]
 cisco_ios_show_ap_summary.textfsm, .*, cisco_ios, sh[[ow]] ap sum[[mary]]
 cisco_ios_show_dhcp_lease.textfsm, .*, cisco_ios, sh[[ow]] dh[[cp]] l[[ease]]
 cisco_ios_show_interfaces.textfsm, .*, cisco_ios, sh[[ow]] int[[erfaces]](?: (?:\S+))?
 cisco_ios_show_ipv6_route.textfsm, .*, cisco_ios, sh[[ow]] ipv6 r[[oute]]
 cisco_ios_show_policy-map.textfsm, .*, cisco_ios, sh[[ow]] pol[[icy-map]]
+cisco_ios_show_power_used.textfsm, .*, cisco_ios, sh[[ow]] pow[[er]] u[[sed]]
 cisco_ios_show_redundancy.textfsm, .*, cisco_ios, sh[[ow]] redu[[ndancy]]
 cisco_ios_show_snmp_group.textfsm, .*, cisco_ios, sh[[ow]] snm[[p]] g[[roup]]
 cisco_ios_show_vrf_detail.textfsm, .*, cisco_ios, sh[[ow]] vrf detail

--- a/tests/cisco_ios/show_power_used/cisco_ios_show_power_used.raw
+++ b/tests/cisco_ios/show_power_used/cisco_ios_show_power_used.raw
@@ -1,0 +1,1 @@
+system power used =      2255.76 Watts (43.38 Amps @ 52V)

--- a/tests/cisco_ios/show_power_used/cisco_ios_show_power_used.yml
+++ b/tests/cisco_ios/show_power_used/cisco_ios_show_power_used.yml
@@ -1,0 +1,5 @@
+---
+parsed_sample:
+  - amps: "43.38"
+    volts: "52"
+    watts: "2255.76"

--- a/tests/cisco_ios/show_stack-power/cisco_ios_show_stack-power.raw
+++ b/tests/cisco_ios/show_stack-power/cisco_ios_show_stack-power.raw
@@ -1,0 +1,5 @@
+    Power Stack                      Stack   Stack    Total   Rsvd    Alloc   Sw_Avail Num  Num
+    Name                             Mode    Topolgy  Pwr(W)  Pwr(W)  Pwr(W)   Pwr(W)  SW   PS
+    --------------------             ------  -------  ------  ------  ------  ------  ----- -----
+    Powerstack-1                     SP-PS   Stndaln  1430    0       340     1090      1    2   
+

--- a/tests/cisco_ios/show_stack-power/cisco_ios_show_stack-power.yml
+++ b/tests/cisco_ios/show_stack-power/cisco_ios_show_stack-power.yml
@@ -1,0 +1,11 @@
+---
+parsed_sample:
+  - allocated_power: "340"
+    power_stack_name: "Powerstack-1"
+    power_supply_numbers: "2"
+    reserved_power: "0"
+    stack_mode: "SP-PS"
+    stack_number: "1"
+    stack_topology: "Stndaln"
+    switch_available_power: "1090"
+    total_power: "1430"


### PR DESCRIPTION
Adding the following templates:

cisco_ios_show_stack-power.textfsm <-- iosxe command to show power information per stack member
cisco_ios_show_power_used.textfsm <-- ios command to show used power

I have tested and used these on a power consumption report I created for my environment.  Please let me if there are any changes you think would be prudent.

Thanks

Jason