### PR TITLE
Regenerate all hp comware disp int br test data

### DIFF
--- a/tests/hp_comware/display_interface_brief/hp_comware_display_interface_brief_release_60615P16.yml
+++ b/tests/hp_comware/display_interface_brief/hp_comware_display_interface_brief_release_60615P16.yml
@@ -82,7 +82,7 @@ parsed_sample:
     speed: ""
     type: ""
   - description: ""
-    duplex: "F"
+    duplex: "F(a)"
     interface: "GE3/0"
     link: "UP"
     main_ip: ""

--- a/tests/hp_comware/display_interface_brief/hp_comware_display_interface_brief_release_9119P17.yml
+++ b/tests/hp_comware/display_interface_brief/hp_comware_display_interface_brief_release_9119P17.yml
@@ -82,7 +82,7 @@ parsed_sample:
     speed: "auto"
     type: "A"
   - description: ""
-    duplex: "F"
+    duplex: "F(a)"
     interface: "GE0/0/3"
     link: "UP"
     main_ip: ""


### PR DESCRIPTION
Fix for mistake in #1964 where it would appear all the test data was not regenerated.
(Only the new test data was generated and present.)