### PR TITLE
Modify disp interface for Comware5/7 variations

### DIFF
--- a/ntc_templates/templates/hp_comware_display_interface.textfsm
+++ b/ntc_templates/templates/hp_comware_display_interface.textfsm
@@ -1,5 +1,5 @@
 Value Required INTERFACE (\S+)
-Value LINE_STATUS (UP|DOWN|Administratively DOWN)
+Value LINE_STATUS (UP|DOWN|Administratively DOWN|STP DOWN)
 Value PROTOCOL_STATUS (UP(\(spoofing\))?|DOWN)
 Value List IP_ADDRESS (\S+)
 Value MTU (\d+)
@@ -27,10 +27,10 @@ Start
   ^\s*Maximum\s+[Tt]ransmi\S+\s+[Uu]nit:\s+${MTU}
   ^\s*The\sMaximum\s+Transmit\s+Unit\sis\s+${MTU}
   ^\s*Maximum\s+frame\s+length:\s*${L2MTU}
-  ^\s*Forbid\s+jumbo\s+frames\s+to\s+pass
+  ^\s*Forbid\s+jumbo\s+frame(s?)\s+to\s+pass
   ^\s*The\s+[Mm]aximum\s+[Ff]rame\s+[Ll]ength\s+is\s+${L2MTU}
-  ^\s*Internet\s+[Aa]ddress:\s+${IP_ADDRESS}\s+\(([Pp]rimary|[Ss]ub|[Cc]ellular-[Aa]llocated)\)
-  ^\s*Internet\s+[Aa]ddress\s+is\s+${IP_ADDRESS}\s+[Pp]rimary
+  ^\s*Internet\s+[Aa]ddress:\s+${IP_ADDRESS}\s+\(([Pp]rimary|[Ss]ub|[Cc]ellular-[Aa]llocated|DHCP-[Aa]llocated)\)
+  ^\s*Internet\s+[Aa]ddress\s+is\s+${IP_ADDRESS}\s+([Pp]rimary|[Ss]ub|[Cc]ellular-[Aa]llocated|DHCP-[Aa]llocated)
   ^\s*IP\s+[Pp]acket\s+[Ff]rame\s+[Tt]ype\s*:\s*[^,]+,\s+[Hh]ardware\s+[Aa]ddress:\s+${HW_ADDRESS}
   ^\s*IPv6\s+[Pp]acket\s+[Ff]rame\s+[Tt]ype\s*:\s*[^,]+,\s+[Hh]ardware\s+[Aa]ddress:\s+${HW_ADDRESS}
   ^\s*${SPEED}\s+mode\s*,\s+${DUPLEX}\s+mode
@@ -38,6 +38,7 @@ Start
   ^\s*PVID:\s+${VLAN_NATIVE}
   ^\s*Port\s+link-type:\s+${PORT_LINK_TYPE}
   ^\s*Un[Tt]agged\s+VLAN\s+ID\s*:\s*${UNTAGGED_VLAN_ID}
+  ^\s*Un[Tt]agged\s+(VLAN|Vlan)(s?):\s*${UNTAGGED_VLAN_ID}
   # Trunk - Passing VLANs (parsing multiple times with Continue)
   ^\s+VLAN\s+[Pp]assing\s*:\s+${VLAN_PASSING},* -> Continue
   # Skip initial VLANs and read the Nth + 1
@@ -142,19 +143,22 @@ Start
   ^\s*Trunk\s+port
   ^\s*Loopback
   ^\s*Media
+  ^\s*Ethernet\s+port\s+mode:
   ^\s*[Ff]low
   ^\s*Allow\s+jumbo
   ^\s*Broadcast
   ^\s*Multicast
   ^\s*Unicast
+  ^\s*Known-unicast
   ^\s*No\sconnector
   ^\s*M[Dd][Ii]\s+type
+  ^\s*Port\s+up-mode
   ^\s*Port\s+priority
   ^\s*Current\s*system
   ^\s*Peak
   ^\s*IPv4\s+traffic
   ^\s*IPv6\s+traffic
-  ^\s+Tagged\s+VLAN
+  ^\s+Tagged\s+(VLAN|Vlan)
   ^\s+Un[tT]agged\s+VLAN
   ^\s*[Ii]nput
   ^\s*[Oo]utput
@@ -165,14 +169,14 @@ Start
   ^\s+-\s+unicasts
   ^\s+\d+\s+[Cc][Rr][Cc]
   ^\s+\d+\s+aborts
-  ^\s+\d+\s+packets,*\s*
+  ^\s*\d+\s+packets,*\s*
   ^\s+\d+\s+errors,*\s*
   ^\s+\d+\s+lost
   ^\s+\d+\s+input\s+error
   ^\s+\d+\s+output\s+error
   ^\s+\d+\s+drops,*\s*
   ^\s+\d+\s+deferred,*\s*
-  ^\s+\d+\s+broadcasts
+  ^\s+(-|\d+)\s+broadcasts
   ^\s+\d+\s+ignored
   ^\s+\d+\s+dribbles
   ^\s*Tunnel\s

--- a/tests/hp_comware/display_interface/hp_comware_display_interface.yml
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface.yml
@@ -77,7 +77,7 @@ parsed_sample:
     port_link_type: "Access"
     protocol_status: "DOWN"
     speed: "Unknown-speed"
-    untagged_vlan_id: ""
+    untagged_vlan_id: "1"
     vlan_native: "1"
     vlan_passing: []
     vlan_permitted: []

--- a/tests/hp_comware/display_interface/hp_comware_display_interface12.raw
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface12.raw
@@ -1,0 +1,100 @@
+HundredGigE3/0/23
+Current state: Administratively DOWN
+Line protocol state: DOWN
+IP packet frame type: Ethernet II, hardware address: dc68-0c3c-2388
+Description: SOME-DEVICE-DESC
+Bandwidth: 100000000 kbps
+Loopback is not set
+Media type is not sure, port is No connector
+Ethernet port mode: LAN
+Unknown-speed mode, unknown-duplex mode
+Link speed type is autonegotiation, link duplex type is autonegotiation
+Flow-control is not enabled
+Maximum frame length: 9416
+Allow jumbo frames to pass
+Broadcast max-ratio: 100%
+Multicast max-ratio: 100%
+Unicast max-ratio: 100%
+PVID: 1
+MDI type: Automdix
+Port link-type: Access
+ Tagged VLANs:   None
+ Untagged VLANs: 1
+Port priority: 0
+Last link flapping: Never
+Last clearing of counters: 21:02:03 Sat 05/31/2025 
+Current system time:2025-09-29 17:34:11 EST-05:00:00
+Last time when physical state changed to up:-
+Last time when physical state changed to down:2000-12-31 19:04:54 EST-05:00:00
+ Peak input rate: 0 bytes/sec, at 2025-05-31 21:02:08 
+ Peak output rate: 0 bytes/sec, at 2025-05-31 21:02:08 
+ Last 300 seconds input: 0 packets/sec 0 bytes/sec -%
+ Last 300 seconds output: 0 packets/sec 0 bytes/sec -%
+ Input (total):  0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Input (normal):  0 packets, - bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, - overruns, 0 aborts
+         - ignored, - parity errors
+ Output (total): 0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Output (normal): 0 packets, - bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Output: 0 output errors, - underruns, 0 buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, - no carrier
+IPv4 traffic statistics:
+ Last 300 seconds input rate: 0 packets/sec, 0 bytes/sec
+ Last 300 seconds output rate: 0 packets/sec, 0 bytes/sec
+ Input: 0 packets, 0 bytes
+ Output: 0 packets, 0 bytes
+IPv6 traffic statistics:
+ Last 300 seconds input rate: 0 packets/sec, 0 bytes/sec
+ Last 300 seconds output rate: 0 packets/sec, 0 bytes/sec
+ Input: 0 packets, 0 bytes
+ Output: 0 packets, 0 bytes
+
+Ten-GigabitEthernet13/2/12
+Current state: UP
+Line protocol state: UP
+IP packet frame type: Ethernet II, hardware address: 40b9-3c3c-e9a0
+Description: SOME_DEVICE_DESCR
+Bandwidth: 1000000 kbps
+Loopback is not set
+Media type is twisted pair, port hardware type is 1000_BASE_T_AN_SFP
+1000Mbps-speed mode, full-duplex mode
+Link speed type is autonegotiation, link duplex type is autonegotiation
+Flow-control is not enabled
+Maximum frame length: 10000
+Allow jumbo frames to pass
+Broadcast max-ratio: 100%
+Multicast max-ratio: 100%
+Unicast max-ratio: 100%
+PVID: 1
+MDI type: Automdix
+Port up-mode is enabled
+Port link-type: Access
+ Tagged VLANs:   None
+ Untagged VLANs: 1
+Port priority: 0
+Last link flapping: 299 weeks 3 days 18 hours 27 minutes
+Last clearing of counters: 23:10:42 Sun 03/07/2021 
+ Peak input rate: 0 bytes/sec, at 2025-03-06 17:03:07 
+ Peak output rate: 32 bytes/sec, at 2025-03-06 17:03:46 
+ Last 300 second input: 0 packets/sec 0 bytes/sec 0%
+ Last 300 second output: 0 packets/sec 32 bytes/sec 0%
+ Input (total):  0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Input (normal):  0 packets, - bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, - overruns, 0 aborts
+         - ignored, - parity errors
+ Output (total): 72002554 packets, 4608163456 bytes
+         0 unicasts, 0 broadcasts, 72002554 multicasts, 0 pauses
+ Output (normal): 72002554 packets, - bytes
+         0 unicasts, 0 broadcasts, 72002554 multicasts, 0 pauses
+ Output: 0 output errors, - underruns, - buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, - no carrier

--- a/tests/hp_comware/display_interface/hp_comware_display_interface12.yml
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface12.yml
@@ -1,0 +1,36 @@
+---
+parsed_sample:
+  - bandwidth: "100000000 kbps"
+    description: "SOME-DEVICE-DESC"
+    duplex: "unknown-duplex"
+    hw_address:
+      - "dc68-0c3c-2388"
+    interface: "HundredGigE3/0/23"
+    ip_address: []
+    l2mtu: "9416"
+    line_status: "Administratively DOWN"
+    mtu: ""
+    port_link_type: "Access"
+    protocol_status: "DOWN"
+    speed: "Unknown-speed"
+    untagged_vlan_id: "1"
+    vlan_native: "1"
+    vlan_passing: []
+    vlan_permitted: []
+  - bandwidth: "1000000 kbps"
+    description: "SOME_DEVICE_DESCR"
+    duplex: "full-duplex"
+    hw_address:
+      - "40b9-3c3c-e9a0"
+    interface: "Ten-GigabitEthernet13/2/12"
+    ip_address: []
+    l2mtu: "10000"
+    line_status: "UP"
+    mtu: ""
+    port_link_type: "Access"
+    protocol_status: "UP"
+    speed: "1000Mbps-speed"
+    untagged_vlan_id: "1"
+    vlan_native: "1"
+    vlan_passing: []
+    vlan_permitted: []

--- a/tests/hp_comware/display_interface/hp_comware_display_interface2.yml
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface2.yml
@@ -13,7 +13,7 @@ parsed_sample:
     port_link_type: "Access"
     protocol_status: "DOWN"
     speed: "Unknown-speed"
-    untagged_vlan_id: ""
+    untagged_vlan_id: "1"
     vlan_native: "1"
     vlan_passing: []
     vlan_permitted: []

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_dhcp.raw
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_dhcp.raw
@@ -1,0 +1,14 @@
+Vlan-interface123
+Current state: UP
+Line protocol state: UP
+Description: Vlan-interface123 Interface
+Bandwidth: 10000000 kbps
+Maximum transmission unit: 1500
+Internet address: 10.11.12.13/24 (DHCP-allocated)
+IP packet frame type: Ethernet II, hardware address: 5c8a-3849-a0c5
+IPv6 packet frame type: Ethernet II, hardware address: 5c8a-3849-a0c5
+Last clearing of counters: Never
+Last 300 seconds input rate: 0 bytes/sec, 0 bits/sec, 0 packets/sec
+Last 300 seconds output rate: 0 bytes/sec, 0 bits/sec, 0 packets/sec
+Input: 0 packets, 0 bytes, 0 drops
+Output: 0 packets, 0 bytes, 0 drops

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_dhcp.yml
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_dhcp.yml
@@ -1,0 +1,21 @@
+---
+parsed_sample:
+  - bandwidth: "10000000 kbps"
+    description: "Vlan-interface123 Interface"
+    duplex: ""
+    hw_address:
+      - "5c8a-3849-a0c5"
+      - "5c8a-3849-a0c5"
+    interface: "Vlan-interface123"
+    ip_address:
+      - "10.11.12.13/24"
+    l2mtu: ""
+    line_status: "UP"
+    mtu: "1500"
+    port_link_type: ""
+    protocol_status: "UP"
+    speed: ""
+    untagged_vlan_id: ""
+    vlan_native: ""
+    vlan_passing: []
+    vlan_permitted: []

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_known_unicast.raw
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_known_unicast.raw
@@ -1,0 +1,56 @@
+GigabitEthernet11/0/57
+Current state: DOWN
+Line protocol state: DOWN
+IP packet frame type: Ethernet II, hardware address: dc68-0c81-c28e
+Description: GigabitEthernet11/0/57 Interface
+Bandwidth: 1000000 kbps
+Loopback is not set
+Media type is not sure, port hardware type is No connector
+Unknown-speed mode, unknown-duplex mode
+Link speed type is autonegotiation, link duplex type is autonegotiation
+Flow-control is not enabled
+Maximum frame length: 9416
+Allow jumbo frames to pass
+Broadcast max-ratio: 100%
+Multicast max-ratio: 100%
+Unicast max-ratio: 100%
+Known-unicast max-ratio: 100%
+PVID: 1
+MDI type: Automdix
+Port link-type: Access
+ Tagged VLANs:   None
+ Untagged VLANs: 1
+Port priority: 0
+Last link flapping: Never
+Last clearing of counters: Never
+Current system time:2025-09-29 16:22:53 EST-05:00:00
+Last time when physical state changed to up:-
+Last time when physical state changed to down:2001-01-01 00:05:34 EST-05:00:00
+ Peak input rate: 0 bytes/sec, at 2000-12-31 19:06:09 
+ Peak output rate: 0 bytes/sec, at 2000-12-31 19:06:09 
+ Last 300 seconds input: 0 packets/sec 0 bytes/sec -%
+ Last 300 seconds output: 0 packets/sec 0 bytes/sec -%
+ Input (total):  0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Input (normal):  0 packets, - bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, - overruns, 0 aborts
+         - ignored, - parity errors
+ Output (total): 0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Output (normal): 0 packets, - bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Output: 0 output errors, - underruns, 0 buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, - no carrier
+IPv4 traffic statistics:
+ Last 300 seconds input rate: 0 packets/sec, 0 bytes/sec
+ Last 300 seconds output rate: 0 packets/sec, 0 bytes/sec
+ Input: 0 packets, 0 bytes
+ Output: 0 packets, 0 bytes
+IPv6 traffic statistics:
+ Last 300 seconds input rate: 0 packets/sec, 0 bytes/sec
+ Last 300 seconds output rate: 0 packets/sec, 0 bytes/sec
+ Input: 0 packets, 0 bytes
+ Output: 0 packets, 0 bytes

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_known_unicast.yml
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_known_unicast.yml
@@ -1,0 +1,19 @@
+---
+parsed_sample:
+  - bandwidth: "1000000 kbps"
+    description: "GigabitEthernet11/0/57 Interface"
+    duplex: "unknown-duplex"
+    hw_address:
+      - "dc68-0c81-c28e"
+    interface: "GigabitEthernet11/0/57"
+    ip_address: []
+    l2mtu: "9416"
+    line_status: "DOWN"
+    mtu: ""
+    port_link_type: "Access"
+    protocol_status: "DOWN"
+    speed: "Unknown-speed"
+    untagged_vlan_id: "1"
+    vlan_native: "1"
+    vlan_passing: []
+    vlan_permitted: []

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_release_09119P17.yml
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_release_09119P17.yml
@@ -50,7 +50,7 @@ parsed_sample:
     port_link_type: "Access"
     protocol_status: "DOWN"
     speed: "Unknown-speed"
-    untagged_vlan_id: ""
+    untagged_vlan_id: "1"
     vlan_native: "1"
     vlan_passing: []
     vlan_permitted: []
@@ -67,7 +67,7 @@ parsed_sample:
     port_link_type: "Access"
     protocol_status: "UP"
     speed: "1000Mbps-speed"
-    untagged_vlan_id: ""
+    untagged_vlan_id: "1"
     vlan_native: "1"
     vlan_passing: []
     vlan_permitted: []
@@ -84,7 +84,7 @@ parsed_sample:
     port_link_type: "Access"
     protocol_status: "DOWN"
     speed: "Unknown-speed"
-    untagged_vlan_id: ""
+    untagged_vlan_id: "1"
     vlan_native: "1"
     vlan_passing: []
     vlan_permitted: []
@@ -101,7 +101,7 @@ parsed_sample:
     port_link_type: "Access"
     protocol_status: "DOWN"
     speed: "Unknown-speed"
-    untagged_vlan_id: ""
+    untagged_vlan_id: "1"
     vlan_native: "1"
     vlan_passing: []
     vlan_permitted: []
@@ -118,7 +118,7 @@ parsed_sample:
     port_link_type: "Access"
     protocol_status: "DOWN"
     speed: "Unknown-speed"
-    untagged_vlan_id: ""
+    untagged_vlan_id: "1"
     vlan_native: "1"
     vlan_passing: []
     vlan_permitted: []
@@ -135,7 +135,7 @@ parsed_sample:
     port_link_type: "Access"
     protocol_status: "DOWN"
     speed: "Unknown-speed"
-    untagged_vlan_id: ""
+    untagged_vlan_id: "1"
     vlan_native: "1"
     vlan_passing: []
     vlan_permitted: []
@@ -152,7 +152,7 @@ parsed_sample:
     port_link_type: "Access"
     protocol_status: "DOWN"
     speed: "Unknown-speed"
-    untagged_vlan_id: ""
+    untagged_vlan_id: "1"
     vlan_native: "1"
     vlan_passing: []
     vlan_permitted: []
@@ -169,7 +169,7 @@ parsed_sample:
     port_link_type: "Access"
     protocol_status: "DOWN"
     speed: "Unknown-speed"
-    untagged_vlan_id: ""
+    untagged_vlan_id: "1"
     vlan_native: "1"
     vlan_passing: []
     vlan_permitted: []

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_stp-down_jumbo.raw
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_stp-down_jumbo.raw
@@ -1,0 +1,84 @@
+ GigabitEthernet12/0/17 current state: DOWN ( Administratively )
+ IP Packet Frame Type: PKTFMT_ETHNT_2, Hardware Address: 3822-d629-5e21
+ Description: GigabitEthernet12/0/17 Interface
+ Loopback is not set
+ Media type is twisted pair
+ Port hardware type is  1000_BASE_T
+ Unknown-speed mode, unknown-duplex mode
+ Link speed type is autonegotiation, link duplex type is autonegotiation
+ Flow-control is not enabled
+ The Maximum Frame Length is 1518
+ Broadcast MAX-ratio: 100%
+ Unicast MAX-ratio: 100%
+ Multicast MAX-ratio: 100%
+ Forbid jumbo frame to pass
+ PVID: 200
+ Mdi type: auto
+ Link delay is 0(sec)
+ Port link-type: access
+  Tagged   VLAN ID : none
+  Untagged VLAN ID : 200
+ Port priority: 0
+ Last clearing of counters:  23:17:06 Sun 03/07/2021
+ Peak value of input: 51839 bytes/sec, at 2022-05-06 09:37:18
+ Peak value of output: 65267 bytes/sec, at 2022-04-29 01:23:12
+ Last 300 seconds input:  0 packets/sec 0 bytes/sec -%
+ Last 300 seconds output:  0 packets/sec 0 bytes/sec -%
+ Input (total):  15657716 packets, 2077724863 bytes
+         13292312 unicasts, 67542 broadcasts, 2297862 multicasts, 0 pauses
+ Input (normal):  15657716 packets, - bytes
+         13292312 unicasts, 67542 broadcasts, 2297862 multicasts, 0 pauses
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, - overruns, 0 aborts
+         - ignored, - parity errors
+ Output (total): 224919997 packets, 23685575500 bytes
+         22486252 unicasts, 126451753 broadcasts, 75981992 multicasts, 0 pauses
+ Output (normal): 224919997 packets, - bytes
+         22486252 unicasts, 126451753 broadcasts, 75981992 multicasts, 0 pauses
+ Output: 0 output errors, - underruns, - buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, - no carrier
+
+GigabitEthernet11/0/17
+Current state: STP DOWN
+Line protocol state: DOWN
+IP packet frame type: Ethernet II, hardware address: ec9b-8baa-f45e
+Description: Server Mgmt Port
+Bandwidth: 1000000 kbps
+Loopback is not set
+Media type is twisted pair
+Port hardware type is 1000_BASE_T
+Unknown-speed mode, unknown-duplex mode
+Link speed type is autonegotiation, link duplex type is autonegotiation
+Flow-control is not enabled
+Maximum frame length: 1536
+Forbid jumbo frames to pass
+Broadcast max-ratio: 100%
+Multicast max-ratio: 100%
+Unicast max-ratio: 100%
+PVID: 231
+MDI type: automdix
+Port link-type: Access
+ Tagged VLANs:   None
+ Untagged VLANs: 231
+Port priority: 0
+Last link flapping: 61 weeks 6 days 20 hours 43 minutes
+Last clearing of counters: Never
+ Peak input rate: 2 bytes/sec, at 2024-07-22 20:46:58 
+ Peak output rate: 5 bytes/sec, at 2024-07-22 20:46:58 
+ Last 300 second input: 0 packets/sec 0 bytes/sec -%
+ Last 300 second output: 0 packets/sec 0 bytes/sec -%
+ Input (total):  3 packets, 773 bytes
+         1 unicasts, 0 broadcasts, 2 multicasts, 0 pauses
+ Input (normal):  3 packets, - bytes
+         1 unicasts, 0 broadcasts, 2 multicasts, 0 pauses
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, - overruns, 0 aborts
+         - ignored, - parity errors
+ Output (total): 7 packets, 1674 bytes
+         4 unicasts, 0 broadcasts, 3 multicasts, 0 pauses
+ Output (normal): 7 packets, - bytes
+         4 unicasts, 0 broadcasts, 3 multicasts, 0 pauses
+ Output: 0 output errors, - underruns, - buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, - no carrier

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_stp-down_jumbo.yml
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_stp-down_jumbo.yml
@@ -1,0 +1,36 @@
+---
+parsed_sample:
+  - bandwidth: ""
+    description: "GigabitEthernet12/0/17 Interface"
+    duplex: "unknown-duplex"
+    hw_address:
+      - "3822-d629-5e21"
+    interface: "GigabitEthernet12/0/17"
+    ip_address: []
+    l2mtu: "1518"
+    line_status: "DOWN"
+    mtu: ""
+    port_link_type: "access"
+    protocol_status: ""
+    speed: "Unknown-speed"
+    untagged_vlan_id: "200"
+    vlan_native: "200"
+    vlan_passing: []
+    vlan_permitted: []
+  - bandwidth: "1000000 kbps"
+    description: "Server Mgmt Port"
+    duplex: "unknown-duplex"
+    hw_address:
+      - "ec9b-8baa-f45e"
+    interface: "GigabitEthernet11/0/17"
+    ip_address: []
+    l2mtu: "1536"
+    line_status: "STP DOWN"
+    mtu: ""
+    port_link_type: "Access"
+    protocol_status: "DOWN"
+    speed: "Unknown-speed"
+    untagged_vlan_id: "231"
+    vlan_native: "231"
+    vlan_passing: []
+    vlan_permitted: []

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_tagged-vlan-none.raw
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_tagged-vlan-none.raw
@@ -1,0 +1,41 @@
+FortyGigE7/0/49
+Current state: DOWN
+Line protocol state: DOWN
+IP Packet Frame Type: PKTFMT_ETHNT_2, Hardware Address: bcea-fa12-b487
+Description: FortyGigE7/0/49 Interface
+Bandwidth: 40000000kbps
+Loopback is not set
+Media type is not sure, Port hardware type is no connector
+Unknown-speed mode, unknown-duplex mode
+Link speed type is autonegotiation, link duplex type is autonegotiation
+Flow-control is not enabled
+The Maximum Frame Length is 10000
+Allow jumbo frame to pass
+Broadcast MAX-ratio: 100%
+Multicast MAX-ratio: 100%
+Unicast MAX-ratio: 100%
+PVID: 1
+Mdi type: automdix
+Port link-type: access
+ Tagged Vlan:   none
+ UnTagged Vlan: 1
+Port priority: 0
+Last clearing of counters: Never
+ Peak value of input: 0 bytes/sec, at 2010-12-31 19:01:18 
+ Peak value of output: 0 bytes/sec, at 2010-12-31 19:01:18 
+ Last 300 seconds input:  0 packets/sec 0 bytes/sec -%
+ Last 300 seconds output:  0 packets/sec 0 bytes/sec -%
+ Input (total):  0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Input (normal):  0 packets, - bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Input:  0 input errors, 0 runts, 0 giants, 0 throttles
+         0 CRC, 0 frame, - overruns, 0 aborts
+         - ignored, - parity errors
+ Output (total): 0 packets, 0 bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Output (normal): 0 packets, - bytes
+         0 unicasts, 0 broadcasts, 0 multicasts, 0 pauses
+ Output: 0 output errors, - underruns, - buffer failures
+         0 aborts, 0 deferred, 0 collisions, 0 late collisions
+         0 lost carrier, - no carrier

--- a/tests/hp_comware/display_interface/hp_comware_display_interface_tagged-vlan-none.yml
+++ b/tests/hp_comware/display_interface/hp_comware_display_interface_tagged-vlan-none.yml
@@ -1,0 +1,19 @@
+---
+parsed_sample:
+  - bandwidth: "40000000kbps"
+    description: "FortyGigE7/0/49 Interface"
+    duplex: "unknown-duplex"
+    hw_address:
+      - "bcea-fa12-b487"
+    interface: "FortyGigE7/0/49"
+    ip_address: []
+    l2mtu: "10000"
+    line_status: "DOWN"
+    mtu: ""
+    port_link_type: "access"
+    protocol_status: "DOWN"
+    speed: "Unknown-speed"
+    untagged_vlan_id: "1"
+    vlan_native: "1"
+    vlan_passing: []
+    vlan_permitted: []


### PR DESCRIPTION
Ran textfsm template through our inventory of comware5/comware7 devices, modified the template to account for the following issues:

1) Updated LINE_STATUS capture group to include 'STP DOWN' state 
2) updated to account for optional 's' in 'forbid jumbo frames'
 3) Updated to account for DHCP-Allocated address
4) Updated to account for Untagged Vlans
5) Other modification to account for lines that are in the output

ran cli.py to update test cases to ensure backward capability is maintained.