### PR TITLE
Add ACI mode support to cisco_nxos show version

### DIFF
--- a/ntc_templates/templates/cisco_nxos_show_version.textfsm
+++ b/ntc_templates/templates/cisco_nxos_show_version.textfsm
@@ -13,6 +13,8 @@ Start
   ^\s+(NXOS|kickstart)\s+image\s+file\s+is:\s+${BOOT_IMAGE}\s*$$
   ^\s+cisco\s+${PLATFORM}\s+[cC]hassis
   ^\s+cisco\s+Nexus\d+\s+${PLATFORM}
+  # N9K ACI-mode
+  ^\s+cisco\s+N\d+K-${PLATFORM}\s+\("supervisor"\)
   # Cisco N5K platform
   ^\s+cisco\s+Nexus\s+${PLATFORM}\s+[cC]hassis
   ^\s+Device\s+name:\s+${HOSTNAME}$$

--- a/ntc_templates/templates/cisco_nxos_show_version.textfsm
+++ b/ntc_templates/templates/cisco_nxos_show_version.textfsm
@@ -9,7 +9,7 @@ Value SERIAL (\w+)
 
 Start
   ^\s+(BIOS:\s+version)\s+${BIOS}\s*$$
-  ^\s+(NXOS: version|system:\s+version)\s+${OS}\s*$$
+  ^\s+(NXOS:\s+version|system:\s+version)\s+${OS}\s*$$
   ^\s+(NXOS|kickstart)\s+image\s+file\s+is:\s+${BOOT_IMAGE}\s*$$
   ^\s+cisco\s+${PLATFORM}\s+[cC]hassis
   ^\s+cisco\s+Nexus\d+\s+${PLATFORM}

--- a/ntc_templates/templates/cisco_nxos_show_version.textfsm
+++ b/ntc_templates/templates/cisco_nxos_show_version.textfsm
@@ -21,3 +21,41 @@ Start
   ^\s*Processor\s[Bb]oard\sID\s+${SERIAL}$$
   ^Kernel\s+uptime\s+is\s+${UPTIME}
   ^\s+Reason:\s${LAST_REBOOT_REASON} -> Record
+  #
+  # Uncaptured lines
+  ^Cisco\s+Nexus\s+Operating\s+System
+  ^TAC\s+support:
+  ^Documents:
+  ^Copyright
+  ^All\s+rights\s+reserved
+  ^The\s+copyrights
+  ^(owned\s+by\s+)?other\s+third\s+parties
+  ^licenses,\s+such
+  ^such\s+license
+  ^otherwise\s+stated
+  ^limited\s+to
+  ^(license\.\s+)?Certain\s+components
+  ^(the\s+)?(GNU|Lesser)\s+General
+  ^A\s+copy
+  ^Some\s+parts
+  ^License
+  ^http://
+  ^Software$$
+  ^\s+(Power\s+Sequencer|((QSFP|CXP)\s+)?Microcontroller)\s+Firmware:
+  ^\s+Module\s+(\d+:|not\s+detected)
+  ^\s+(loader|power-seq|((SFP\s+)?uC)):
+  ^\s+(kickstart|system)(:|\s+(image|compile))
+  ^\s+PE:
+  ^\s+Host\s+NXOS:
+  ^\s+(BIOS|NXOS)\s+compile
+  ^\s+NXOS\s+boot\s+mode
+  ^Hardware$$
+  ^\s+Intel
+  ^\s+bootflash:
+  ^Last\s+reset
+  ^\s+System\s+version
+  ^\s+Service:
+  ^plugin$$
+  ^\s+\S+\s+Plugin
+  ^Active\s+Package
+  ^. -> Error

--- a/tests/cisco_nxos/show_version/cisco_nxos_show_version_aci.raw
+++ b/tests/cisco_nxos/show_version/cisco_nxos_show_version_aci.raw
@@ -1,0 +1,42 @@
+Cisco Nexus Operating System (NX-OS) Software
+TAC support: http://www.cisco.com/tac
+Documents: http://www.cisco.com/en/US/products/ps9372/tsd_products_support_series_home.html
+Copyright (c) 2002-2014, Cisco Systems, Inc. All rights reserved.
+The copyrights to certain works contained in this software are
+owned by other third parties and used and distributed under
+license. Certain components of this software are licensed under
+the GNU General Public License (GPL) version 2.0 or the GNU
+Lesser General Public License (LGPL) Version 2.1. A copy of each
+such license is available at
+http://www.opensource.org/licenses/gpl-2.0.php and
+http://www.opensource.org/licenses/lgpl-2.1.php
+
+Software
+  BIOS:      version 05.53
+  kickstart: version 16.0(9e) [build 16.0(9e)]
+  system:    version 16.0(9e) [build 16.0(9e)]
+  PE:        version 6.0(9e)
+  BIOS compile time:       01/22/2025
+  kickstart image file is: /bootflash/aci-n9000-dk9.16.0.9e.bin
+  kickstart compile time:  08/05/2025 12:57:46 [08/05/2025 12:57:46]
+  system image file is:    /bootflash/auto-s
+  system compile time:     08/05/2025 12:57:46 [08/05/2025 12:57:46]
+
+
+Hardware
+  cisco N9K-C93180LC-EX ("supervisor")
+   Intel(R) Xeon(R) CPU D-1526 @ 1.80GHz with 24419328 kB of memory.
+  Processor Board ID XYZ12345678
+
+  Device name: leaf1
+  bootflash:    62522368 kB
+
+Kernel uptime is 79 day(s), 19 hour(s), 33 minute(s), 28 second(s)
+
+Last reset at 484000 usecs after Sat Apr 11 20:02:15 2026 CDT
+  Reason: reset-by-installer
+  System version: 16.0(7e)
+  Service: Upgrade
+
+plugin
+  Core Plugin, Ethernet Plugin

--- a/tests/cisco_nxos/show_version/cisco_nxos_show_version_aci.yml
+++ b/tests/cisco_nxos/show_version/cisco_nxos_show_version_aci.yml
@@ -5,6 +5,6 @@ parsed_sample:
     hostname: "leaf1"
     last_reboot_reason: "reset-by-installer"
     os: "16.0(9e) [build 16.0(9e)]"
-    platform: "EX"
+    platform: "C93180LC-EX"
     serial: "XYZ12345678"
     uptime: "79 day(s), 19 hour(s), 33 minute(s), 28 second(s)"

--- a/tests/cisco_nxos/show_version/cisco_nxos_show_version_aci.yml
+++ b/tests/cisco_nxos/show_version/cisco_nxos_show_version_aci.yml
@@ -1,0 +1,10 @@
+---
+parsed_sample:
+  - bios: "05.53"
+    boot_image: "/bootflash/aci-n9000-dk9.16.0.9e.bin"
+    hostname: "leaf1"
+    last_reboot_reason: "reset-by-installer"
+    os: "16.0(9e) [build 16.0(9e)]"
+    platform: "EX"
+    serial: "XYZ12345678"
+    uptime: "79 day(s), 19 hour(s), 33 minute(s), 28 second(s)"


### PR DESCRIPTION
resolves #2326 

* Add Error directive to cisco_nxos show version template
* Add ACI-mode support for capturing the platform
* (minor) Swap a literal space for a regex (nxos version line)