### PR TITLE
Fix arista_eos sh ip bgp sum for PfxAdv column

### DIFF
--- a/ntc_templates/templates/arista_eos_show_ip_bgp_summary.textfsm
+++ b/ntc_templates/templates/arista_eos_show_ip_bgp_summary.textfsm
@@ -18,6 +18,7 @@ Start
   ^\s*Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+InQ\s+OutQ\s+Up/Down\s+State/PfxRcd\s*$$
   ^\s*Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+InQ\s+OutQ\s+Up/Down\s+State\s+PfxRcd\s*$$
   ^\s*Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+InQ\s+OutQ\s+Up/Down\s+State\s+PfxRcd\s+PfxAcc\s*$$
+  ^\s+Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+InQ\s+OutQ\s+Up/Down\s+State\s+PfxRcd\s+PfxAcc\s+PfxAdv\s*$$
   ^\s*Description\s+Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+InQ\s+OutQ\s+Up/Down\s+State\s+PfxRcd\s+PfxAcc\s*$$
   ^.+\s+${ROUTER_ID},\s+[Ll]ocal\s+[Aa][Ss]\s+[Nn]umber\s+${LOCAL_AS}
   ^\s+${BGP_NEIGH}\s+\d+\s+${NEIGH_AS}\s+${MSG_RCVD}\s+${MSG_SENT}\s+${IN_QUEUE}\s+${OUT_QUEUE}\s+${UP_DOWN}\s+${STATE}\s+${STATE_PFXRCD}\s+${STATE_PFXACC} -> Record


### PR DESCRIPTION
Encountered PfxAdv option when working on Lab cEOS devices running 4.34.2F-43232954.4342F, added line 21 to account for that field as previous version encountered error without it

CLI output from device:
<img width="884" height="150" alt="image" src="https://github.com/user-attachments/assets/5af0f6e5-f9cf-4109-a9b0-8d2f607d8ec8" />

Error received without line:
<img width="1517" height="590" alt="image" src="https://github.com/user-attachments/assets/e3059834-32eb-4b87-90ce-ea9e760bf587" />

Results after adding line to local template file:
<img width="1270" height="44" alt="image" src="https://github.com/user-attachments/assets/7dd59b3f-602b-437e-8fb5-cef6ff3765e7" />
