### PR TITLE
Add paloalto_panos show lacp aggregate-ethernet all

### DIFF
--- a/ntc_templates/templates/index
+++ b/ntc_templates/templates/index
@@ -949,6 +949,7 @@ oneaccess_oneos_ls.textfsm, .*, oneaccess_oneos, ls( -[lh][lh]? )?.*
 
 paloalto_panos_show_high-availability_path-monitoring.textfsm, .*, paloalto_panos, sh[[ow]] high[[-availability]] pa[[th-monitoring]]
 paloalto_panos_show_routing_protocol_bgp_summary.textfsm, .*, paloalto_panos, sh[[ow]] ro[[uting]] pr[[otocol]] b[[gp]] s[[ummary]]
+paloalto_panos_show_lacp_aggregate-ethernet_all.textfsm, .*, paloalto_panos, sh[[ow]] la[[cp]] ag[[gregate-ethernet]] all
 paloalto_panos_show_running_security-policy.textfsm, .*, paloalto_panos, sh[[ow]] runn[[ing]] security[[-policy]]
 paloalto_panos_show_high-availability_all.textfsm, .*, paloalto_panos, sh[[ow]] high[[-availability]] all
 paloalto_panos_test_security-policy-match.textfsm, .*, paloalto_panos, test security-policy-match.*

--- a/ntc_templates/templates/paloalto_panos_show_lacp_aggregate-ethernet_all.textfsm
+++ b/ntc_templates/templates/paloalto_panos_show_lacp_aggregate-ethernet_all.textfsm
@@ -1,0 +1,56 @@
+Value Required BUNDLE_NAME (\S+)
+Value List MEMBER_INTERFACE (\S+)
+Value List BUNDLED (yes|no)
+Value List RECEIVE_STATE (\S+)
+Value List MUX_STATE (\S+)
+Value List SELECTION_STATE (\S+)
+Value STATUS (\S+)
+Value MODE (\S+)
+Value RATE (\S+)
+Value MAX_PORT (\d+)
+Value FAST_FAILOVER (\S+)
+Value PRE_NEGOTIATION (\S+)
+Value LOCAL_SYSTEM_PRIORITY (\d+)
+Value LOCAL_SYSTEM_MAC (\S+)
+Value LOCAL_KEY (\d+)
+Value PARTNER_SYSTEM_PRIORITY (\d+)
+Value PARTNER_SYSTEM_MAC (\S+)
+Value PARTNER_KEY (\d+)
+
+Start
+  ^LACP\s*:\s*$$
+  ^\*+\s*$$
+  ^AE\s+group:\s+${BUNDLE_NAME}\s*$$ -> AeBlock
+  ^\s*$$
+  ^. -> Error
+
+AeBlock
+  ^Members:\s+Bndl\s+Rx\s+state\s+Mux\s+state\s+Sel\s+state\s*$$
+  ^\s+${MEMBER_INTERFACE}\s+${BUNDLED}\s+${RECEIVE_STATE}\s+${MUX_STATE}\s+${SELECTION_STATE}\s*$$
+  ^Status:\s+${STATUS}\s*$$
+  ^Mode:\s+${MODE}\s*$$
+  ^Rate:\s+${RATE}\s*$$
+  ^Max-port:\s+${MAX_PORT}\s*$$
+  ^Fast-failover:\s+${FAST_FAILOVER}\s*$$
+  ^Pre-negotiation:\s+${PRE_NEGOTIATION}\s*$$
+  ^Local:\s+System\s+Priority:\s+${LOCAL_SYSTEM_PRIORITY}\s*$$ -> Local
+  ^\s*$$
+  ^. -> Error
+
+Local
+  ^\s+System\s+MAC:\s+${LOCAL_SYSTEM_MAC}\s*$$
+  ^\s+Key:\s+${LOCAL_KEY}\s*$$
+  ^Partner:\s+System\s+Priority:\s+${PARTNER_SYSTEM_PRIORITY}\s*$$ -> Partner
+  ^\s*$$
+  ^. -> Error
+
+Partner
+  ^\s+System\s+MAC:\s+${PARTNER_SYSTEM_MAC}\s*$$
+  ^\s+Key:\s+${PARTNER_KEY}\s*$$ -> PostBlock
+  ^\s*$$
+  ^. -> Error
+
+PostBlock
+  ^\*+\s*$$ -> Record Start
+  ^\s*$$
+  ^.

--- a/tests/paloalto_panos/show_lacp_aggregate-ethernet_all/paloalto_panos_show_lacp_aggregate-ethernet_all.raw
+++ b/tests/paloalto_panos/show_lacp_aggregate-ethernet_all/paloalto_panos_show_lacp_aggregate-ethernet_all.raw
@@ -1,0 +1,66 @@
+**********************************************************************************
+AE group: ae1
+Members:                Bndl Rx state       Mux state  Sel state
+  ethernet1/19          yes  Current        Tx_Rx      Selected
+  ethernet1/20          yes  Current        Tx_Rx      Selected
+Status:           Enabled
+Mode:             Active
+Rate:             Slow
+Max-port:         8
+Fast-failover:    Disabled
+Pre-negotiation:  Enabled
+Local:            System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             64
+Partner:          System Priority: 65534
+                  System MAC:      0a:00:00:aa:bb:cc
+                  Key:             103
+Port State
+--------------------------------------------------------------------------------
+Interface                       Port
+                    Number Priority  Mode    Rate  Key      State
+--------------------------------------------------------------------------------
+ethernet1/19         34     32768    Active  Slow  64       0x3D
+Partner              3      1        Active  Slow  103      0x3D
+
+ethernet1/20         35     32768    Active  Slow  64       0x3D
+Partner              1003   1        Active  Slow  103      0x3D
+
+Port Counters
+--------------------------------------------------------------------------------
+Interface               LACPDUs         Marker      Marker Response       Error
+                    Sent     Recv     Sent Recv     Sent     Recv     Unknown  Illegal
+--------------------------------------------------------------------------------
+ethernet1/19         100      100      0    0        0        0        0        0
+ethernet1/20         100      100      0    0        0        0        0        0
+
+**********************************************************************************
+AE group: ae2
+Members:                Bndl Rx state       Mux state  Sel state
+  ethernet1/11          yes  Current        Tx_Rx      Selected
+Status:           Enabled
+Mode:             Active
+Rate:             Slow
+Max-port:         8
+Fast-failover:    Disabled
+Pre-negotiation:  Enabled
+Local:            System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             65
+Partner:          System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             67
+Port State
+--------------------------------------------------------------------------------
+Interface                       Port
+                    Number Priority  Mode    Rate  Key      State
+--------------------------------------------------------------------------------
+ethernet1/11         26     32768    Active  Slow  65       0x3D
+Partner              27     32768    Active  Slow  67       0x3D
+
+Port Counters
+--------------------------------------------------------------------------------
+Interface               LACPDUs         Marker      Marker Response       Error
+                    Sent     Recv     Sent Recv     Sent     Recv     Unknown  Illegal
+--------------------------------------------------------------------------------
+ethernet1/11         100      100      0    0        0        0        0        0

--- a/tests/paloalto_panos/show_lacp_aggregate-ethernet_all/paloalto_panos_show_lacp_aggregate-ethernet_all.yml
+++ b/tests/paloalto_panos/show_lacp_aggregate-ethernet_all/paloalto_panos_show_lacp_aggregate-ethernet_all.yml
@@ -1,0 +1,53 @@
+---
+parsed_sample:
+  - bundle_name: "ae1"
+    bundled:
+      - "yes"
+      - "yes"
+    fast_failover: "Disabled"
+    local_key: "64"
+    local_system_mac: "64:7c:e8:aa:bb:01"
+    local_system_priority: "32768"
+    max_port: "8"
+    member_interface:
+      - "ethernet1/19"
+      - "ethernet1/20"
+    mode: "Active"
+    mux_state:
+      - "Tx_Rx"
+      - "Tx_Rx"
+    partner_key: "103"
+    partner_system_mac: "0a:00:00:aa:bb:cc"
+    partner_system_priority: "65534"
+    pre_negotiation: "Enabled"
+    rate: "Slow"
+    receive_state:
+      - "Current"
+      - "Current"
+    selection_state:
+      - "Selected"
+      - "Selected"
+    status: "Enabled"
+  - bundle_name: "ae2"
+    bundled:
+      - "yes"
+    fast_failover: "Disabled"
+    local_key: "65"
+    local_system_mac: "64:7c:e8:aa:bb:01"
+    local_system_priority: "32768"
+    max_port: "8"
+    member_interface:
+      - "ethernet1/11"
+    mode: "Active"
+    mux_state:
+      - "Tx_Rx"
+    partner_key: "67"
+    partner_system_mac: "64:7c:e8:aa:bb:01"
+    partner_system_priority: "32768"
+    pre_negotiation: "Enabled"
+    rate: "Slow"
+    receive_state:
+      - "Current"
+    selection_state:
+      - "Selected"
+    status: "Enabled"

--- a/tests/paloalto_panos/show_lacp_aggregate-ethernet_all/paloalto_panos_show_lacp_aggregate-ethernet_all2.raw
+++ b/tests/paloalto_panos/show_lacp_aggregate-ethernet_all/paloalto_panos_show_lacp_aggregate-ethernet_all2.raw
@@ -1,0 +1,171 @@
+LACP:
+
+**********************************************************************************
+AE group: ae1
+Members:                Bndl Rx state       Mux state  Sel state
+  ethernet1/19          yes  Current        Tx_Rx      Selected
+  ethernet1/20          yes  Current        Tx_Rx      Selected
+Status:           Enabled
+Mode:             Active
+Rate:             Slow
+Max-port:         8
+Fast-failover:    Disabled
+Pre-negotiation:  Enabled
+Local:            System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             64
+Partner:          System Priority: 65534
+                  System MAC:      0a:00:00:aa:bb:cc
+                  Key:             103
+Port State
+--------------------------------------------------------------------------------
+Interface                       Port
+                    Number Priority  Mode    Rate  Key      State
+--------------------------------------------------------------------------------
+ethernet1/19         34     32768    Active  Slow  64       0x3D
+Partner              3      1        Active  Slow  103      0x3D
+
+ethernet1/20         35     32768    Active  Slow  64       0x3D
+Partner              1003   1        Active  Slow  103      0x3D
+
+Port Counters
+--------------------------------------------------------------------------------
+Interface               LACPDUs         Marker      Marker Response       Error
+                    Sent     Recv     Sent Recv     Sent     Recv     Unknown  Illegal
+--------------------------------------------------------------------------------
+ethernet1/19         584295   584296   0    0        0        0        0        0
+ethernet1/20         584295   584297   0    0        0        0        0        0
+
+**********************************************************************************
+AE group: ae2
+Members:                Bndl Rx state       Mux state  Sel state
+  ethernet1/11          yes  Current        Tx_Rx      Selected
+Status:           Enabled
+Mode:             Active
+Rate:             Slow
+Max-port:         8
+Fast-failover:    Disabled
+Pre-negotiation:  Enabled
+Local:            System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             65
+Partner:          System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             67
+Port State
+--------------------------------------------------------------------------------
+Interface                       Port
+                    Number Priority  Mode    Rate  Key      State
+--------------------------------------------------------------------------------
+ethernet1/11         26     32768    Active  Slow  65       0x3D
+Partner              27     32768    Active  Slow  67       0x3D
+
+Port Counters
+--------------------------------------------------------------------------------
+Interface               LACPDUs         Marker      Marker Response       Error
+                    Sent     Recv     Sent Recv     Sent     Recv     Unknown  Illegal
+--------------------------------------------------------------------------------
+ethernet1/11         584290   584286   0    0        0        0        0        0
+
+**********************************************************************************
+AE group: ae4
+Members:                Bndl Rx state       Mux state  Sel state
+  ethernet1/12          yes  Current        Tx_Rx      Selected
+Status:           Enabled
+Mode:             Active
+Rate:             Slow
+Max-port:         8
+Fast-failover:    Disabled
+Pre-negotiation:  Enabled
+Local:            System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             67
+Partner:          System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             65
+Port State
+--------------------------------------------------------------------------------
+Interface                       Port
+                    Number Priority  Mode    Rate  Key      State
+--------------------------------------------------------------------------------
+ethernet1/12         27     32768    Active  Slow  67       0x3D
+Partner              26     32768    Active  Slow  65       0x3D
+
+Port Counters
+--------------------------------------------------------------------------------
+Interface               LACPDUs         Marker      Marker Response       Error
+                    Sent     Recv     Sent Recv     Sent     Recv     Unknown  Illegal
+--------------------------------------------------------------------------------
+ethernet1/12         584290   584286   0    0        0        0        0        0
+
+**********************************************************************************
+AE group: ae5
+Members:                Bndl Rx state       Mux state  Sel state
+  ethernet1/15          yes  Current        Tx_Rx      Selected
+  ethernet1/17          yes  Current        Tx_Rx      Selected
+Status:           Enabled
+Mode:             Active
+Rate:             Slow
+Max-port:         8
+Fast-failover:    Disabled
+Pre-negotiation:  Enabled
+Local:            System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             68
+Partner:          System Priority: 65534
+                  System MAC:      0a:00:00:aa:bb:cc
+                  Key:             101
+Port State
+--------------------------------------------------------------------------------
+Interface                       Port
+                    Number Priority  Mode    Rate  Key      State
+--------------------------------------------------------------------------------
+ethernet1/15         30     32768    Active  Slow  68       0x3D
+Partner              1001   1        Active  Slow  101      0x3D
+
+ethernet1/17         32     32768    Active  Slow  68       0x3D
+Partner              1      1        Active  Slow  101      0x3D
+
+Port Counters
+--------------------------------------------------------------------------------
+Interface               LACPDUs         Marker      Marker Response       Error
+                    Sent     Recv     Sent Recv     Sent     Recv     Unknown  Illegal
+--------------------------------------------------------------------------------
+ethernet1/15         584299   584270   0    0        0        0        0        0
+ethernet1/17         584300   584271   0    0        0        0        0        0
+
+**********************************************************************************
+AE group: ae6
+Members:                Bndl Rx state       Mux state  Sel state
+  ethernet1/21          yes  Current        Tx_Rx      Selected
+  ethernet1/22          yes  Current        Tx_Rx      Selected
+Status:           Enabled
+Mode:             Active
+Rate:             Slow
+Max-port:         8
+Fast-failover:    Disabled
+Pre-negotiation:  Enabled
+Local:            System Priority: 32768
+                  System MAC:      64:7c:e8:aa:bb:01
+                  Key:             69
+Partner:          System Priority: 65534
+                  System MAC:      0a:00:00:aa:bb:cc
+                  Key:             102
+Port State
+--------------------------------------------------------------------------------
+Interface                       Port
+                    Number Priority  Mode    Rate  Key      State
+--------------------------------------------------------------------------------
+ethernet1/21         36     32768    Active  Slow  69       0x3D
+Partner              2      1        Active  Slow  102      0x3D
+
+ethernet1/22         37     32768    Active  Slow  69       0x3D
+Partner              1002   1        Active  Slow  102      0x3D
+
+Port Counters
+--------------------------------------------------------------------------------
+Interface               LACPDUs         Marker      Marker Response       Error
+                    Sent     Recv     Sent Recv     Sent     Recv     Unknown  Illegal
+--------------------------------------------------------------------------------
+ethernet1/21         584296   584297   0    0        0        0        0        0
+ethernet1/22         584296   584297   0    0        0        0        0        0

--- a/tests/paloalto_panos/show_lacp_aggregate-ethernet_all/paloalto_panos_show_lacp_aggregate-ethernet_all2.yml
+++ b/tests/paloalto_panos/show_lacp_aggregate-ethernet_all/paloalto_panos_show_lacp_aggregate-ethernet_all2.yml
@@ -1,0 +1,132 @@
+---
+parsed_sample:
+  - bundle_name: "ae1"
+    bundled:
+      - "yes"
+      - "yes"
+    fast_failover: "Disabled"
+    local_key: "64"
+    local_system_mac: "64:7c:e8:aa:bb:01"
+    local_system_priority: "32768"
+    max_port: "8"
+    member_interface:
+      - "ethernet1/19"
+      - "ethernet1/20"
+    mode: "Active"
+    mux_state:
+      - "Tx_Rx"
+      - "Tx_Rx"
+    partner_key: "103"
+    partner_system_mac: "0a:00:00:aa:bb:cc"
+    partner_system_priority: "65534"
+    pre_negotiation: "Enabled"
+    rate: "Slow"
+    receive_state:
+      - "Current"
+      - "Current"
+    selection_state:
+      - "Selected"
+      - "Selected"
+    status: "Enabled"
+  - bundle_name: "ae2"
+    bundled:
+      - "yes"
+    fast_failover: "Disabled"
+    local_key: "65"
+    local_system_mac: "64:7c:e8:aa:bb:01"
+    local_system_priority: "32768"
+    max_port: "8"
+    member_interface:
+      - "ethernet1/11"
+    mode: "Active"
+    mux_state:
+      - "Tx_Rx"
+    partner_key: "67"
+    partner_system_mac: "64:7c:e8:aa:bb:01"
+    partner_system_priority: "32768"
+    pre_negotiation: "Enabled"
+    rate: "Slow"
+    receive_state:
+      - "Current"
+    selection_state:
+      - "Selected"
+    status: "Enabled"
+  - bundle_name: "ae4"
+    bundled:
+      - "yes"
+    fast_failover: "Disabled"
+    local_key: "67"
+    local_system_mac: "64:7c:e8:aa:bb:01"
+    local_system_priority: "32768"
+    max_port: "8"
+    member_interface:
+      - "ethernet1/12"
+    mode: "Active"
+    mux_state:
+      - "Tx_Rx"
+    partner_key: "65"
+    partner_system_mac: "64:7c:e8:aa:bb:01"
+    partner_system_priority: "32768"
+    pre_negotiation: "Enabled"
+    rate: "Slow"
+    receive_state:
+      - "Current"
+    selection_state:
+      - "Selected"
+    status: "Enabled"
+  - bundle_name: "ae5"
+    bundled:
+      - "yes"
+      - "yes"
+    fast_failover: "Disabled"
+    local_key: "68"
+    local_system_mac: "64:7c:e8:aa:bb:01"
+    local_system_priority: "32768"
+    max_port: "8"
+    member_interface:
+      - "ethernet1/15"
+      - "ethernet1/17"
+    mode: "Active"
+    mux_state:
+      - "Tx_Rx"
+      - "Tx_Rx"
+    partner_key: "101"
+    partner_system_mac: "0a:00:00:aa:bb:cc"
+    partner_system_priority: "65534"
+    pre_negotiation: "Enabled"
+    rate: "Slow"
+    receive_state:
+      - "Current"
+      - "Current"
+    selection_state:
+      - "Selected"
+      - "Selected"
+    status: "Enabled"
+  - bundle_name: "ae6"
+    bundled:
+      - "yes"
+      - "yes"
+    fast_failover: "Disabled"
+    local_key: "69"
+    local_system_mac: "64:7c:e8:aa:bb:01"
+    local_system_priority: "32768"
+    max_port: "8"
+    member_interface:
+      - "ethernet1/21"
+      - "ethernet1/22"
+    mode: "Active"
+    mux_state:
+      - "Tx_Rx"
+      - "Tx_Rx"
+    partner_key: "102"
+    partner_system_mac: "0a:00:00:aa:bb:cc"
+    partner_system_priority: "65534"
+    pre_negotiation: "Enabled"
+    rate: "Slow"
+    receive_state:
+      - "Current"
+      - "Current"
+    selection_state:
+      - "Selected"
+      - "Selected"
+    status: "Enabled"


### PR DESCRIPTION
##### ISSUE TYPE
 - New Template Pull Request

##### COMPONENT
paloalto_panos, `show lacp aggregate-ethernet all`

##### SUMMARY
Adds a new template for the PAN-OS
`show lacp aggregate-ethernet all` command. Captures one record
per AE (aggregate-ethernet) group, with per-member fields collected
into parallel `Value List` arrays — matching the convention used by
`juniper_junos_show_lacp_interfaces`.

##### CAPTURE GROUPS
Per-AE-group fields: `BUNDLE_NAME` (Required), `STATUS`, `MODE`,
`RATE`, `MAX_PORT`, `FAST_FAILOVER`, `PRE_NEGOTIATION`,
`LOCAL_SYSTEM_PRIORITY`, `LOCAL_SYSTEM_MAC`, `LOCAL_KEY`,
`PARTNER_SYSTEM_PRIORITY`, `PARTNER_SYSTEM_MAC`, `PARTNER_KEY`.

Per-member fields (`Value List`, parallel-indexed):
`MEMBER_INTERFACE`, `BUNDLED`, `RECEIVE_STATE`, `MUX_STATE`,
`SELECTION_STATE`.

##### IMPLEMENTATION NOTES
The template uses a 5-state machine (`Start` → `AeBlock` → `Local` →
`Partner` → `PostBlock` → `Start`) driven off the `*****` separator
PAN-OS prints between AE-group blocks.

The `PostBlock` state silently consumes the per-AE Port State and
Port Counters tables (which we don't capture; they're recoverable
via more specific commands) until the trailing `*****` separator
fires `-> Record Start`.

The `Start` state includes a `^LACP\s*:\s*$$` swallow rule for the
optional `LACP:` header that some firmware revisions print before
the first AE block.

##### CROSS-VENDOR ALIGNMENT
Field names follow `juniper_junos_show_lacp_interfaces`:
- `BUNDLE_NAME` (juniper / cisco — the LAG / port-channel ID).
- `MEMBER_INTERFACE`, `RECEIVE_STATE`, `MUX_STATE` (juniper).

PAN-OS-specific fields kept under PA names: `SELECTION_STATE`
(PA's `Sel state` column) and `BUNDLED` (PA's `Bndl` column).

##### TEST DATA
Two fixtures:
- `paloalto_panos_show_lacp_aggregate-ethernet_all.{raw,yml}` —
  2 AE-groups covering foreign-partner and same-chassis-partner
  scenarios.
- `paloalto_panos_show_lacp_aggregate-ethernet_all2.{raw,yml}` —
  5 AE-groups (`ae1`, `ae2`, `ae4`, `ae5`, `ae6`) including the
  leading `LACP:` header line. Mix of single-member / multi-member,
  foreign-partner / same-chassis-partner.

Index entry inserted within the `paloalto_panos` block at the
length-40 position (after `show_routing_protocol_bgp_summary`
length 41 and before `show_running_security-policy` length 36).