### PR TITLE
Add aruba_aoscx_show_ip_interface_brief

### DIFF
--- a/ntc_templates/templates/aruba_aoscx_show_ip_interface_brief.textfsm
+++ b/ntc_templates/templates/aruba_aoscx_show_ip_interface_brief.textfsm
@@ -1,0 +1,18 @@
+Value Required INTERFACE (\S+)
+Value IP_ADDRESS ([\d\.]+/\d+|No\s+Address)
+Value LINK_STATUS (up|down)
+Value ADMIN_STATUS (up|down)
+
+Start
+  # Skip ALL header-related lines
+  ^\s*Interface -> Next
+  ^\s*IP\s*.Address -> Next
+  ^\s*link/admin -> Next
+  ^Interface.Status -> Next
+  ^-+$$ -> Next
+  ^\s*$$ -> Next
+  # Process interface data
+  ^${INTERFACE}\s+${IP_ADDRESS}\s+${LINK_STATUS}/${ADMIN_STATUS}$$ -> Record
+  ^${INTERFACE}\s+${IP_ADDRESS}\s*$$
+  ^\s+${LINK_STATUS}/${ADMIN_STATUS}$$ -> Record
+  ^. -> Error "LINE NOT FOUND"

--- a/ntc_templates/templates/index
+++ b/ntc_templates/templates/index
@@ -117,6 +117,7 @@ aruba_aoscx_show_aaa_authentication_port-access_interface_all_client-status.text
 aruba_aoscx_show_lldp_neighbors-info_detail.textfsm, .*, aruba_aoscx, sh[[ow]] ll[[dp]] nei[[ghbor]]s?[[-info]] d[[etail]]
 aruba_aoscx_show_bgp_all-vrfs_all_summary.textfsm, .*, aruba_aoscx, sh[[ow]] bgp all-[[vrfs]] a[[ll]] s[[ummary]]
 aruba_aoscx_show_interface_dom_detail.textfsm , .*, aruba_aoscx, sh[[ow]] int[[erface]] dom d[[etail]]
+aruba_aoscx_show_ip_interface_brief.textfsm, .*, aruba_aoscx, sh[[ow]] ip int[[erface]] b[[rief]]
 aruba_aoscx_show_ip_route_all-vrfs.textfsm, .*, aruba_aoscx, sh[[ow]] ip r[[oute]] a[[ll-vrfs]]
 aruba_aoscx_show_mac-address-table.textfsm, .*, aruba_aoscx, sh[[ow]] ma[[c-address-table]]
 aruba_aoscx_show_ntp_associations.textfsm, .*, aruba_aoscx, sh[[ow]] ntp as[[sociations]]

--- a/tests/aruba_aoscx/show_ip_interface_brief/aruba_aoscx_show_ip_interface_brief.raw
+++ b/tests/aruba_aoscx/show_ip_interface_brief/aruba_aoscx_show_ip_interface_brief.raw
@@ -1,0 +1,11 @@
+Interface         IP Address             Interface Status
+                                           link/admin
+loopback1        192.168.216.15/24           up/up
+
+vlan1            No Address                down/up
+
+vlan300          192.168.200.13/24           up/up
+
+vlan302          No Address                up/up
+
+

--- a/tests/aruba_aoscx/show_ip_interface_brief/aruba_aoscx_show_ip_interface_brief.yml
+++ b/tests/aruba_aoscx/show_ip_interface_brief/aruba_aoscx_show_ip_interface_brief.yml
@@ -1,0 +1,18 @@
+---
+parsed_sample:
+  - admin_status: "up"
+    interface: "loopback1"
+    ip_address: "192.168.216.15/24"
+    link_status: "up"
+  - admin_status: "up"
+    interface: "vlan1"
+    ip_address: "No Address"
+    link_status: "down"
+  - admin_status: "up"
+    interface: "vlan300"
+    ip_address: "192.168.200.13/24"
+    link_status: "up"
+  - admin_status: "up"
+    interface: "vlan302"
+    ip_address: "No Address"
+    link_status: "up"


### PR DESCRIPTION
## Description

Adds a new TextFSM template to support parsing `show ip interface brief` for **Aruba AOS-CX** switches.

### Files Added / Modified
- `ntc_templates/templates/aruba_aoscx_show_ip_interface_brief.textfsm`
- `ntc_templates/templates/index`
- `tests/aruba_aoscx/show_ip_interface_brief/aruba_aoscx_show_ip_interface_brief.raw`
- `tests/aruba_aoscx/show_ip_interface_brief/aruba_aoscx_show_ip_interface_brief.yml`

---

## Example CLI Output

```text
Interface         IP Address             Interface Status
                                         link/admin
loopback1        192.168.216.15/24           up/up

vlan1            No Address                down/up

vlan300          192.168.200.13/24           up/up

vlan302          No Address                up/up

```

## Parsed Data Structure

```json
[
  {
    "interface": "loopback1",
    "ip_address": "192.168.216.15/24",
    "link_status": "up",
    "admin_status": "up"
  },
  {
    "interface": "vlan1",
    "ip_address": "No Address",
    "link_status": "down",
    "admin_status": "up"
  },
  {
    "interface": "vlan300",
    "ip_address": "192.168.200.13/24",
    "link_status": "up",
    "admin_status": "up"
  },
  {
    "interface": "vlan302",
    "ip_address": "No Address",
    "link_status": "up",
    "admin_status": "up"
  }
]

```

---

## Verification

* [x] Generated YAML test files (`invoke gen-yaml-folder`)
* [x] Tested with `poetry run pytest -k aruba_aoscx_show_ip_interface_brief` (All tests pass)
* [x] Passed style and quality checks (`invoke yamllint black flake8`)

```

```