### PR TITLE
Fix Arista show version for cEOS

### DIFF
--- a/ntc_templates/templates/arista_eos_show_version.textfsm
+++ b/ntc_templates/templates/arista_eos_show_version.textfsm
@@ -20,4 +20,6 @@ Start
   ^Uptime:\s+${UPTIME}
   ^Total\s+memory:\s+${TOTAL_MEMORY}
   ^Free\s+memory:\s+${FREE_MEMORY} -> Record
+  ^cEOS\s+tools\s+version:
+  ^Kernel\s+version:
   ^. -> Error

--- a/tests/arista_eos/show_version/arista_eos_show_version_ceos.raw
+++ b/tests/arista_eos/show_version/arista_eos_show_version_ceos.raw
@@ -1,0 +1,19 @@
+Arista cEOSLab
+Hardware version:
+Serial number: 35BA12C16E793CAD48DE0EEC072CFD74
+Hardware MAC address: 001c.73cd.2352
+System MAC address: 001c.73cd.2352
+
+Software image version: 4.31.6M-39953990.4316M (engineering build)
+Architecture: x86_64
+Internal build version: 4.31.6M-39953990.4316M
+Internal build ID: 27a18095-d8a6-4dcf-a74c-c9ad0f655faf
+Image format version: 1.0
+Image optimization: None
+
+cEOS tools version: (unknown)
+Kernel version: 6.8.0-60-generic
+
+Uptime: 2 days, 15 hours and 56 minutes
+Total memory: 43138472 kB
+Free memory: 27548760 kB

--- a/tests/arista_eos/show_version/arista_eos_show_version_ceos.yml
+++ b/tests/arista_eos/show_version/arista_eos_show_version_ceos.yml
@@ -1,0 +1,10 @@
+---
+parsed_sample:
+  - free_memory: "27548760"
+    hw_version: ""
+    image: "4.31.6M-39953990.4316M"
+    model: "cEOSLab"
+    serial_number: "35BA12C16E793CAD48DE0EEC072CFD74"
+    sys_mac: "001c.73cd.2352"
+    total_memory: "43138472"
+    uptime: "2 days, 15 hours and 56 minutes"


### PR DESCRIPTION
resolves #2135

Adds missing lines so the template works for cEOS output