### PR TITLE
Update cisco_xr_ping.textfsm for trailing commas

### DIFF
--- a/ntc_templates/templates/cisco_xr_ping.textfsm
+++ b/ntc_templates/templates/cisco_xr_ping.textfsm
@@ -14,7 +14,7 @@ Value RTT_MAX (\d+)
 Start
   ^(Mon?)|(Tue?)|(Wed?)|(Thu?)|(Fri?)|(Sat?)|(Sun?)\s.*$$
   ^Type\s+escape\s+sequence\s+to\s+abort.
-  ^Sending\s+${SENT_QTY},\s+${SENT_TYPE}\s+to\s+${DESTINATION},\s+timeout\s+is\s+${TIMEOUT}\s+seconds:
+  ^Sending\s+${SENT_QTY},\s+${SENT_TYPE}\s+to\s+${DESTINATION}(?:,)?\s+timeout\s+is\s+${TIMEOUT}\s+seconds:
   ^Packet\s+sent\s+with\s+a\s+source\s+address\s+of\s+${SOURCE}
   ^Packet\s+sent\s+with\s+the\s+DF\s+bit\s+set
   ^${RESPONSE_STREAM}

--- a/ntc_templates/templates/cisco_xr_ping.textfsm
+++ b/ntc_templates/templates/cisco_xr_ping.textfsm
@@ -14,7 +14,7 @@ Value RTT_MAX (\d+)
 Start
   ^(Mon?)|(Tue?)|(Wed?)|(Thu?)|(Fri?)|(Sat?)|(Sun?)\s.*$$
   ^Type\s+escape\s+sequence\s+to\s+abort.
-  ^Sending\s+${SENT_QTY},\s+${SENT_TYPE}\s+to\s+${DESTINATION}(?:,)?\s+timeout\s+is\s+${TIMEOUT}\s+seconds:
+  ^Sending\s+${SENT_QTY},\s+${SENT_TYPE}\s+to\s+${DESTINATION},?\s+timeout\s+is\s+${TIMEOUT}\s+seconds:
   ^Packet\s+sent\s+with\s+a\s+source\s+address\s+of\s+${SOURCE}
   ^Packet\s+sent\s+with\s+the\s+DF\s+bit\s+set
   ^${RESPONSE_STREAM}

--- a/ntc_templates/templates/cisco_xr_ping.textfsm
+++ b/ntc_templates/templates/cisco_xr_ping.textfsm
@@ -1,6 +1,6 @@
 Value Required SENT_QTY (\d+)
 Value Required SENT_TYPE (.*)
-Value Required DESTINATION (\S+)
+Value Required DESTINATION (\S+(.*[^,]))
 Value Required TIMEOUT (\d+)
 Value SOURCE (\S+)
 Value List RESPONSE_STREAM ([\.\!/Q/U]+)

--- a/ntc_templates/templates/cisco_xr_ping.textfsm
+++ b/ntc_templates/templates/cisco_xr_ping.textfsm
@@ -1,6 +1,6 @@
 Value Required SENT_QTY (\d+)
 Value Required SENT_TYPE (.*)
-Value Required DESTINATION (\S+(.*[^,]))
+Value Required DESTINATION (\S+[^,])
 Value Required TIMEOUT (\d+)
 Value SOURCE (\S+)
 Value List RESPONSE_STREAM ([\.\!/Q/U]+)

--- a/tests/cisco_xr/ping/cisco_xr_ping.yml
+++ b/tests/cisco_xr/ping/cisco_xr_ping.yml
@@ -1,14 +1,14 @@
 ---
 parsed_sample:
-  - sent_qty: "5"
-    sent_type: "100-byte ICMP Echos"
-    destination: "10.191.129.114"
-    timeout: "2"
-    source: ""
+  - destination: "10.191.129.114"
     response_stream:
       - "!!!!!"
-    success_pct: "100"
-    success_qty: "5"
-    rtt_min: "1"
     rtt_avg: "1"
     rtt_max: "1"
+    rtt_min: "1"
+    sent_qty: "5"
+    sent_type: "100-byte ICMP Echos"
+    source: ""
+    success_pct: "100"
+    success_qty: "5"
+    timeout: "2"

--- a/tests/cisco_xr/ping/cisco_xr_ping_fail.yml
+++ b/tests/cisco_xr/ping/cisco_xr_ping_fail.yml
@@ -1,14 +1,14 @@
 ---
 parsed_sample:
-  - sent_qty: "5"
-    sent_type: "100-byte ICMP Echos"
-    destination: "10.27.18.2"
-    timeout: "2"
-    source: ""
+  - destination: "10.27.18.2"
     response_stream:
       - "....."
-    success_pct: "0"
-    success_qty: "0"
-    rtt_min: ""
     rtt_avg: ""
     rtt_max: ""
+    rtt_min: ""
+    sent_qty: "5"
+    sent_type: "100-byte ICMP Echos"
+    source: ""
+    success_pct: "0"
+    success_qty: "0"
+    timeout: "2"

--- a/tests/cisco_xr/ping/cisco_xr_ping_mix.yml
+++ b/tests/cisco_xr/ping/cisco_xr_ping_mix.yml
@@ -1,14 +1,14 @@
 ---
 parsed_sample:
-  - sent_qty: "5"
-    sent_type: "100-byte ICMP Echos"
-    destination: "10.245.179.14"
-    timeout: "2"
-    source: ""
+  - destination: "10.245.179.14"
     response_stream:
       - "Q..U!"
-    success_pct: "20"
-    success_qty: "1"
-    rtt_min: "9"
     rtt_avg: "9"
     rtt_max: "9"
+    rtt_min: "9"
+    sent_qty: "5"
+    sent_type: "100-byte ICMP Echos"
+    source: ""
+    success_pct: "20"
+    success_qty: "1"
+    timeout: "2"

--- a/tests/cisco_xr/ping/cisco_xr_ping_nocomma.raw
+++ b/tests/cisco_xr/ping/cisco_xr_ping_nocomma.raw
@@ -1,0 +1,5 @@
+Mon Apr  7 17:46:45.631 BRT
+Type escape sequence to abort.
+Sending 5, 100-byte ICMP Echos to 10.17.230.14 timeout is 1 seconds:
+!!!!!
+Success rate is 100 percent (5/5), round-trip min/avg/max = 3/3/4 ms

--- a/tests/cisco_xr/ping/cisco_xr_ping_nocomma.yml
+++ b/tests/cisco_xr/ping/cisco_xr_ping_nocomma.yml
@@ -1,14 +1,14 @@
 ---
 parsed_sample:
-  - sent_qty: "5"
-    sent_type: "100-byte ICMP Echos"
-    destination: "10.17.230.14"
-    timeout: "1"
-    source: ""
+  - destination: "10.17.230.14"
     response_stream:
       - "!!!!!"
-    success_pct: "100"
-    success_qty: "5"
-    rtt_min: "3"
     rtt_avg: "3"
     rtt_max: "4"
+    rtt_min: "3"
+    sent_qty: "5"
+    sent_type: "100-byte ICMP Echos"
+    source: ""
+    success_pct: "100"
+    success_qty: "5"
+    timeout: "1"

--- a/tests/cisco_xr/ping/cisco_xr_ping_nocomma.yml
+++ b/tests/cisco_xr/ping/cisco_xr_ping_nocomma.yml
@@ -1,0 +1,14 @@
+---
+parsed_sample:
+  - sent_qty: "5"
+    sent_type: "100-byte ICMP Echos"
+    destination: "10.17.230.14"
+    timeout: "1"
+    source: ""
+    response_stream:
+      - "!!!!!"
+    success_pct: "100"
+    success_qty: "5"
+    rtt_min: "3"
+    rtt_avg: "3"
+    rtt_max: "4"

--- a/tests/cisco_xr/ping/cisco_xr_ping_quench.yml
+++ b/tests/cisco_xr/ping/cisco_xr_ping_quench.yml
@@ -1,14 +1,14 @@
 ---
 parsed_sample:
-  - sent_qty: "5"
-    sent_type: "100-byte ICMP Echos"
-    destination: "10.245.179.14"
-    timeout: "2"
-    source: ""
+  - destination: "10.245.179.14"
     response_stream:
       - "QQQQQ"
-    success_pct: "0"
-    success_qty: "0"
-    rtt_min: ""
     rtt_avg: ""
     rtt_max: ""
+    rtt_min: ""
+    sent_qty: "5"
+    sent_type: "100-byte ICMP Echos"
+    source: ""
+    success_pct: "0"
+    success_qty: "0"
+    timeout: "2"

--- a/tests/cisco_xr/ping/cisco_xr_ping_unreachable.yml
+++ b/tests/cisco_xr/ping/cisco_xr_ping_unreachable.yml
@@ -1,14 +1,14 @@
 ---
 parsed_sample:
-  - sent_qty: "5"
-    sent_type: "100-byte ICMP Echos"
-    destination: "10.245.179.14"
-    timeout: "2"
-    source: ""
+  - destination: "10.245.179.14"
     response_stream:
       - "UUUUU"
-    success_pct: "0"
-    success_qty: "0"
-    rtt_min: ""
     rtt_avg: ""
     rtt_max: ""
+    rtt_min: ""
+    sent_qty: "5"
+    sent_type: "100-byte ICMP Echos"
+    source: ""
+    success_pct: "0"
+    success_qty: "0"
+    timeout: "2"


### PR DESCRIPTION
Updated cisco_xr_ping.textfsm.

Found that some versions of Cisco XR ommit the comma after the destination address

`Sending 5, 100-byte ICMP Echos to 10.245.179.18 timeout is 2 seconds`

instead of

`Sending 5, 100-byte ICMP Echos to 10.245.179.18, timeout is 2 seconds`

Corrected template and added test case.