### PR TITLE
Added cisco_ios_show_cts_credentials.textfsm

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_cts_credentials.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_cts_credentials.textfsm
@@ -1,0 +1,11 @@
+Value DEVICE_ID (\S+)
+Value ERROR (No\s+CTS\s+credentials\s+exist)
+
+Start
+  ^\s*Load\s+for\s+five\s+secs\s*:
+  ^\s*Time\s+source\s+is\s+
+  ^-+\s+show\s+cts\s+credentials\s+-+
+  ^\s*CTS\s+password\s+is\s+defined\s+in\s+keystore,\s+device-id\s+=\s+${DEVICE_ID} 
+  ^${ERROR}
+  ^\s*$$
+  ^.* -> Error

--- a/ntc_templates/templates/index
+++ b/ntc_templates/templates/index
@@ -301,6 +301,7 @@ cisco_ios_show_ip_bgp_neighbors.textfsm, .*, cisco_ios, sh[[ow]] ip bgp nei[[ghb
 cisco_ios_show_ip_ospf_database.textfsm, .*, cisco_ios, sh[[ow]] ip ospf data[[base]]
 cisco_ios_show_ip_ospf_neighbor.textfsm, .*, cisco_ios, sh[[ow]] ip ospf nei[[ghbor]]
 cisco_ios_show_ip_route_summary.textfsm, .*, cisco_ios, sh[[ow]] ip ro[[ute]] sum[[mary]]
+cisco_ios_show_cts_credentials.textfsm, .*, cisco_ios, sh[[ow]] ct[[s]] c[[redentials]]
 cisco_ios_show_ip_access-lists.textfsm, .*, cisco_ios, sh[[ow]] ip acce[[ss-lists]]
 cisco_ios_show_ip_dhcp_binding.textfsm, .*, cisco_ios, sh[[ow]] ip dh[[cp]] b[[inding]]
 cisco_ios_show_mpls_interfaces.textfsm, .*, cisco_ios, sh[[ow]] mpls interfa[[ces]]

--- a/tests/cisco_ios/show_cts_credentials/cisco_ios_show_cts_credentials.raw
+++ b/tests/cisco_ios/show_cts_credentials/cisco_ios_show_cts_credentials.raw
@@ -1,0 +1,1 @@
+No CTS credentials exist.

--- a/tests/cisco_ios/show_cts_credentials/cisco_ios_show_cts_credentials.yml
+++ b/tests/cisco_ios/show_cts_credentials/cisco_ios_show_cts_credentials.yml
@@ -1,0 +1,4 @@
+---
+parsed_sample:
+  - device_id: ""
+    error: "No CTS credentials exist"

--- a/tests/cisco_ios/show_cts_credentials/cisco_ios_show_cts_credentials_2.raw
+++ b/tests/cisco_ios/show_cts_credentials/cisco_ios_show_cts_credentials_2.raw
@@ -1,0 +1,1 @@
+CTS password is defined in keystore, device-id = switch0001

--- a/tests/cisco_ios/show_cts_credentials/cisco_ios_show_cts_credentials_2.yml
+++ b/tests/cisco_ios/show_cts_credentials/cisco_ios_show_cts_credentials_2.yml
@@ -1,0 +1,4 @@
+---
+parsed_sample:
+  - device_id: "switch0001"
+    error: ""

--- a/tests/cisco_ios/show_cts_credentials/cisco_ios_show_cts_credentials_3.raw
+++ b/tests/cisco_ios/show_cts_credentials/cisco_ios_show_cts_credentials_3.raw
@@ -1,0 +1,4 @@
+Load for five secs: 2%/0%; one minute: 2%; five minutes: 2%
+Time source is NTP, 10:23:11.179 CEST Sun Aug 17 2025
+------------------ show cts credentials  ------------------
+CTS password is defined in keystore, device-id = switch0001

--- a/tests/cisco_ios/show_cts_credentials/cisco_ios_show_cts_credentials_3.yml
+++ b/tests/cisco_ios/show_cts_credentials/cisco_ios_show_cts_credentials_3.yml
@@ -1,0 +1,4 @@
+---
+parsed_sample:
+  - device_id: "switch0001"
+    error: ""


### PR DESCRIPTION
##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
`cisco_ios_show_cts_credentials`

##### SUMMARY
Setting CTS Credentials is crucial for retrieving a RADIUS PAC in TrustSec Environments that use a PAC.

Typically a network admin is interested in:
- Does the network device have CTS Credentials defined?
  - If no credentials are defined
  - `ERROR` will have the value `No CTS credentials exist`
```yaml
---
parsed_sample:
  - device_id: ""
    error: "No CTS credentials exist"
```
-  the Device ID (is it correct?):
  - Example:
```yaml
---
parsed_sample:
  - device_id: "switch0001"
    error: ""
``` 
The CTS Password is not part of the `show cts credentials` output:
```text
CTS password is defined in keystore, device-id = switch0001

```
