### PR TITLE
Update nxos sh int trans for FC and 400Gb

### DIFF
--- a/ntc_templates/templates/cisco_nxos_show_interface_transceiver.textfsm
+++ b/ntc_templates/templates/cisco_nxos_show_interface_transceiver.textfsm
@@ -11,27 +11,32 @@ Start
   ^${INTERFACE}
   ^\s+transceiver\s+is\s+${STATUS}
   ^\s+type\s+is(\s+${TYPE})?
-  ^\s+name\s+is(\s+${MANUFACTURER})?
-  ^\s+part\s+number\s+is(\s+${PART_NUMBER})?
-  ^\s+serial\s+number\s+is(\s+${SERIAL})?
+  ^\s+[nN]ame\s+is(\s+${MANUFACTURER})?
+  ^\s+(Manufacturer's\s+)?part\s+number\s+is(\s+${PART_NUMBER})?
+  ^\s+[sS]erial\s+number\s+is(\s+${SERIAL})?
   ^\s+transceiver\s+
-  ^\s+nominal\s+
-  ^\s+revision\s+
+  ^\s+[nN]ominal\s+
+  ^\s+[rR]evision\s+
   ^\s+Link\s+
   ^\s+cable\s+type\s+is
   ^\s+cisco\s+id
-  ^\s+cisco\s+extended
-  ^\s+cisco\s+part\s+number
+  ^\s+[cC]isco\s+extended
+  ^\s+[cC]isco\s+part\s+number
   ^\s+cisco\s+product\s+id\s+is(\s+${PRODUCT_ID})?
   ^\s+cisco\s+version\s+id
   ^\s+cisco\s+vendor\s+id
   ^\s*DOM\s+is\s+(Enabled|Disabled)
   ^\s*Lane\s+Number
-  ^\s*SFP\s+Detail\s+Diagnostics\s+Information
+  ^\s*SFP(\s+Detail)?\s+Diagnostics\s+Information
   ^\s*-+
   ^\s*(Alarms|Warnings)
   ^\s*(High|Low)
-  ^\s*(Temperature|Voltage|Current|[TR]x\s+Power)
-  ^\s*Transmit\s+Fault\s+Count
+  ^\s*(Temperature|Voltage|Current|(Optical\s+)?[TR]x\s+Power)
+  ^\s*T(x|ransmit)\s+Fault\s+[cC]ount
+  ^\s+FC\s+Transmitter
+  ^\s+Transmission\s+medium
+  ^\s+Supported\s+speeds
+  ^\s+.*\s+diagnostic\s+monitoring\s+type
+  ^\s+Note:
   ^\s*$$
   ^. -> Error

--- a/ntc_templates/templates/cisco_nxos_show_interface_transceiver.textfsm
+++ b/ntc_templates/templates/cisco_nxos_show_interface_transceiver.textfsm
@@ -38,5 +38,16 @@ Start
   ^\s+Supported\s+speeds
   ^\s+.*\s+diagnostic\s+monitoring\s+type
   ^\s+Note:
+  ^\s+firmware\s+version
+  ^\s+Wavelength\s+tolerance
+  ^\s+(host|media)\s+lane\s+count
+  ^\s+\S+\s+module\s+temperature
+  ^\s+\S+\s+operational\s+voltage
+  ^\s+vendor\s+OUI
+  ^\s+(date|clei|Advertising)\s+code
+  ^\s+power\s+class
+  ^\s+max\s+power
+  ^\s+(near|far)-end\s+lane
+  ^\s+(media|Host\s+electrical)\s+interface
   ^\s*$$
   ^. -> Error

--- a/tests/cisco_nxos/show_interface_transceiver/cisco_nxos_show_interface_transceiver_400g.raw
+++ b/tests/cisco_nxos/show_interface_transceiver/cisco_nxos_show_interface_transceiver_400g.raw
@@ -1,0 +1,67 @@
+Ethernet1/35
+    transceiver is present
+    type is QSFP-DD-400G-FR4
+    name is CISCO-INNOLIGHT
+    part number is T-DQ4CNT-NC2
+    revision is 3C
+    serial number is IND282502DJ
+    nominal bitrate is 425000 MBit/sec per channel
+    cisco id is 24
+   cisco extended id number is 6
+    cisco part number is 10-3321-01
+    cisco product id is QDD-400G-FR4-S
+    cisco version id is V01
+    firmware version is 234.6
+    Link length SMF is 2 km
+    Nominal transmitter wavelength is 1301.00 nm
+    Wavelength tolerance is 6.500 nm
+    host lane count is 8
+    media lane count is 4
+    max module temperature is 75 deg C
+    min module temperature is 0 deg C
+    min operational voltage is 3.14 V
+    vendor OUI is 0x447c7f
+    date code is 240619  
+    clei code is CMUIAUNCAA
+    power class is 6 (12.0 W maximum)
+    max power is 12.00 W
+    near-end lanes used none
+    far-end lane code for 8 lanes Undefined
+    media interface is 1310 nm EML
+    Advertising code is Optical Interfaces: SMF
+    Host electrical interface code is 400GAUI-8 C2M (Annex 120E)
+    media interface advertising code is 400G-FR4
+
+Ethernet1/36
+    transceiver is present
+    type is QSFP-DD-400G-FR4
+    name is CISCO-INNOLIGHT
+    part number is T-DQ4CNT-NC2
+    revision is 3C
+    serial number is IND282501TU
+    nominal bitrate is 425000 MBit/sec per channel
+    cisco id is 24
+   cisco extended id number is 6
+    cisco part number is 10-3321-01
+    cisco product id is QDD-400G-FR4-S
+    cisco version id is V01
+    firmware version is 234.6
+    Link length SMF is 2 km
+    Nominal transmitter wavelength is 1301.00 nm
+    Wavelength tolerance is 6.500 nm
+    host lane count is 8
+    media lane count is 4
+    max module temperature is 75 deg C
+    min module temperature is 0 deg C
+    min operational voltage is 3.14 V
+    vendor OUI is 0x447c7f
+    date code is 240619  
+    clei code is CMUIAUNCAA
+    power class is 6 (12.0 W maximum)
+    max power is 12.00 W
+    near-end lanes used none
+    far-end lane code for 8 lanes Undefined
+    media interface is 1310 nm EML
+    Advertising code is Optical Interfaces: SMF
+    Host electrical interface code is 400GAUI-8 C2M (Annex 120E)
+    media interface advertising code is 400G-FR4

--- a/tests/cisco_nxos/show_interface_transceiver/cisco_nxos_show_interface_transceiver_400g.yml
+++ b/tests/cisco_nxos/show_interface_transceiver/cisco_nxos_show_interface_transceiver_400g.yml
@@ -1,0 +1,16 @@
+---
+parsed_sample:
+  - interface: "Ethernet1/35"
+    manufacturer: "CISCO-INNOLIGHT"
+    part_number: "T-DQ4CNT-NC2"
+    product_id: "QDD-400G-FR4-S"
+    serial: "IND282502DJ"
+    status: "present"
+    type: "QSFP-DD-400G-FR4"
+  - interface: "Ethernet1/36"
+    manufacturer: "CISCO-INNOLIGHT"
+    part_number: "T-DQ4CNT-NC2"
+    product_id: "QDD-400G-FR4-S"
+    serial: "IND282501TU"
+    status: "present"
+    type: "QSFP-DD-400G-FR4"

--- a/tests/cisco_nxos/show_interface_transceiver/cisco_nxos_show_interface_transceiver_fc_n5k.raw
+++ b/tests/cisco_nxos/show_interface_transceiver/cisco_nxos_show_interface_transceiver_fc_n5k.raw
@@ -1,0 +1,24 @@
+fc1/48 sfp is present 
+    Name is CISCO-FINISAR   
+    Manufacturer's part number is FTLF8528P2BCV-CS
+    Revision is D   
+    Serial number is FNS1547168F     
+    Cisco part number is 
+    FC Transmitter type is short wave laser w/o OFC (SN)
+    FC Transmitter supports short distance link length
+    Transmission medium is multimode laser with 62.5 um aperture (M6)
+    Supported speeds are - Min speed: 2000 Mb/s, Max speed: 8000 Mb/s
+    Nominal bit rate is 8500 Mb/s
+    Link length supported for 50/125mm fiber is 50 m
+    Link length supported for 62.5/125mm fiber is 20 m
+    Cisco extended id is unknown (0x0)
+
+    No tx fault, rx loss, no sync exists, diagnostic monitoring type is 0x68
+    SFP Diagnostics Information:
+        Temperature           :  34.63 C  + 
+        Voltage               :   3.29 V       
+        Current               :   0.00 mA       --
+        Optical Tx Power      : -14.95 dBm      --
+        Optical Rx Power      :  N/A   dBm      --
+        Tx Fault count  : 0
+    Note: ++  high-alarm; +  high-warning; --  low-alarm; -low-warning

--- a/tests/cisco_nxos/show_interface_transceiver/cisco_nxos_show_interface_transceiver_fc_n5k.yml
+++ b/tests/cisco_nxos/show_interface_transceiver/cisco_nxos_show_interface_transceiver_fc_n5k.yml
@@ -1,0 +1,9 @@
+---
+parsed_sample:
+  - interface: "fc1/48"
+    manufacturer: "CISCO-FINISAR"
+    part_number: "FTLF8528P2BCV-CS"
+    product_id: ""
+    serial: "FNS1547168F"
+    status: ""
+    type: ""


### PR DESCRIPTION
resolves #2178

* Support Fibre Channel (FC) ports in Nexus 5k (running 7.x)
* Support 400Gb ports in Nexus 9k (running 10.3.6)