### PR TITLE
Add AB Stratix support to cisco_ios sh ver

### DIFF
--- a/ntc_templates/templates/cisco_ios_show_version.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_version.textfsm
@@ -32,7 +32,7 @@ Start
   ^[Ss]ystem\s+image\s+file\s+is\s+"(.*?):${RUNNING_IMAGE}"
   ^(?:[Ll]ast\s+reload\s+reason:|System\s+returned\s+to\s+ROM\s+by)\s+${RELOAD_REASON}\s*$$
   ^[Pp]rocessor\s+board\s+ID\s+${SERIAL}
-  ^[Cc]isco\s+${HARDWARE}\s+\(.+\).+
+  ^([Cc]isco|Allen-Bradley)\s+${HARDWARE}\s+\(.+\).+
   ^[Cc]onfiguration\s+register\s+is\s+${CONFIG_REGISTER}
   ^Base\s+[Ee]thernet\s+MAC\s+[Aa]ddress\s+:\s+${MAC_ADDRESS}
   ^System\s+restarted\s+at\s+${RESTARTED}$$
@@ -58,13 +58,13 @@ Start
   ^compliance\s+with
   ^(\S+\s+)?to\s+comply
   ^A\s+summary
-  ^http://
+  ^\(?http://
   ^If\s+you
   ^export@cisco\.com
   ^\S+\s+CPU\s+at
   ^Last\s+reset
-  ^\d+(\s+\S+)?\s+\S+\s+Ethernet
-  ^\S+\s+bytes\s+of\s+(non-volatile|physical|Crash\s+Files|Flash|WebUI|eUSB)
+  ^\d+.+\s+interface
+  ^\S+\s+bytes\s+of.*(non-volatile|physical|Crash\s+Files|Flash|Bootflash|WebUI|webui|eUSB|crashinfo|SD\s+Flash|ATA|Dummy)
   ^licensed\s+under
   ^software(\s+code|\.)
   ^with\s+ABSOLUTELY
@@ -78,11 +78,17 @@ Start
   ^Current\s+Type
   # license level with dash, ex: network-advantage
   ^[a-z]+-[a-z]+\s+\S+\s+\S+
+  ^None\s+Subscription
   ^Smart\s+Licensing\s+Status
   ^Motherboard\s+(Assembly|Serial|Revision)\s+Number
   ^Model(\s+Revision)?\s+Number
   ^System\s+Serial\s+Number
-  ^(Next\s+reload\s+)?[Ll]icense\s+(Level|Type):
+  ^(Next\s+reload\s+(AIR)?|AIR)?\s*[Ll]icense\s+(Level|Type):
+  ^Top\s+Assembly\s+(Part|Revision)\s+Number
+  ^System\s+FPGA\s+version
+  ^CIP\s+Serial\s+Number
+  ^SKU\s+Brand\s+Name
+  ^DRAM\s+configuration
   ^\s+$$
   ^. -> Error
 

--- a/ntc_templates/templates/cisco_ios_show_version.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_version.textfsm
@@ -36,9 +36,8 @@ Start
   ^[Cc]onfiguration\s+register\s+is\s+${CONFIG_REGISTER}
   ^Base\s+[Ee]thernet\s+MAC\s+[Aa]ddress\s+:\s+${MAC_ADDRESS}
   ^System\s+restarted\s+at\s+${RESTARTED}$$
-  ^Switch\s+Port -> Stack
+  ^Switch\s+(Port|\d+) -> Stack
   # Capture time-stamp if vty line has command time-stamping turned on
-  ^Switch\s\d+ -> Stack
   ^Load\s+for\s+
   ^Time\s+source\s+is
 

--- a/ntc_templates/templates/cisco_ios_show_version.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_version.textfsm
@@ -42,7 +42,6 @@ Start
   ^Load\s+for\s+
   ^Time\s+source\s+is
 
-
 Stack
   ^[Ss]ystem\s+[Ss]erial\s+[Nn]umber\s+:\s+${SERIAL}
   ^[Mm]odel\s+[Nn]umber\s+:\s+${HARDWARE}\s*

--- a/ntc_templates/templates/cisco_ios_show_version.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_version.textfsm
@@ -47,3 +47,9 @@ Stack
   ^[Mm]odel\s+[Nn]umber\s+:\s+${HARDWARE}\s*
   ^[Cc]onfiguration\s+register\s+is\s+${CONFIG_REGISTER}
   ^Base [Ee]thernet MAC [Aa]ddress\s+:\s+${MAC_ADDRESS}
+  ^---+
+  ^\*?\s+\d\s+\d+\s+\S+
+  ^Switch\s+(\d+|uptime)
+  ^Motherboard\s+(Assembly|Serial|Revision)\s+Number
+  ^Model\s+Revision\s+Number
+  ^. -> Error

--- a/ntc_templates/templates/cisco_ios_show_version.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_version.textfsm
@@ -29,8 +29,8 @@ Start
   ^.*\s+uptime\s+is.*\s+${UPTIME_DAYS}\sday -> Continue
   ^.*\s+uptime\s+is.*\s+${UPTIME_HOURS}\shour -> Continue
   ^.*\s+uptime\s+is.*\s+${UPTIME_MINUTES}\sminute
-  ^[sS]ystem\s+image\s+file\s+is\s+"(.*?):${RUNNING_IMAGE}"
-  ^(?:[lL]ast\s+reload\s+reason:|System\s+returned\s+to\s+ROM\s+by)\s+${RELOAD_REASON}\s*$$
+  ^[Ss]ystem\s+image\s+file\s+is\s+"(.*?):${RUNNING_IMAGE}"
+  ^(?:[Ll]ast\s+reload\s+reason:|System\s+returned\s+to\s+ROM\s+by)\s+${RELOAD_REASON}\s*$$
   ^[Pp]rocessor\s+board\s+ID\s+${SERIAL}
   ^[Cc]isco\s+${HARDWARE}\s+\(.+\).+
   ^[Cc]onfiguration\s+register\s+is\s+${CONFIG_REGISTER}

--- a/ntc_templates/templates/cisco_ios_show_version.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_version.textfsm
@@ -40,6 +40,51 @@ Start
   # Capture time-stamp if vty line has command time-stamping turned on
   ^Load\s+for\s+
   ^Time\s+source\s+is
+  #
+  # Unmatched
+  ^.*(Software,|IOS XE)\s+Version:?\s+\S+
+  ^This\s+software
+  ^Technical\s+Support
+  ^.*Copyright
+  ^All\s+rights
+  ^Compiled
+  ^Image\s+text-base
+  ^\S+\s+Revision\s+\d+
+  ^This\s+product
+  ^States\s+and\s+local
+  ^use\.\s+Delivery
+  ^third-party
+  ^Importers
+  ^compliance\s+with
+  ^(\S+\s+)?to\s+comply
+  ^A\s+summary
+  ^http://
+  ^If\s+you
+  ^export@cisco\.com
+  ^\S+\s+CPU\s+at
+  ^Last\s+reset
+  ^\d+(\s+\S+)?\s+\S+\s+Ethernet
+  ^\S+\s+bytes\s+of\s+(non-volatile|physical|Crash\s+Files|Flash|WebUI|eUSB)
+  ^licensed\s+under
+  ^software(\s+code|\.)
+  ^with\s+ABSOLUTELY
+  ^GPL\s+code
+  ^documentation\s+or
+  ^or\s+the\s+applicable
+  ^BOOTLDR:
+  ^Uptime\s+for
+  ^Technology(\s+|-)[Pp]ackage
+  ^---+
+  ^Current\s+Type
+  # license level with dash, ex: network-advantage
+  ^[a-z]+-[a-z]+\s+\S+\s+\S+
+  ^Smart\s+Licensing\s+Status
+  ^Motherboard\s+(Assembly|Serial|Revision)\s+Number
+  ^Model(\s+Revision)?\s+Number
+  ^System\s+Serial\s+Number
+  ^(Next\s+reload\s+)?[Ll]icense\s+(Level|Type):
+  ^\s+$$
+  ^. -> Error
 
 Stack
   ^[Ss]ystem\s+[Ss]erial\s+[Nn]umber\s+:\s+${SERIAL}

--- a/ntc_templates/templates/cisco_ios_show_version.textfsm
+++ b/ntc_templates/templates/cisco_ios_show_version.textfsm
@@ -43,9 +43,9 @@ Start
 
 Stack
   ^[Ss]ystem\s+[Ss]erial\s+[Nn]umber\s+:\s+${SERIAL}
-  ^[Mm]odel\s+[Nn]umber\s+:\s+${HARDWARE}\s*
+  ^[Mm]odel\s+[Nn]umber\s+:\s+${HARDWARE}
   ^[Cc]onfiguration\s+register\s+is\s+${CONFIG_REGISTER}
-  ^Base [Ee]thernet MAC [Aa]ddress\s+:\s+${MAC_ADDRESS}
+  ^Base\s+[Ee]thernet\s+MAC\s+[Aa]ddress\s+:\s+${MAC_ADDRESS}
   ^---+
   ^\*?\s+\d\s+\d+\s+\S+
   ^Switch\s+(\d+|uptime)

--- a/tests/cisco_ios/show_version/cisco_ios_show_version_ab_stratix.raw
+++ b/tests/cisco_ios/show_version/cisco_ios_show_version_ab_stratix.raw
@@ -1,0 +1,81 @@
+Cisco IOS XE Software, Version 17.12.04
+Cisco IOS Software [Dublin], S5200 Switch Software (S5200-UNIVERSALK9-M), Version 17.12.4, RELEASE SOFTWARE (fc3)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2024 by Cisco Systems, Inc.
+Compiled Tue 23-Jul-24 10:25 by mcpre
+
+
+Cisco IOS-XE software, Copyright (c) 2005-2024 by cisco Systems, Inc.
+All rights reserved.  Certain components of Cisco IOS-XE software are
+licensed under the GNU General Public License ("GPL") Version 2.0.  The
+software code licensed under GPL Version 2.0 is free software that comes
+with ABSOLUTELY NO WARRANTY.  You can redistribute and/or modify such
+GPL code under the terms of GPL Version 2.0.  For more details, see the
+documentation or "License Notice" file accompanying the IOS-XE software,
+or the applicable URL provided on the flyer accompanying the IOS-XE
+software.
+
+
+ROM: IOS-XE ROMMON
+BOOTLDR: Version 0.2.5 [RELEASE SOFTWARE] crashkernel=64M
+PAS-IDF17-SW02 uptime is 2 weeks, 6 days, 17 hours, 32 minutes
+Uptime for this control processor is 2 weeks, 6 days, 17 hours, 33 minutes
+System returned to ROM by Swapdrive Restore
+System image file is "flash:packages.conf"
+Last reload reason: Swapdrive Restore
+
+
+
+This product contains cryptographic features and is subject to United
+States and local country laws governing import, export, transfer and
+use. Delivery of Cisco cryptographic products does not imply
+third-party authority to import, export, distribute or use encryption.
+Importers, exporters, distributors and users are responsible for
+compliance with U.S. and local country laws. By using this product you
+agree to comply with applicable laws and regulations. If you are unable
+to comply with U.S. and local laws, return this product immediately.
+
+A summary of U.S. laws governing Cisco cryptographic products may be found at:
+http://www.cisco.com/wwl/export/crypto/tool/stqrg.html
+
+If you require further assistance please contact us by sending email to
+export@cisco.com.
+
+
+Technology Package License Information:
+
+------------------------------------------------------------------------------
+Technology-package                                     Technology-package
+Current                        Type                       Next reboot
+------------------------------------------------------------------------------
+network-essentials      Smart License                    None
+None                    Subscription Smart License       None
+
+
+Smart Licensing Status: Smart Licensing Using Policy
+
+Allen-Bradley 1783-CMS20DP (ARM) processor (revision V02) with 638793K/6147K bytes of memory.
+Processor board ID ABC123
+3 Virtual Ethernet interfaces
+20 Gigabit Ethernet interfaces
+4096K bytes of non-volatile configuration memory.
+3491708K bytes of physical memory.
+524288K bytes of crashinfo at crashinfo:.
+1945600K bytes of Flash at flash:.
+7897088K bytes of SD Flash at sdflash:.
+
+Base Ethernet MAC Address          : 68:c8:eb:12:34:56
+Motherboard Assembly Number        : 73-123456-05
+Motherboard Serial Number          : 321CBA
+Model Revision Number              : V02
+Motherboard Revision Number        : 5
+Model Number                       : 1783-CMS20DP
+System Serial Number               : ABC123
+Top Assembly Part Number           : 68-123456-04
+Top Assembly Revision Number       : B0
+System FPGA version                : 0.2.22
+CIP Serial Number                  : 0x7018B719
+SKU Brand Name                     : Rockwell
+
+
+Configuration register is 0x102

--- a/tests/cisco_ios/show_version/cisco_ios_show_version_ab_stratix.yml
+++ b/tests/cisco_ios/show_version/cisco_ios_show_version_ab_stratix.yml
@@ -1,0 +1,23 @@
+---
+parsed_sample:
+  - config_register: "0x102"
+    hardware:
+      - "1783-CMS20DP"
+    hostname: "PAS-IDF17-SW02"
+    mac_address:
+      - "68:c8:eb:12:34:56"
+    release: "fc3"
+    reload_reason: "Swapdrive Restore"
+    restarted: ""
+    rommon: "IOS-XE"
+    running_image: "packages.conf"
+    serial:
+      - "ABC123"
+    software_image: "S5200-UNIVERSALK9-M"
+    uptime: "2 weeks, 6 days, 17 hours, 32 minutes"
+    uptime_days: "6"
+    uptime_hours: "17"
+    uptime_minutes: "32"
+    uptime_weeks: "2"
+    uptime_years: ""
+    version: "17.12.4"


### PR DESCRIPTION
resolves #2243

* Add Error directive to `Stack` state
* Some consolidation regarding transitions to `Stack` state
* Add Error directive to `Start` state
* Add a bunch of previously unmatched patterns (otherwise ignored, not captured)
* Add Allen-Bradley Stratix support to cisco_ios show version

Note: Given the variations in the licensing verbiage, for maintenance reasons we might ***not*** want the Error directive in the `Start` state.