### PR TITLE
Update textfsm web tools in faq docs

### DIFF
--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -9,7 +9,7 @@ You can follow the local development procedures, but for your convenience here a
 * [textfsm.nornir.tech](https://textfsm.nornir.tech/) - An online textfsm editor.
 * [Packet Coders TextFSM Parser](https://tools.packetcoders.io/textfsm-parser/) - An online textfsm editor by Packet Coders.
 * [Slurp'it TextFSM Template Builder](https://textfsm.slurpit.io/) - An online AI-integrated textfsm editor by Slurp'it.
-   * [Overview page](https://slurpit.io/textfsm-template-builder/) which links to [code on GitLab](https://gitlab.com/slurpit.io/template_builder) for a self-hosted version.
+    * [Overview page](https://slurpit.io/textfsm-template-builder/) which links to [code on GitLab](https://gitlab.com/slurpit.io/template_builder) for a self-hosted version.
 
 ## Why is there a requirement to use `Error` in every template?
 

--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -7,6 +7,7 @@ From an outsider's view, some design choices, requirements, and testing procedur
 You can follow the local development procedures, but for your convenience here are included locations to test your template:
 
 * [textfsm.nornir.tech](https://textfsm.nornir.tech/) - An online textfsm editor.
+* [Packet Coders TextFSM Parser](https://tools.packetcoders.io/textfsm-parser/) - An online textfsm editor by Packet Coders.
 
 ## Why is there a requirement to use `Error` in every template?
 

--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -7,7 +7,6 @@ From an outsider's view, some design choices, requirements, and testing procedur
 You can follow the local development procedures, but for your convenience here are included locations to test your template:
 
 * [textfsm.nornir.tech](https://textfsm.nornir.tech/) - An online textfsm editor.
-* [Itential](https://template.itential.io/) - An online textfsm editor by Itential.
 
 ## Why is there a requirement to use `Error` in every template?
 

--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -8,6 +8,8 @@ You can follow the local development procedures, but for your convenience here a
 
 * [textfsm.nornir.tech](https://textfsm.nornir.tech/) - An online textfsm editor.
 * [Packet Coders TextFSM Parser](https://tools.packetcoders.io/textfsm-parser/) - An online textfsm editor by Packet Coders.
+* [Slurp'it TextFSM Template Builder](https://textfsm.slurpit.io/) - An online AI-integrated textfsm editor by Slurp'it.
+   * [Overview page](https://slurpit.io/textfsm-template-builder/) which links to [code on GitLab](https://gitlab.com/slurpit.io/template_builder) for a self-hosted version.
 
 ## Why is there a requirement to use `Error` in every template?
 


### PR DESCRIPTION
This is strictly a docs edit, no templates have been changed.

* Remove decommissioned Itential TextFSM editor from faq
* Add Packet Coders TextFSM parser in place of Itential's (in faq)
* Add Slurp'it TextFSM template builder to faq

I stumbled on https://github.com/nornir-automation/nornir/issues/988 where the Nornir project discusses their website domain renewal. The nornir thread preempted me to check the ntc-templates project docs and locate a link to https://textfsm.nornir.tech

As long as nornir.tech remains registered to the Nornir project, we should leave the link to that web tool. :heart:
(Thanks goes out to @tbotnz for maintaining the tool. :slightly_smiling_face:)