### PR TITLE
Fix arista_eos sh vrf since RD column was removed

### DIFF
--- a/ntc_templates/templates/arista_eos_show_vrf.textfsm
+++ b/ntc_templates/templates/arista_eos_show_vrf.textfsm
@@ -1,9 +1,10 @@
 Value VRF (\S+)
 Value RD (\d\S+|<.+>)
-Value List INTERFACES ([\w\./-]+)
+Value List INTERFACES ([A-Z]\S+\d+)
 
 Start
   ^\s+V[rR][fF]\s+RD\s+Protocols\s+State\s+Interfaces -> VRF
+  ^\s+V[rR][fF]\s+Protocols\s+State\s+Interfaces -> VRF_NO_RD
   ^Maximum
   ^\s*$$
   ^. -> Error
@@ -95,4 +96,43 @@ VRF
   ^\s+${VRF}\s+${RD}\s+\S+\s+\S+:\S+(\s\S+)*,?\s+$$
   #
   ################## Unmatched ###################
+  ^---+
+
+VRF_NO_RD
+  ^\s+\S+\s+\S+\s+(no\s)?routing.*$$ -> Continue.Record
+  #
+  # no interfaces
+  ^\s+${VRF}\s+\S+\s+(no\s)?routing\s+$$ -> Record
+  #
+  # first line, first interface
+  ^\s+${VRF}\s+\S+\s+\S+(\s\S+)?\s+${INTERFACES},?(\s\S+,?)*\s*$$ -> Continue
+  # first line, second of multiple interfaces
+  ^\s+\S+\s+\S+\s+\S+(\s\S+)?\s+(?:\S+,\s){1}${INTERFACES},? -> Continue
+  # first line, third of multiple interfaces
+  ^\s+\S+\s+\S+\s+\S+(\s\S+)?\s+(?:\S+,\s){2}${INTERFACES},? -> Continue
+  # first line, fourth of multiple interfaces
+  ^\s+\S+\s+\S+\s+\S+(\s\S+)?\s+(?:\S+,\s){3}${INTERFACES},? -> Continue
+  # first line, fifth of multiple interfaces
+  ^\s+\S+\s+\S+\s+\S+(\s\S+)?\s+(?:\S+,\s){4}${INTERFACES},? -> Continue
+  # first line, sixth of multiple interfaces
+  ^\s+\S+\s+\S+\s+\S+(\s\S+)?\s+(?:\S+,\s){5}${INTERFACES},? -> Continue
+  # first line, seventh of multiple interfaces
+  ^\s+\S+\s+\S+\s+\S+(\s\S+)?\s+(?:\S+,\s){6}${INTERFACES},? -> Continue
+  #
+  # line begins with whitespace, first interface
+  ^\s+${INTERFACES},? -> Continue
+  # line begins with whitespace, second interface
+  ^\s+(?:\S+,\s){1}${INTERFACES},? -> Continue
+  # line begins with whitespace, third interface
+  ^\s+(?:\S+,\s){2}${INTERFACES},? -> Continue
+  # line begins with whitespace, fourth interface
+  ^\s+(?:\S+,\s){3}${INTERFACES},? -> Continue
+  # line begins with whitespace, fifth interface
+  ^\s+(?:\S+,\s){4}${INTERFACES},? -> Continue
+  # line begins with whitespace, sixth interface
+  ^\s+(?:\S+,\s){5}${INTERFACES},? -> Continue
+  # line begins with whitespace, seventh interface
+  ^\s+(?:\S+,\s){6}${INTERFACES},? -> Continue
+  #
+  # Unmatched
   ^---+

--- a/ntc_templates/templates/arista_eos_show_vrf.textfsm
+++ b/ntc_templates/templates/arista_eos_show_vrf.textfsm
@@ -93,3 +93,5 @@ VRF
   #
   # match vrf line with no interfaces
   ^\s+${VRF}\s+${RD}\s+\S+\s+\S+:\S+(\s\S+)*,?\s+$$
+  #
+  ^---+

--- a/ntc_templates/templates/arista_eos_show_vrf.textfsm
+++ b/ntc_templates/templates/arista_eos_show_vrf.textfsm
@@ -37,7 +37,7 @@ VRF
   # three interfaces displayed per line
   ^\s+\S+\s+\S+(\s\S+)*\s+\S+\s+\S+:\S+(\s\S+)*,?\s+(?:\S+,\s){2}${INTERFACES}, -> Continue
   #
-  ############## Lines that contains state ##################
+  ############## Lines that contain state ##################
   #
   # match state only line
   ^\s+(\S+:\S+(?:\s\S+)*)\s*$$
@@ -94,4 +94,5 @@ VRF
   # match vrf line with no interfaces
   ^\s+${VRF}\s+${RD}\s+\S+\s+\S+:\S+(\s\S+)*,?\s+$$
   #
+  ################## Unmatched ###################
   ^---+

--- a/tests/arista_eos/show_vrf/arista_eos_show_vrf-no-rd.raw
+++ b/tests/arista_eos/show_vrf/arista_eos_show_vrf-no-rd.raw
@@ -1,0 +1,19 @@
+Maximum number of VRFs allowed: 1023
+   VRF             Protocols       State         Interfaces                             
+--------------- --------------- ---------------- ---------------------------------------
+   default         IPv4            routing       Vl2000, Vl4094                         
+   default         IPv6            no routing                                           
+   guest-wan       IPv4            routing       Et4.930, Lo23, Vl23, Vl53, Vl93, Vl466 
+   guest-wan       IPv6            no routing                                           
+   p-wan           IPv4            routing       Et3, Lo29, Vl2, Vl5, Vl22, Vl29, Vl55, 
+                                                 Vl99, Vl463                            
+   p-wan           IPv6            no routing                                           
+   sdwan           IPv4            routing       Et2                                    
+   sdwan           IPv6            no routing                                           
+   sip-ext         IPv4            routing       Et19, Vl204, Vl206, Vl207, Vl213       
+   sip-ext         IPv6            no routing                                           
+   sip-wan         IPv4            routing       Vl58, Vl89, Vl205, Vl208, Vl209, Vl210,
+                                                 Vl211, Vl212, Vl468                    
+   sip-wan         IPv6            no routing                                           
+   trade-wan       IPv4            routing       Et4.970, Lo26, Vl26, Vl57, Vl96, Vl465 
+   trade-wan       IPv6            no routing                                           

--- a/tests/arista_eos/show_vrf/arista_eos_show_vrf-no-rd.yml
+++ b/tests/arista_eos/show_vrf/arista_eos_show_vrf-no-rd.yml
@@ -1,0 +1,82 @@
+---
+parsed_sample:
+  - interfaces:
+      - "Vl2000"
+      - "Vl4094"
+    rd: ""
+    vrf: "default"
+  - interfaces: []
+    rd: ""
+    vrf: "default"
+  - interfaces:
+      - "Et4.930"
+      - "Lo23"
+      - "Vl23"
+      - "Vl53"
+      - "Vl93"
+      - "Vl466"
+    rd: ""
+    vrf: "guest-wan"
+  - interfaces: []
+    rd: ""
+    vrf: "guest-wan"
+  - interfaces:
+      - "Et3"
+      - "Lo29"
+      - "Vl2"
+      - "Vl5"
+      - "Vl22"
+      - "Vl29"
+      - "Vl55"
+      - "Vl99"
+      - "Vl463"
+    rd: ""
+    vrf: "p-wan"
+  - interfaces: []
+    rd: ""
+    vrf: "p-wan"
+  - interfaces:
+      - "Et2"
+    rd: ""
+    vrf: "sdwan"
+  - interfaces: []
+    rd: ""
+    vrf: "sdwan"
+  - interfaces:
+      - "Et19"
+      - "Vl204"
+      - "Vl206"
+      - "Vl207"
+      - "Vl213"
+    rd: ""
+    vrf: "sip-ext"
+  - interfaces: []
+    rd: ""
+    vrf: "sip-ext"
+  - interfaces:
+      - "Vl58"
+      - "Vl89"
+      - "Vl205"
+      - "Vl208"
+      - "Vl209"
+      - "Vl210"
+      - "Vl211"
+      - "Vl212"
+      - "Vl468"
+    rd: ""
+    vrf: "sip-wan"
+  - interfaces: []
+    rd: ""
+    vrf: "sip-wan"
+  - interfaces:
+      - "Et4.970"
+      - "Lo26"
+      - "Vl26"
+      - "Vl57"
+      - "Vl96"
+      - "Vl465"
+    rd: ""
+    vrf: "trade-wan"
+  - interfaces: []
+    rd: ""
+    vrf: "trade-wan"

--- a/tests/arista_eos/show_vrf/arista_eos_show_vrf.yml
+++ b/tests/arista_eos/show_vrf/arista_eos_show_vrf.yml
@@ -1,8 +1,6 @@
 ---
 parsed_sample:
-  - vrf: "blue"
-    rd: "10.125.253.15:1"
-    interfaces:
+  - interfaces:
       - "Vlan1006"
       - "Vlan2230"
       - "Vlan2231"
@@ -15,9 +13,9 @@ parsed_sample:
       - "Vlan2238"
       - "Vlan2240"
       - "Vlan2239"
-  - vrf: "green"
-    rd: "<not set>"
-    interfaces:
+    rd: "10.125.253.15:1"
+    vrf: "blue"
+  - interfaces:
       - "Vlan1015"
       - "Vlan1016"
       - "Vlan1017"
@@ -25,14 +23,16 @@ parsed_sample:
       - "Vlan1019"
       - "Vlan1020"
       - "Vlan1021"
-  - vrf: "yellow"
-    rd: "10.125.253.15:4"
-    interfaces:
+    rd: "<not set>"
+    vrf: "green"
+  - interfaces:
       - "Vlan1009"
-  - vrf: "red"
+    rd: "10.125.253.15:4"
+    vrf: "yellow"
+  - interfaces: []
     rd: "10.125.253.15:6"
-    interfaces: []
-  - vrf: "black"
-    rd: "999:999"
-    interfaces:
+    vrf: "red"
+  - interfaces:
       - "Management1"
+    rd: "999:999"
+    vrf: "black"

--- a/tests/arista_eos/show_vrf/arista_eos_show_vrf_2.yml
+++ b/tests/arista_eos/show_vrf/arista_eos_show_vrf_2.yml
@@ -1,14 +1,14 @@
 ---
 parsed_sample:
-  - vrf: "red"
-    rd: "100:100"
-    interfaces:
+  - interfaces:
       - "Ethernet3"
       - "Ethernet4"
       - "Ethernet5"
       - "Ethernet6"
       - "Ethernet7"
-  - vrf: "blue"
-    rd: "1:1"
-    interfaces:
+    rd: "100:100"
+    vrf: "red"
+  - interfaces:
       - "Management1"
+    rd: "1:1"
+    vrf: "blue"

--- a/tests/arista_eos/show_vrf/arista_eos_show_vrf_3.yml
+++ b/tests/arista_eos/show_vrf/arista_eos_show_vrf_3.yml
@@ -1,16 +1,16 @@
 ---
 parsed_sample:
-  - vrf: "red"
-    rd: "<not set>"
-    interfaces:
+  - interfaces:
       - "Ethernet10"
       - "Ethernet20/1"
       - "Loopback0"
       - "Vlan100"
       - "Vlan200"
-  - vrf: "blue"
-    rd: "1:1"
-    interfaces:
+    rd: "<not set>"
+    vrf: "red"
+  - interfaces:
       - "Ethernet20/1.10"
       - "Loopback1"
       - "Port-Channel1.20"
+    rd: "1:1"
+    vrf: "blue"


### PR DESCRIPTION
resolves #2130

Fix the template since the RD column was removed from arista_eos `show vrf` output somewhere around 4.32.x.

* Ended up having to make some of the new rules more rigid (`(no\s)?routing`) for proper parsing.
* Also had to adjust the `INTERFACES` regex to make it a bit more rigid (_start with a capital letter and end with a number_) so the VRF name wasn't being matched and placed into the interfaces list.
  * Certainly a VRF name crafted a certain way _may_ end up matched -- ***and for that I'm open to updates from others***.

This one was a bit of a pain, hah. :sweat_smile: Given the parsing plan (with the list of interfaces that can span more than one line), there are no `Error` directives and it isn't likely there can be.