### PR TITLE
Modify Comware disp ip int for DHCP assigned IP

### DIFF
--- a/ntc_templates/templates/hp_comware_display_ip_interface.textfsm
+++ b/ntc_templates/templates/hp_comware_display_ip_interface.textfsm
@@ -15,7 +15,7 @@ Interface
   ^\S+\s+current\s+state -> Continue.Record
   ^${INTERFACE}\s+current\s+state\s*:\s*${LINE_STATUS}
   ^Line\s+protocol\s+current\s+state\s*:\s*${PROTOCOL_STATUS}
-  ^Internet\s+Address\s+is\s+${IP_ADDRESS}\s+(Primary|Sub|CELLULAR-Allocated)
+  ^Internet\s+Address\s+is\s+${IP_ADDRESS}\s+(Primary|Sub|CELLULAR-Allocated|DHCP-[Aa]llocated)
   ^Broadcast\s+address\s*:\s*\S+
   ^The\s+Maximum\s+Transmit\s+Unit\s*:\s*${MTU}\s+bytes
   ^Policy\s+routing\s+is\s+enabled,\s+using\s+route\s+map\s+${ROUTE_MAP}

--- a/tests/hp_comware/display_ip_interface/hp_comware_display_ip_interface_dhcp.raw
+++ b/tests/hp_comware/display_ip_interface/hp_comware_display_ip_interface_dhcp.raw
@@ -1,0 +1,25 @@
+Vlan-interface1 current state: UP
+Line protocol current state: UP
+Internet Address is 11.12.13.14/24 DHCP-Allocated
+Broadcast address: 33.44.55.255
+The Maximum Transmit Unit: 1500 bytes
+input packets : 33792574, bytes : 1522224875, multicasts : 9702362
+output packets : 21273396, bytes : 330739408, multicasts : 0
+TTL invalid packet number:         0
+ICMP packet input number:     632945
+  Echo reply:                      5
+  Unreachable:                 40608
+  Source quench:                   0
+  Routing redirect:                0
+  Echo request:               590845
+  Router advert:                   0
+  Router solicit:                  0
+  Time exceed:                     0
+  IP header bad:                   0
+  Timestamp request:             496
+  Timestamp reply:                 0
+  Information request:             0
+  Information reply:               0
+  Netmask request:               496
+  Netmask reply:                   0
+  Unknown type:                  495

--- a/tests/hp_comware/display_ip_interface/hp_comware_display_ip_interface_dhcp.yml
+++ b/tests/hp_comware/display_ip_interface/hp_comware_display_ip_interface_dhcp.yml
@@ -1,0 +1,9 @@
+---
+parsed_sample:
+  - interface: "Vlan-interface1"
+    ip_address:
+      - "11.12.13.14/24"
+    line_status: "UP"
+    mtu: "1500"
+    protocol_status: "UP"
+    route_map: ""


### PR DESCRIPTION
updated the template to account for IP address assigned via DHCP.

Test file added and cli.py script ran to run test sets to prove backward compatability