### PR TITLE
Fix space issue for command date, seen on XR6.6.3

### DIFF
--- a/ntc_templates/templates/cisco_xr_show_running-config_hostname.textfsm
+++ b/ntc_templates/templates/cisco_xr_show_running-config_hostname.textfsm
@@ -2,7 +2,7 @@ Value HOSTNAME (\S+)
 
 Start
   # Capture date output by XR by 'show run hostname' first
-  ^\S+ \S+ \S+ .*$$
+  ^\S+\s+\S+\s+\d+\s+\d+:\d+:\d+\.\d+\s+\S+$$
   # Capture hostname
   ^hostname ${HOSTNAME}$$
   ^\s*$$

--- a/ntc_templates/templates/cisco_xr_show_running-config_hostname.textfsm
+++ b/ntc_templates/templates/cisco_xr_show_running-config_hostname.textfsm
@@ -4,6 +4,6 @@ Start
   # Capture date output by XR by 'show run hostname' first
   ^\S+\s+\S+\s+\d+\s+\d+:\d+:\d+\.\d+\s+\S+$$
   # Capture hostname
-  ^hostname ${HOSTNAME}$$
+  ^hostname\s+${HOSTNAME}$$
   ^\s*$$
   ^. -> Error

--- a/tests/cisco_xr/show_running-config_hostname/cisco_xr_show_run_hostname1.raw
+++ b/tests/cisco_xr/show_running-config_hostname/cisco_xr_show_run_hostname1.raw
@@ -1,0 +1,2 @@
+Fri Apr  4 15:15:54.223 UTC
+hostname NCS5011-LAB

--- a/tests/cisco_xr/show_running-config_hostname/cisco_xr_show_run_hostname1.yml
+++ b/tests/cisco_xr/show_running-config_hostname/cisco_xr_show_run_hostname1.yml
@@ -1,0 +1,3 @@
+---
+parsed_sample:
+  - hostname: "NCS5011-LAB"


### PR DESCRIPTION
During work on Nautobot Device Onboarding, this template was failing due to the double space allocated to the date. 
11 April was OK, 4 April was not, due to the space layout. 

The regex now takes account of multiple spaces and the unit tests increased to reflect this. 

Developer Note: This is one of the few commands to match on the command date. It may be possible to remove this match and converge on a common solution within the XR commands. Will open an Issue to discuss 