### PR TITLE
Fix XR7 parse error where ARP EVPN line exists

### DIFF
--- a/ntc_templates/templates/cisco_xr_show_ipv4_interface.textfsm
+++ b/ntc_templates/templates/cisco_xr_show_ipv4_interface.textfsm
@@ -35,10 +35,10 @@ Start
   ^\s+Outgoing\s+access\s+list\s+is\s+${OUT_ACL}
   ^\s+Inbound\s+(?:common)?\s+access\s+list\s+is\s+${IN_ACL}
   ^\s+Proxy.*$$
-  ^\s+ARP EVPN.*$$
-  ^\s+ICMP redirects.*$$
-  ^\s+ICMP unreachables.*$$
-  ^\s+ICMP mask.*$$
+  ^\s+ARP\s+EVPN.*$$
+  ^\s+ICMP\s+redirects.*$$
+  ^\s+ICMP\s+unreachables.*$$
+  ^\s+ICMP\s+mask.*$$
   ^\s+Table.*$$
   ^\s+mLACP.*$$
   ^IP\s+unicast\s+RPF\s+check\s+is\s+${RPF_CHECK}

--- a/ntc_templates/templates/cisco_xr_show_ipv4_interface.textfsm
+++ b/ntc_templates/templates/cisco_xr_show_ipv4_interface.textfsm
@@ -35,6 +35,7 @@ Start
   ^\s+Outgoing\s+access\s+list\s+is\s+${OUT_ACL}
   ^\s+Inbound\s+(?:common)?\s+access\s+list\s+is\s+${IN_ACL}
   ^\s+Proxy.*$$
+  ^\s+ARP EVPN.*$$
   ^\s+ICMP redirects.*$$
   ^\s+ICMP unreachables.*$$
   ^\s+ICMP mask.*$$

--- a/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface6.raw
+++ b/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface6.raw
@@ -1,0 +1,33 @@
+Mon Mar 31 18:49:52.390 UTC
+Bundle-Ether123 is Down, ipv4 protocol is Down 
+  Vrf is default (vrfid 0x60000000)
+  Internet protocol processing disabled
+MgmtEth0/RP0/CPU0/0 is Up, ipv4 protocol is Up 
+  Vrf is MGMT (vrfid 0x60000001)
+  Internet address is 192.168.254.130/24
+  MTU is 1514 (1500 is available to IP)
+  Helper address is not set
+  Directed broadcast forwarding is disabled
+  Outgoing access list is not set
+  Inbound  common access list is not set, access list is not set
+  Proxy ARP is disabled
+  ARP EVPN Proxy is disabled
+  ICMP redirects are never sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  Table Id is 0xe0000001
+GigabitEthernet0/0/0/0 is Shutdown, ipv4 protocol is Down 
+  Vrf is default (vrfid 0x60000000)
+  Internet protocol processing disabled
+GigabitEthernet0/0/0/1 is Shutdown, ipv4 protocol is Down 
+  Vrf is default (vrfid 0x60000000)
+  Internet protocol processing disabled
+GigabitEthernet0/0/0/1.100 is Shutdown, ipv4 protocol is Down 
+  Vrf is default (vrfid 0x60000000)
+  Internet protocol processing disabled
+GigabitEthernet0/0/0/2 is Shutdown, ipv4 protocol is Down 
+  Vrf is default (vrfid 0x60000000)
+  Internet protocol processing disabled
+GigabitEthernet0/0/0/3 is Up, ipv4 protocol is Up 
+  Vrf is MGMT (vrfid 0x60000001)
+  Internet protocol processing disabled

--- a/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface6.yml
+++ b/tests/cisco_xr/show_ipv4_interface/cisco_xr_show_ipv4_interface6.yml
@@ -1,0 +1,114 @@
+---
+parsed_sample:
+  - interface: "Bundle-Ether123"
+    in_acl: ""
+    ip_address: ""
+    ip_mtu: ""
+    link_status: "Down"
+    mtu: ""
+    multicast_groups: []
+    out_acl: ""
+    prefix_length: ""
+    protocol: "ipv4"
+    protocol_status: "Down"
+    rpf_check: ""
+    sec_ip_address: []
+    sec_prefix_length: []
+    vrf: "default"
+    vrf_id: "0x60000000"
+  - interface: "MgmtEth0/RP0/CPU0/0"
+    in_acl: "not set, access list is not set"
+    ip_address: "192.168.254.130"
+    ip_mtu: "1500"
+    link_status: "Up"
+    mtu: "1514"
+    multicast_groups: []
+    out_acl: "not set"
+    prefix_length: "24"
+    protocol: "ipv4"
+    protocol_status: "Up"
+    rpf_check: ""
+    sec_ip_address: []
+    sec_prefix_length: []
+    vrf: "MGMT"
+    vrf_id: "0x60000001"
+  - interface: "GigabitEthernet0/0/0/0"
+    in_acl: ""
+    ip_address: ""
+    ip_mtu: ""
+    link_status: "Shutdown"
+    mtu: ""
+    multicast_groups: []
+    out_acl: ""
+    prefix_length: ""
+    protocol: "ipv4"
+    protocol_status: "Down"
+    rpf_check: ""
+    sec_ip_address: []
+    sec_prefix_length: []
+    vrf: "default"
+    vrf_id: "0x60000000"
+  - interface: "GigabitEthernet0/0/0/1"
+    in_acl: ""
+    ip_address: ""
+    ip_mtu: ""
+    link_status: "Shutdown"
+    mtu: ""
+    multicast_groups: []
+    out_acl: ""
+    prefix_length: ""
+    protocol: "ipv4"
+    protocol_status: "Down"
+    rpf_check: ""
+    sec_ip_address: []
+    sec_prefix_length: []
+    vrf: "default"
+    vrf_id: "0x60000000"
+  - interface: "GigabitEthernet0/0/0/1.100"
+    in_acl: ""
+    ip_address: ""
+    ip_mtu: ""
+    link_status: "Shutdown"
+    mtu: ""
+    multicast_groups: []
+    out_acl: ""
+    prefix_length: ""
+    protocol: "ipv4"
+    protocol_status: "Down"
+    rpf_check: ""
+    sec_ip_address: []
+    sec_prefix_length: []
+    vrf: "default"
+    vrf_id: "0x60000000"
+  - interface: "GigabitEthernet0/0/0/2"
+    in_acl: ""
+    ip_address: ""
+    ip_mtu: ""
+    link_status: "Shutdown"
+    mtu: ""
+    multicast_groups: []
+    out_acl: ""
+    prefix_length: ""
+    protocol: "ipv4"
+    protocol_status: "Down"
+    rpf_check: ""
+    sec_ip_address: []
+    sec_prefix_length: []
+    vrf: "default"
+    vrf_id: "0x60000000"
+  - interface: "GigabitEthernet0/0/0/3"
+    in_acl: ""
+    ip_address: ""
+    ip_mtu: ""
+    link_status: "Up"
+    mtu: ""
+    multicast_groups: []
+    out_acl: ""
+    prefix_length: ""
+    protocol: "ipv4"
+    protocol_status: "Up"
+    rpf_check: ""
+    sec_ip_address: []
+    sec_prefix_length: []
+    vrf: "MGMT"
+    vrf_id: "0x60000001"


### PR DESCRIPTION
Fixes an IOS-XR version 7 issue, where a line is now included for ARP EVPN