### PR TITLE
Fix arista eos show version for containerlab ceos

### DIFF
--- a/ntc_templates/templates/arista_eos_show_version.textfsm
+++ b/ntc_templates/templates/arista_eos_show_version.textfsm
@@ -17,6 +17,7 @@ Start
   ^Architecture:\s+\S+
   ^Internal\s+build\s+(version|ID):\s+\S+
   ^Image\s+(format\s+version|optimization):\s+\S+
+  ^Kernel\s+version:\s+\S+
   ^Uptime:\s+${UPTIME}
   ^Total\s+memory:\s+${TOTAL_MEMORY}
   ^Free\s+memory:\s+${FREE_MEMORY} -> Record

--- a/tests/arista_eos/show_version/arista_eos_show_version_clab.raw
+++ b/tests/arista_eos/show_version/arista_eos_show_version_clab.raw
@@ -1,0 +1,18 @@
+Arista cEOSLab
+Hardware version: 
+Serial number: 
+Hardware MAC address: 001c.7312.b056
+System MAC address: 001c.7312.b056
+
+Software image version: 4.32.1F-37265360.4321F (engineering build)
+Architecture: x86_64
+Internal build version: 4.32.1F-37265360.4321F
+Internal build ID: 5cc97ff0-08f5-438e-9b7c-c94dea3f44a6
+Image format version: 1.0
+Image optimization: None
+
+Kernel version: 6.6.87.2-microsoft-standard-WSL2
+
+Uptime: 1 hour and 16 minutes
+Total memory: 16378596 kB
+Free memory: 8609248 kB

--- a/tests/arista_eos/show_version/arista_eos_show_version_clab.yml
+++ b/tests/arista_eos/show_version/arista_eos_show_version_clab.yml
@@ -1,0 +1,10 @@
+---
+parsed_sample:
+  - free_memory: "8609248"
+    hw_version: ""
+    image: "4.32.1F-37265360.4321F"
+    model: "cEOSLab"
+    serial_number: ""
+    sys_mac: "001c.7312.b056"
+    total_memory: "16378596"
+    uptime: "1 hour and 16 minutes"


### PR DESCRIPTION
Fixes this error in nautobot-app-device-onboarding:

```
Traceback (most recent call last):
File "/source/nautobot_device_onboarding/nornir_plays/command_getter.py", line 180, in netmiko_send_commands
parsed_output = parse_output(
^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/ntc_templates/parse.py", line 77, in parse_output
cli_table.ParseCmd(data, attrs)
File "/usr/local/lib/python3.11/site-packages/textfsm/clitable.py", line 282, in ParseCmd
self.table = self._ParseCmdItem(self.raw, template_file=template_files[0])
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/textfsm/clitable.py", line 315, in _ParseCmdItem
for record in fsm.ParseText(cmd_input):
^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/textfsm/parser.py", line 895, in ParseText
self._CheckLine(line)
File "/usr/local/lib/python3.11/site-packages/textfsm/parser.py", line 944, in _CheckLine
if self._Operations(rule, line):
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/textfsm/parser.py", line 1024, in _Operations
raise TextFSMError('State Error raised. Rule Line: %s. Input Line: %s'
textfsm.parser.TextFSMError: State Error raised. Rule Line: 23. Input Line: Kernel version: 6.6.87.2-microsoft-standard-WSL2
```

Sample output:

```
router2#show version
Arista cEOSLab
Hardware version: 
Serial number: 
Hardware MAC address: 001c.7312.b056
System MAC address: 001c.7312.b056

Software image version: 4.32.1F-37265360.4321F (engineering build)
Architecture: x86_64
Internal build version: 4.32.1F-37265360.4321F
Internal build ID: 5cc97ff0-08f5-438e-9b7c-c94dea3f44a6
Image format version: 1.0
Image optimization: None

Kernel version: 6.6.87.2-microsoft-standard-WSL2

Uptime: 1 hour and 16 minutes
Total memory: 16378596 kB
Free memory: 8609248 kB
```